### PR TITLE
PicoFaceMD: clamp the ladder cutoff to where the coefficient fits hold

### DIFF
--- a/instruments/PicoFaceMD/include/moog/moog_defs.h
+++ b/instruments/PicoFaceMD/include/moog/moog_defs.h
@@ -165,6 +165,15 @@
 #define MOOG_CUTOFF_MIN_HZ    16.0f
 #define MOOG_CUTOFF_MAX_HZ 16000.0f
 
+/* Ceiling on the cutoff the ladder itself will accept, as a fraction of the
+ * rate it runs at: one radian per sample, 1/2pi. Everything above the panel
+ * range -- Contour, keyboard tracking, the modulation mix -- adds octaves on
+ * top of the panel setting, so the filter is asked for cutoffs far past
+ * MOOG_CUTOFF_MAX_HZ in ordinary playing, and past this point the Huovilainen
+ * fits in moog_ladder.h stop being fits and start being wrong. See the note
+ * on setCutoff(). */
+#define MOOG_LADDER_WC_MAX_OVER_2PI 0.15915f
+
 /* Emphasis 0..10. The manual: "When the EMPHASIS control is set to 10, the
  * filter breaks into oscillation, and produces a pure sine wave tone." The
  * model self-oscillates just above 1.0, so the top of the control has to

--- a/instruments/PicoFaceMD/include/moog/moog_ladder.h
+++ b/instruments/PicoFaceMD/include/moog/moog_ladder.h
@@ -54,13 +54,25 @@ public:
      * pole sections, which keeps the cutoff where it is asked for instead of
      * flattening out towards Nyquist the way a plain bilinear transform does.
      *
-     * Clamped to 0.49 of the sample rate: the fit is only valid below
-     * Nyquist, and beyond it the loop goes unstable rather than simply
-     * sounding wrong.
+     * Clamped so that wc stays at or below one radian per sample. Both fits
+     * are only good for about that far, and the resonance one does not merely
+     * lose accuracy past it -- it crosses zero at wc = 1.085 and goes
+     * negative, which turns the feedback around the loop from negative into
+     * positive. The tanh at the input keeps that bounded, so nothing ever
+     * overflows, but the stage sits pinned against its own saturation and
+     * what comes out is a crushed square rather than a filtered note. The
+     * tuning fit goes past 1.0 shortly after, at which point the one pole
+     * sections overshoot on every step as well.
+     *
+     * Nothing musical is lost by stopping here: one radian per sample is
+     * sr/2pi, which at the oversampled rate this filter runs at is a little
+     * over 14 kHz, and the decimation filter downstream is a 6th order
+     * Butterworth at 15 kHz. The cutoff could not be heard above the clamp
+     * even if the model stayed well behaved up there.
      */
     void setCutoff(float hz)
     {
-        hz = moogClamp(hz, 5.0f, sr_ * 0.49f);
+        hz = moogClamp(hz, 5.0f, sr_ * MOOG_LADDER_WC_MAX_OVER_2PI);
         wc_ = 2.0f * (float) M_PI * hz / sr_;
 
         const float w2 = wc_ * wc_;


### PR DESCRIPTION
Fixes #3.

The report is a real defect, though the mechanism differs from the one in the
issue. There is no overflow: the `tanh` at the ladder input bounds the feedback
loop by construction. What goes wrong is a sign error in the coefficients.

## Cause

The ladder uses Huovilainen's polynomial fits, valid to about one radian per
sample. The resonance fit does not merely lose accuracy past that — it crosses
zero at `wc = 1.085` and goes negative, turning the loop from negative feedback
into positive. Bounded by the `tanh`, but the input stage then sits pinned
against its own saturation, so a filtered note comes out as a crushed square.
Further up, the tuning fit passes 1.0 as well and the one-pole sections
overshoot on every step.

The old ceiling of `0.49 * sr` allowed all of it. At the 88.2 kHz the filter
runs at:

| Cutoff | wc | g | gRes/res |
|---|---|---|---|
| 12000 | 0.855 | 0.604 | +0.385 |
| 15230 | 1.085 | 0.711 | 0.000 ← sign change |
| 16000 | 1.140 | 0.734 | −0.108 |
| 43218 (old clamp) | 3.079 | **1.145** | **−6.976** |

CC 74 = 127 puts the base cutoff at 16 kHz, already past the sign change, and
Contour (up to 6 octaves), keyboard tracking and Filter Mod add octaves on top —
so ordinary playing reaches the broken region, not only the top of the control.

Two points beyond what the issue describes:

- Not limited to CC 74 ≥ 110. "Fat Bass" enters the broken region during the
  contour attack with the control at 0.75, heard as a transient spike rather
  than sustained distortion.
- On some patches the symptom is not distortion at all. "Brass" at CC 74 = 127
  goes **silent**, sustain peak 0.002.

## Fix

Clamp the ladder cutoff to `wc <= 1`, i.e. `sr/2pi`, a little over 14 kHz at the
oversampled rate. Nothing audible is lost — the decimation filter downstream is
a 6th-order Butterworth at 15 kHz, so the cutoff could not be heard above the
clamp even if the model behaved up there. The clamp is a fraction of the sample
rate, so it holds at other oversampling factors.

## Verification

Rendered offline against the engine:

- "Brass" at the top of the control is back to peak 0.464.
- Crest factors stay in the 1.85–2.4 band across the whole control range,
  instead of collapsing to 1.59.
- A sweep of all 25 factory presets × 21 cutoff steps is unchanged outside the
  broken region; the single pre-existing flag ("Whistle" with the filter nearly
  shut) is identical before and after.

**Not yet tried on hardware.** Host build only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)