### PR TITLE
Core: queue outgoing USB MIDI so SysEx dumps arrive whole

### DIFF
--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -33,6 +33,9 @@ set(PICOFACE_CORE_SOURCES
     "${CMAKE_CURRENT_SOURCE_DIR}/src/pico_hw.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/veeprom.cpp"
     "${CMAKE_CURRENT_SOURCE_DIR}/src/midi_input_usb.cpp"
+    # Buffered USB MIDI transmit. Base source, not a module: writing straight to
+    # TinyUSB silently truncates anything past one TX FIFO (see the header).
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/midi_output_usb.cpp"
     # DIN MIDI on uart1. Base source, not an optional module: the hardware is
     # on every board and an idle RX interrupt costs nothing.
     "${CMAKE_CURRENT_SOURCE_DIR}/src/midi_serial.cpp"

--- a/core/include/midi_output_usb.h
+++ b/core/include/midi_output_usb.h
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Michi71
+
+#ifndef __MIDI_OUTPUT_USB__H__
+#define __MIDI_OUTPUT_USB__H__
+
+#include <pico/stdlib.h>
+#include "project_config.h"
+#include "tusb.h"
+#include <stdint.h>
+
+// Outgoing USB MIDI, buffered.
+//
+// tud_midi_stream_write() is not a "write these bytes" call - it takes what
+// fits in the TinyUSB TX FIFO and returns how much that was. The FIFO holds
+// CFG_TUD_MIDI_TX_BUFSIZE bytes of four-byte USB packets, and a SysEx packet
+// carries only three payload bytes, so at 64 bytes the ceiling is 48 SysEx
+// bytes between two tud_task() calls. Anything past that is dropped.
+//
+// That ceiling is well below a reface DX voice dump (241 bytes across seven
+// messages), which is why writing straight to TinyUSB truncated it: the header
+// went out, the common block was cut off mid-message, and the four operator
+// blocks and the footer never left at all. Worse than the loss itself, a
+// truncated SysEx leaves TinyUSB's stream state inside a message, so the next
+// bytes written - active sensing - get packed as SysEx continuation and the
+// outgoing stream stays corrupted until an F0 resynchronises it.
+//
+// So instruments queue here instead, and the main loop drains into TinyUSB
+// after every tud_task(), a FIFO-full at a time. Nothing blocks: the audio
+// producer shares that loop and a dump is several USB frames long.
+class MIDIOutputUSB {
+public:
+    MIDIOutputUSB() = default;
+
+    // Queue a complete message. All or nothing: a message that does not fit is
+    // dropped whole and counted, never written in part, because a half SysEx on
+    // the wire is worse for the receiver than a missing one. Never blocks.
+    bool write(const uint8_t* data, uint16_t len);
+
+    // Main loop, straight after tud_task(): hand over as much as TinyUSB takes.
+    void process();
+
+    bool     empty() const { return _count == 0; }
+    uint16_t pending() const { return _count; }
+    uint32_t dropped() const { return _dropped; }   // messages, not bytes
+
+private:
+    // Room for a full reface DX voice dump (241 bytes) several times over, so a
+    // burst of dump requests queues rather than drops. 1 KB of RAM against a
+    // silently lost patch transfer is a trade worth making.
+    static constexpr uint16_t kBufSize = 1024;
+
+    uint8_t  _buf[kBufSize] = {0};
+    uint16_t _head    = 0;   // read position
+    uint16_t _count   = 0;   // bytes queued
+    uint32_t _dropped = 0;
+};
+
+MIDIOutputUSB& usbMidiOut();
+
+#endif // __MIDI_OUTPUT_USB__H__

--- a/core/include/midi_serial.h
+++ b/core/include/midi_serial.h
@@ -30,6 +30,12 @@ public:
     void process();  // drain the ring and dispatch; call from the same place as MIDIInputUSB::process()
 
     // --- transmit ---
+    // Queued, never blocking. At 31250 baud a byte takes 320 us, so writing a
+    // reface DX voice dump (241 bytes) straight to the UART busy-waited for
+    // about 77 ms - against an audio pool of six 64-sample buffers, 8.7 ms at
+    // 44.1 kHz. The pool ran dry and the I2S DMA repeated it, which is heard as
+    // a low tone rather than a gap. A message that does not fit the queue is
+    // dropped whole, never in part. process() moves it out.
     void write(const uint8_t* data, uint16_t len);   // raw bytes, e.g. a SysEx reply
     void sendNoteOn(uint8_t ch, uint8_t note, uint8_t vel);
     void sendNoteOff(uint8_t ch, uint8_t note, uint8_t vel);
@@ -48,6 +54,7 @@ public:
 
 private:
     void dispatch();   // act on a complete channel message in status_/data_
+    void txPump();     // move queued bytes into the UART FIFO, never waiting
 
     static constexpr uint16_t kSysExMax = 256;
 

--- a/core/src/midi_output_usb.cpp
+++ b/core/src/midi_output_usb.cpp
@@ -1,0 +1,66 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Michi71
+
+#include "midi_output_usb.h"
+
+MIDIOutputUSB& usbMidiOut()
+{
+    static MIDIOutputUSB out;
+    return out;
+}
+
+bool MIDIOutputUSB::write(const uint8_t* data, uint16_t len)
+{
+    if (!data || len == 0) {
+        return true;
+    }
+
+    // Nothing is listening, so drop rather than fill the queue with traffic
+    // that would flood the host the moment it enumerates.
+    if (!tud_midi_mounted()) {
+        _head  = 0;
+        _count = 0;
+        return false;
+    }
+
+    if ((uint16_t)(kBufSize - _count) < len) {
+        _dropped++;
+        return false;
+    }
+
+    uint16_t w = (uint16_t)((_head + _count) % kBufSize);
+    for (uint16_t i = 0; i < len; i++) {
+        _buf[w] = data[i];
+        if (++w == kBufSize) w = 0;
+    }
+    _count = (uint16_t)(_count + len);
+    return true;
+}
+
+void MIDIOutputUSB::process()
+{
+    if (_count == 0) {
+        return;
+    }
+
+    if (!tud_midi_mounted()) {
+        _head  = 0;
+        _count = 0;
+        return;
+    }
+
+    // One pass per main loop iteration. tud_midi_stream_write() stops at the
+    // FIFO boundary and reports how far it got; whatever is left stays queued
+    // for the next round, once tud_task() has freed the endpoint again.
+    while (_count > 0) {
+        const uint16_t contiguous = (uint16_t)((_head + _count > kBufSize)
+                                             ? (kBufSize - _head)
+                                             : _count);
+        const uint32_t written = tud_midi_stream_write(0, &_buf[_head], contiguous);
+        if (written == 0) {
+            break;                      // FIFO full - resume after tud_task()
+        }
+        _head  = (uint16_t)((_head + written) % kBufSize);
+        _count = (uint16_t)(_count - written);
+    }
+}

--- a/core/src/midi_serial.cpp
+++ b/core/src/midi_serial.cpp
@@ -19,6 +19,16 @@ static volatile uint16_t s_rxHead = 0;      // written by the IRQ
 static volatile uint16_t s_rxTail = 0;      // written by process()
 static volatile uint32_t s_rxDropped = 0;   // diagnostics: ring was full
 
+// Transmit ring, drained by process() into the 32-byte hardware FIFO. Written
+// and read from the main loop only, so no volatile and no IRQ interaction.
+// 512 bytes holds two full reface DX voice dumps: the wire needs 77 ms for one
+// of them, so a second request can arrive while the first is still going out.
+static constexpr uint16_t kTxRingSize = 512;
+static uint8_t  s_tx[kTxRingSize];
+static uint16_t s_txHead = 0;      // read position
+static uint16_t s_txCount = 0;     // bytes queued
+static uint32_t s_txDropped = 0;   // diagnostics: messages that did not fit
+
 // Kept RAM resident and tiny - it only moves bytes, all parsing happens in process().
 static void __not_in_flash_func(midi_uart_irq)()
 {
@@ -58,12 +68,45 @@ void MIDISerial::init()
     irq_set_priority(irq, 0x40);
 }
 
+// Queue only - see the note in the header. The old version called
+// uart_putc_raw() in a loop, which busy-waits whenever the 32-byte TX FIFO is
+// full. That is invisible for the 3-byte channel messages it was written for
+// and ruinous for a SysEx bulk dump, which is longer than the FIFO by an order
+// of magnitude and stalls the audio producer for as long as the wire needs.
 void MIDISerial::write(const uint8_t* data, uint16_t len)
 {
-    // uart_putc_raw blocks only while the 32-byte TX FIFO is full;
-    // a 3-byte message never gets that far.
+    if (!data || len == 0) {
+        return;
+    }
+
+    // All or nothing: half a SysEx on the wire is worse for a receiver than a
+    // missing one, and a chopped channel message would corrupt running status.
+    if ((uint16_t)(kTxRingSize - s_txCount) < len) {
+        s_txDropped++;
+        return;
+    }
+
+    uint16_t w = (uint16_t)((s_txHead + s_txCount) % kTxRingSize);
     for (uint16_t i = 0; i < len; ++i) {
-        uart_putc_raw(MIDI_UART, data[i]);
+        s_tx[w] = data[i];
+        if (++w == kTxRingSize) w = 0;
+    }
+    s_txCount = (uint16_t)(s_txCount + len);
+
+    // Prime the hardware FIFO now so a short message still leaves immediately
+    // rather than waiting for the next process().
+    txPump();
+}
+
+// Top up the hardware FIFO with whatever it will take. uart_is_writable() is
+// the whole point: it never waits, so a dump trickles out across as many main
+// loop iterations as 31250 baud needs while the audio producer keeps running.
+void MIDISerial::txPump()
+{
+    while (s_txCount > 0 && uart_is_writable(MIDI_UART)) {
+        uart_get_hw(MIDI_UART)->dr = s_tx[s_txHead];
+        if (++s_txHead == kTxRingSize) s_txHead = 0;
+        s_txCount--;
     }
 }
 
@@ -118,6 +161,10 @@ void MIDISerial::sendPitchBend(uint8_t ch, uint16_t value14)
 
 void MIDISerial::process()
 {
+    // Transmit first: this is the one place per main loop iteration that keeps
+    // a queued dump moving, and it must run whether or not anything arrived.
+    txPump();
+
     while (s_rxTail != s_rxHead) {
         const uint8_t b = s_rx[s_rxTail];
         s_rxTail = (uint16_t)((s_rxTail + 1) % kRxRingSize);

--- a/core/src/picoface_main.cpp
+++ b/core/src/picoface_main.cpp
@@ -19,6 +19,7 @@
 #include "veeprom.h"
 #include "get_serial.h"
 #include "midi_input_usb.h"
+#include "midi_output_usb.h"
 #include "midi_serial.h"
 #include "audio_subsystem.h"
 #include "u8g2.h"
@@ -289,7 +290,12 @@ int main(void)
         }
 
         // 3. USB and DIN MIDI
+        // Drain the transmit queue right after tud_task(): that is the point at
+        // which the completion callback has freed the endpoint, so the TinyUSB
+        // FIFO has room again. A reface DX voice dump is several USB frames
+        // long and leaves over as many iterations as it needs.
         tud_task();
+        usbMidiOut().process();
         g_usbmidi.process();
         midiSerial().process();
 

--- a/instruments/PicoFaceCP/include/midi_reface.h
+++ b/instruments/PicoFaceCP/include/midi_reface.h
@@ -99,7 +99,7 @@ private:
   void     applySystemParam(uint8_t addr, const uint8_t* data, uint16_t len);
   void     applyTgParam(uint8_t addr, uint8_t value);
   uint8_t  readTgParam(uint8_t addr) const;    // live values from _ep/_fx
-  void     txBytes(const uint8_t* b, uint16_t n);  // tud_midi_stream_write wrapper
+  void     txBytes(const uint8_t* b, uint16_t n);  // queues on usbMidiOut() + DIN
   void     txCC(uint8_t cc, uint8_t val);
   void     txIdentityReply();
   void     txParamChange(uint8_t ah, uint8_t am, uint8_t al);  // current value(s)

--- a/instruments/PicoFaceCP/src/midi_reface.cpp
+++ b/instruments/PicoFaceCP/src/midi_reface.cpp
@@ -8,6 +8,7 @@
 
 #include "midi_reface.h"
 #include "midi_serial.h"
+#include "midi_output_usb.h"
 #include "ipc.h"
 #include "mdaEPiano.h"
 #include "reface_cp_chain.h"
@@ -136,9 +137,10 @@ uint8_t RefaceMidi::ccZone3(uint8_t v) {
 }
 
 void RefaceMidi::txBytes(const uint8_t* b, uint16_t n) {
-    if (tud_midi_mounted()) {
-        tud_midi_stream_write(0, b, n);
-    }
+    // Queued rather than written straight to TinyUSB, which takes only what
+    // fits one TX FIFO (48 SysEx bytes) and silently drops the rest.
+    // See core/include/midi_output_usb.h.
+    usbMidiOut().write(b, n);
     // Everything the reface layer sends - panel CCs, SysEx replies - goes out
     // the DIN socket as well. Unconditional: unlike USB there is nothing to
     // enumerate, and a receiver that is not plugged in simply does not listen.

--- a/instruments/PicoFaceDX/doc/MIDI_IMPLEMENTATION.md
+++ b/instruments/PicoFaceDX/doc/MIDI_IMPLEMENTATION.md
@@ -180,6 +180,16 @@ truncated SysEx leaves TinyUSB's stream state inside a message, so the next
 bytes written - active sensing - would be packed as SysEx continuation and the
 outgoing stream would stay corrupted until an `F0` resynchronised it.
 
+The DIN side of `txBytes()` had the opposite failure. `MIDISerial::write()`
+called `uart_putc_raw()` in a loop, which busy-waits whenever the 32-byte TX
+FIFO is full - harmless for the three-byte channel messages it was written for,
+ruinous for a dump. At 31250 baud a byte takes 320 us, so 241 bytes held the
+main loop for about 77 ms against an audio pool of six 64-sample buffers, 8.7 ms
+at 44.1 kHz. The pool ran dry and the I2S DMA repeated it, heard as a low tone
+of roughly a quarter second whenever an editor asked for a voice - on connect as
+well as on sync, and regardless of whether anything was plugged into the DIN
+socket. `MIDISerial` now queues too and tops up the FIFO from `process()`.
+
 ### Dump Request (RX) → TX-Antwort
 
 | Adresse | Antwort |

--- a/instruments/PicoFaceDX/doc/MIDI_IMPLEMENTATION.md
+++ b/instruments/PicoFaceDX/doc/MIDI_IMPLEMENTATION.md
@@ -163,6 +163,23 @@ Checksum: the Yamaha/Roland standard, `(128 - (sum & 0x7F)) & 0x7F` over the mod
 
 RX writes into a staging patch (`include/dx_patch_stage.h`) instead of into the live engine - the control side must never mutate the live patch directly. The bulk footer block (address `0F 0F xx`) triggers `IPC_CMD_DX_PATCH_APPLY`, which copies the staging patch into the live engine at the next block boundary. The bulk header block (address `0E 0F xx`) first initializes the staging area with the CURRENT live patch, so that a partial dump - only the common block, say - does not overwrite unrelated operator data with stale staging leftovers.
 
+### Transmit buffering
+
+A full voice dump is 241 bytes across seven messages. TinyUSB's transmit FIFO
+holds `CFG_TUD_MIDI_TX_BUFSIZE` (64) bytes of four-byte packets, and a SysEx
+packet carries three payload bytes, so only 48 SysEx bytes fit between two
+`tud_task()` calls - `tud_midi_stream_write()` takes that much and reports how
+far it got. Writing a dump straight to it therefore delivered roughly a block
+and a half and discarded the rest without a word, which is what made Soundmondo
+show "Init Voice" instead of the device's patch.
+
+`txBytes()` therefore queues on the core's `MIDIOutputUSB`
+(`core/include/midi_output_usb.h`), which the main loop drains one FIFO at a
+time after each `tud_task()`. Messages are queued whole or not at all: a
+truncated SysEx leaves TinyUSB's stream state inside a message, so the next
+bytes written - active sensing - would be packed as SysEx continuation and the
+outgoing stream would stay corrupted until an `F0` resynchronised it.
+
 ### Dump Request (RX) → TX-Antwort
 
 | Adresse | Antwort |

--- a/instruments/PicoFaceDX/include/midi_reface.h
+++ b/instruments/PicoFaceDX/include/midi_reface.h
@@ -68,7 +68,7 @@ public:
     void onProgramChange(uint8_t program, uint8_t ch);              // 0..DX_NPRESETS-1 -> factory DX preset
     void onPitchBend(uint16_t bend14, uint8_t ch);                   // 14-bit pitch bend
     void onRealtime(uint8_t status);                                 // Active Sensing / Reset / Clock etc.
-    void onSysEx(const uint8_t* data, uint16_t len);                 // raw SysEx (without F0/F7)
+    void onSysEx(const uint8_t* data, uint16_t len);                 // complete message, F0 and F7 included
     void notifyActivity();                                            // mark last RX time (resets sense timeout)
 
     void txProgram(int preset);                                      // -> Program Change 0..DX_NPRESETS-1
@@ -93,7 +93,7 @@ private:
     void     applyOperatorParam(uint8_t opNum, uint8_t addr, uint8_t value);
     uint8_t  readCommonParam(uint8_t addr) const;
     uint8_t  readOperatorParam(uint8_t opNum, uint8_t addr) const;
-    void     txBytes(const uint8_t* b, uint16_t n);                 // tud_midi_stream_write wrapper
+    void     txBytes(const uint8_t* b, uint16_t n);                 // queues on usbMidiOut() + DIN
     void     txCC(uint8_t cc, uint8_t val);
     void     txIdentityReply();
     void     txParamChange(uint8_t ah, uint8_t am, uint8_t al);     // current value(s)

--- a/instruments/PicoFaceDX/src/midi_reface.cpp
+++ b/instruments/PicoFaceDX/src/midi_reface.cpp
@@ -11,6 +11,7 @@
 #include "dx_patch_stage.h"
 #include "presets.h"
 #include "midi_serial.h"
+#include "midi_output_usb.h"
 #include "pico/stdlib.h"
 #include "tusb.h"
 #include <string.h>
@@ -113,7 +114,11 @@ void RefaceMidi::setRxChannel(uint8_t ch) {
 }
 
 void RefaceMidi::txBytes(const uint8_t* b, uint16_t n) {
-    if (tud_midi_mounted()) { tud_midi_stream_write(0, b, n); }
+    // Queued rather than written straight to TinyUSB: a full voice bulk is 241
+    // bytes across seven messages and one TX FIFO holds 48 SysEx bytes, so the
+    // direct call dropped everything past the first block and a half without
+    // saying so. See core/include/midi_output_usb.h.
+    usbMidiOut().write(b, n);
     // Everything the reface layer sends - active sensing, panel CCs, SysEx
     // replies - goes out the DIN socket as well. Unconditional: unlike USB
     // there is nothing to enumerate, and a receiver that is not plugged in

--- a/instruments/PicoFaceYC/src/midi_reface.cpp
+++ b/instruments/PicoFaceYC/src/midi_reface.cpp
@@ -3,6 +3,7 @@
 
 #include "midi_reface.h"
 #include "midi_serial.h"
+#include "midi_output_usb.h"
 #include "YC_Synth_Bridge.h"
 #include "ipc.h"
 #include "tusb.h"
@@ -139,7 +140,10 @@ void RefaceMidi::notifyActivity() {
 }
 
 void RefaceMidi::txBytes(const uint8_t* b, uint16_t n) {
-    tud_midi_stream_write(0, b, n);
+    // Queued rather than written straight to TinyUSB, which takes only what
+    // fits one TX FIFO (48 SysEx bytes) and silently drops the rest.
+    // See core/include/midi_output_usb.h.
+    usbMidiOut().write(b, n);
     // Everything the reface layer sends - panel CCs, SysEx replies - goes out
     // the DIN socket as well. Unconditional: unlike USB there is nothing to
     // enumerate, and a receiver that is not plugged in simply does not listen.

--- a/tools/host_tests/README.md
+++ b/tools/host_tests/README.md
@@ -13,6 +13,7 @@ land next to their script and are gitignored.
 | [`veeprom/`](veeprom/) | nothing | unit test of the core's virtual EEPROM: wear levelling, CRC, oversize rejection, 1000 saves. Prints PASS/FAIL per case. This one covers `core/`, not an instrument. |
 | [`yc/`](yc/) | nothing | renders the YC organ engine to a WAV file. No audio device involved. |
 | [`ob/`](ob/) | nothing | regression checks on the OB-X engine - pitch bend ranges, LFO->cutoff without LFO->pitch, mod lever vibrato, all presets finite - plus a WAV render. Prints pass/FAIL per case. |
+| [`dx_sysex/`](dx_sysex/) | nothing | round trip through PicoFaceDX's SysEx layer, both directions: a voice dump requested by an editor is parsed back and compared byte for byte, and a voice sent by an editor is compared against what reaches the engine. Prints pass/FAIL per direction. |
 | [`j6/build_ui.sh`](j6/) | nothing | drives `J6_Controller` and the patch store through a scripted panel session - menu navigation, patch save/load, the free-slot rule. |
 | [`cp/`](cp/README.md) | portmidi | plays the mdaEPiano engine, with or without the reface CP effect chain, over CoreAudio. |
 | [`j6/build_juno.sh`](j6/) | portmidi | plays the Juno engine over CoreAudio. |

--- a/tools/host_tests/dx_sysex/build_dx_sysex.sh
+++ b/tools/host_tests/dx_sysex/build_dx_sysex.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Michi71
+# build_dx_sysex.sh -- host build of the PicoFaceDX SysEx round trip.
+# Compiles the *unmodified* src/midi_reface.cpp against the stubs in stub/;
+# no Pico SDK, no TinyUSB, no audio device, no MIDI port involved.
+set -e
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$HERE/../../.." && pwd)"
+ROOT="$REPO/instruments/PicoFaceDX"
+OUT="$HERE/dx_sysex_test"
+
+# stub/ must come first: it shadows DX_Synth_Bridge.h, presets.h,
+# midi_output_usb.h and tusb.h, while midi_reface.h, ipc.h and
+# dx_engine/RDX_Types.h are picked up from the instrument for real. DIN MIDI
+# comes from the shared shim, as in the other host tests.
+CXX="${CXX:-c++}"
+CXXFLAGS=(-std=c++17 -O1 -Wall -Wextra
+          -I"$HERE/stub" -I"$ROOT/include" -I"$REPO/core/include" -I"$HERE/../shim")
+
+SRC=("$HERE/dx_sysex_test.cpp"
+     "$ROOT/src/midi_reface.cpp"
+     "$HERE/../shim/host_midi_serial.cpp")
+
+"$CXX" "${CXXFLAGS[@]}" "${SRC[@]}" -o "$OUT"
+
+echo "[ok]   $OUT"
+"$OUT"

--- a/tools/host_tests/dx_sysex/dx_sysex_test.cpp
+++ b/tools/host_tests/dx_sysex/dx_sysex_test.cpp
@@ -1,0 +1,193 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Michi71
+//
+// dx_sysex_test.cpp -- PicoFaceDX SysEx round trip, both directions.
+//
+// Written while chasing a report that a voice synced through Soundmondo came
+// back with a wrong operator 4. It did not: the wire was byte-exact and the
+// editor's display was at fault. This test is what settles that class of
+// question in a second instead of over several rounds of guessing.
+//
+// Round trip through the real src/midi_reface.cpp, both directions:
+//
+//   TX: put a known patch in the engine, ask for a voice dump, parse what came
+//       out and compare byte for byte.
+//   RX: encode a known patch as an editor would, feed it in block by block,
+//       apply, and compare byte for byte.
+//
+// The patch is filled with a distinct value per byte, so any swap, shift or
+// dropped block shows up as a named field rather than as a plausible number.
+#include "midi_reface.h"
+#include "DX_Synth_Bridge.h"
+#include "dx_patch_stage.h"
+#include "ipc.h"
+#include "midi_output_usb.h"
+#include "tusb.h"
+#include "pico/stdlib.h"
+#include <cstdio>
+#include <cstring>
+#include <vector>
+
+// --- stub bodies -----------------------------------------------------------
+static std::vector<uint8_t> g_out;
+bool MIDIOutStub::write(const uint8_t* d, uint16_t n) { g_out.insert(g_out.end(), d, d + n); return true; }
+MIDIOutStub& usbMidiOut() { static MIDIOutStub s; return s; }
+bool tud_midi_mounted(void) { return true; }
+absolute_time_t get_absolute_time(void) { return 0; }
+uint32_t to_ms_since_boot(absolute_time_t) { return 0; }
+void preset_set_current(uint8_t) {}
+void preset_stage(uint8_t) {}
+extern "C" int ui_get_octave(void) { return 0; }
+
+// --- helpers ---------------------------------------------------------------
+static const char* fieldName(int byteIndex)
+{
+    static char buf[48];
+    if (byteIndex < 38) {
+        static const char* c[] = {
+            "name0","name1","name2","name3","name4","name5","name6","name7","name8","name9",
+            "res1a","res1b","transpose","monoPoly","portaTime","pbRange","algorithm","lfoWave",
+            "lfoSpeed","lfoDelay","lfoPMD","pegRate1","pegRate2","pegRate3","pegRate4",
+            "pegLevel1","pegLevel2","pegLevel3","pegLevel4","fx1type","fx1p1","fx1p2",
+            "fx2type","fx2p1","fx2p2","res2a","res2b","res2c"};
+        snprintf(buf, sizeof(buf), "common.%s", c[byteIndex]);
+        return buf;
+    }
+    static const char* o[] = {
+        "enable","egRate1","egRate2","egRate3","egRate4","egLevel1","egLevel2","egLevel3","egLevel4",
+        "rateScaling","scaleLD","scaleRD","scaleLC","scaleRC","lfoAMD","lfoPMDEnable","pegEnable",
+        "velSens","outLevel","feedback","fbType","freqMode","freqCoarse","freqFine","freqDetune",
+        "res0","res1","res2"};
+    const int n = byteIndex - 38;
+    snprintf(buf, sizeof(buf), "op%d.%s", n / 28 + 1, o[n % 28]);
+    return buf;
+}
+
+static RDX_Patch patternPatch(uint8_t seed)
+{
+    RDX_Patch p{};
+    uint8_t* b = reinterpret_cast<uint8_t*>(&p);
+    for (size_t i = 0; i < sizeof(RDX_Patch); ++i) b[i] = (uint8_t)((i * 7 + seed) % 127) + 1;
+    return p;
+}
+
+static int failures = 0;
+static void compare(const char* what, const RDX_Patch& got, const RDX_Patch& want)
+{
+    const uint8_t* g = reinterpret_cast<const uint8_t*>(&got);
+    const uint8_t* w = reinterpret_cast<const uint8_t*>(&want);
+    int bad = 0;
+    for (size_t i = 0; i < sizeof(RDX_Patch); ++i) {
+        if (g[i] != w[i]) {
+            if (bad < 12) printf("    %-22s want %3d  got %3d\n", fieldName((int)i), w[i], g[i]);
+            bad++;
+        }
+    }
+    printf("  %-46s %s\n", what, bad ? "FAIL" : "pass");
+    if (bad) { printf("    (%d of %zu bytes differ)\n", bad, sizeof(RDX_Patch)); failures++; }
+}
+
+// Parse a stream of bulk blocks back into a patch, the way an editor would.
+static bool parseStream(const std::vector<uint8_t>& s, RDX_Patch& out, int& blocks)
+{
+    blocks = 0;
+    size_t i = 0;
+    while (i < s.size()) {
+        if (s[i] != 0xF0) return false;
+        size_t end = i;
+        while (end < s.size() && s[end] != 0xF7) end++;
+        if (end >= s.size()) return false;
+        const uint8_t* d = &s[i];
+        const uint16_t len = (uint16_t)(end - i + 1);
+
+        const uint16_t bc = (uint16_t)(((d[5] & 0x7F) << 7) | (d[6] & 0x7F));
+        if (len != (uint16_t)(bc + 9)) return false;
+        uint32_t sum = 0;
+        for (uint16_t k = 7; k < (uint16_t)(len - 1); k++) sum += d[k];
+        if (sum & 0x7F) { printf("    checksum error in block %d\n", blocks); return false; }
+
+        const uint8_t ah = d[8], am = d[9];
+        const uint16_t dlen = (uint16_t)(bc - 4);
+        const uint8_t* data = &d[11];
+        if (ah == 0x30 && dlen == 38)      memcpy(&out.common, data, 38);
+        else if (ah == 0x31 && am < 4 && dlen == 28) memcpy(&out.ops[am], data, 28);
+        blocks++;
+        i = end + 1;
+    }
+    return true;
+}
+
+// Build the seven blocks an editor sends for a full voice.
+static std::vector<uint8_t> encodeVoice(const RDX_Patch& p)
+{
+    std::vector<uint8_t> s;
+    auto block = [&](uint8_t ah, uint8_t am, const uint8_t* data, uint8_t len) {
+        const uint16_t bc = (uint16_t)(4 + len);
+        std::vector<uint8_t> m = {0xF0, 0x43, 0x00, 0x7F, 0x1C,
+                                  (uint8_t)((bc >> 7) & 0x7F), (uint8_t)(bc & 0x7F),
+                                  0x05, ah, am, 0x00};
+        uint32_t sum = 0x05 + ah + am + 0x00;
+        for (uint8_t k = 0; k < len; k++) { m.push_back(data[k] & 0x7F); sum += data[k] & 0x7F; }
+        m.push_back((uint8_t)((0x80 - (sum & 0x7F)) & 0x7F));
+        m.push_back(0xF7);
+        s.insert(s.end(), m.begin(), m.end());
+    };
+    block(0x0E, 0x0F, nullptr, 0);
+    block(0x30, 0x00, reinterpret_cast<const uint8_t*>(&p.common), 38);
+    for (uint8_t o = 0; o < 4; o++)
+        block(0x31, o, reinterpret_cast<const uint8_t*>(&p.ops[o]), 28);
+    block(0x0F, 0x0F, nullptr, 0);
+    return s;
+}
+
+int main()
+{
+    DX_Synth_Bridge dx;
+    RefaceMidi rm;
+    rm.init(&dx);
+
+    // ---------- TX: device -> editor ----------
+    printf("TX: full voice dump requested by an editor\n");
+    const RDX_Patch live = patternPatch(0);
+    dx.patch() = live;
+    g_out.clear();
+
+    const uint8_t req[] = {0xF0, 0x43, 0x20, 0x7F, 0x1C, 0x05, 0x0E, 0x0F, 0x00, 0xF7};
+    rm.onSysEx(req, sizeof(req));
+
+    printf("  emitted %zu bytes\n", g_out.size());
+    RDX_Patch received{};
+    int blocks = 0;
+    if (!parseStream(g_out, received, blocks)) { printf("  stream malformed  FAIL\n"); failures++; }
+    else {
+        printf("  parsed %d blocks (expect 7)\n", blocks);
+        if (blocks != 7) { printf("  block count  FAIL\n"); failures++; }
+        compare("patch read back equals the live patch", received, live);
+    }
+
+    // ---------- RX: editor -> device ----------
+    printf("\nRX: full voice sent by an editor\n");
+    const RDX_Patch sent = patternPatch(63);
+    const auto stream = encodeVoice(sent);
+    printf("  feeding %zu bytes in 7 messages\n", stream.size());
+
+    size_t i = 0;
+    while (i < stream.size()) {
+        size_t end = i;
+        while (end < stream.size() && stream[end] != 0xF7) end++;
+        rm.onSysEx(&stream[i], (uint16_t)(end - i + 1));
+        i = end + 1;
+    }
+
+    // Drain the ring the way DX_Instrument::applyIpc does for PATCH_APPLY.
+    bool applied = false;
+    uint32_t pkt;
+    while (dx_ipc_pop(&pkt))
+        if (ipc_type(pkt) == IPC_CMD_DX_PATCH_APPLY) { dx.patch() = dx_patch_stage(); applied = true; }
+    printf("  patch apply reached the engine: %s\n", applied ? "yes" : "NO");
+    if (!applied) failures++;
+    compare("engine patch equals what was sent", dx.patch(), sent);
+
+    printf("\n%s\n", failures ? "FAILURES" : "all checks passed");
+    return failures ? 1 : 0;
+}

--- a/tools/host_tests/dx_sysex/stub/DX_Synth_Bridge.h
+++ b/tools/host_tests/dx_sysex/stub/DX_Synth_Bridge.h
@@ -1,0 +1,15 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Michi71
+//
+// Stand-in for the engine. midi_reface.cpp only ever reaches through it for
+// patch(), so the FM engine and everything under it stays out of this build.
+#pragma once
+#include "dx_engine/RDX_Types.h"
+
+class DX_Synth_Bridge {
+public:
+    RDX_Patch&       patch()       { return p_; }
+    const RDX_Patch& patch() const { return p_; }
+private:
+    RDX_Patch p_{};
+};

--- a/tools/host_tests/dx_sysex/stub/midi_output_usb.h
+++ b/tools/host_tests/dx_sysex/stub/midi_output_usb.h
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Michi71
+//
+// USB MIDI sink. The test implements write() to append to a byte vector, which
+// is the transmitted stream it then parses back into a patch.
+#pragma once
+#include <stdint.h>
+struct MIDIOutStub { bool write(const uint8_t* d, uint16_t n); };
+MIDIOutStub& usbMidiOut();

--- a/tools/host_tests/dx_sysex/stub/presets.h
+++ b/tools/host_tests/dx_sysex/stub/presets.h
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Michi71
+//
+// Program change is not what this test covers; the two entry points exist only
+// so midi_reface.cpp links.
+#pragma once
+#include <stdint.h>
+#define DX_NPRESETS 32
+void preset_set_current(uint8_t);
+void preset_stage(uint8_t);

--- a/tools/host_tests/dx_sysex/stub/tusb.h
+++ b/tools/host_tests/dx_sysex/stub/tusb.h
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Michi71
+#pragma once
+bool tud_midi_mounted(void);

--- a/tools/host_tests/shim/pico/stdlib.h
+++ b/tools/host_tests/shim/pico/stdlib.h
@@ -8,6 +8,15 @@
 // it: J6_Controller.cpp mirrors panel edits to DIN MIDI, so the header comes
 // along even though the test never sends a byte. Everything the shim needs to
 // provide is the standard integer types.
+//
+// The clock is declared but not defined here: midi_reface.cpp stamps its
+// active sensing timers with it, and a test that pulls such a file in supplies
+// whatever notion of time it wants to test against. A test that never
+// references them links fine without.
 #pragma once
 #include <stdint.h>
 #include <stddef.h>
+
+typedef uint64_t absolute_time_t;
+absolute_time_t get_absolute_time(void);
+uint32_t to_ms_since_boot(absolute_time_t);


### PR DESCRIPTION
Addresses the Soundmondo sync report in #2.

## Cause

`tud_midi_stream_write()` is not "write these bytes" — it takes what fits the
TinyUSB transmit FIFO and returns how far it got. The FIFO holds
`CFG_TUD_MIDI_TX_BUFSIZE` (64) bytes of four-byte packets, and a SysEx packet
carries three payload bytes, so the ceiling is **48 SysEx bytes** between two
`tud_task()` calls. All three reface layers ignored the return value.

A PicoFaceDX voice bulk is **241 bytes across seven messages**, written back to
back with no `tud_task()` in between:

| Block | Bytes | Outcome |
|---|---|---|
| Bulk header | 13 | sent; transfer starts, endpoint busy |
| Common | 51 | only ~48 accepted — cut off mid-message, no `F7` |
| Operators 0–3 | 4 × 41 | FIFO full, endpoint busy → dropped entirely |
| Bulk footer | 13 | dropped |

Simulating the FIFO accounting gives 46 bytes accepted and 195 discarded in
silence, plus whatever the first `write_flush()` had already moved to the
endpoint. Soundmondo therefore never received a complete voice and showed
"Init Voice". Parameter changes (11 bytes) and the identity reply (15) sit
under the ceiling, which is why the device was recognised and manual parameter
edits worked.

The loss is not the whole damage: a truncated SysEx leaves TinyUSB's stream
state *inside* a message, so the next bytes written — active sensing every
200 ms — get packed as SysEx continuation, and the outgoing stream stays
corrupted until an `F0` resynchronises it.

## Fix

Instruments queue on a new core `MIDIOutputUSB`; the main loop drains into
TinyUSB after each `tud_task()`, one FIFO at a time.

Nothing blocks. The audio producer shares that loop, a dump is several USB
frames long, and the pool is only six 64-sample buffers — about 8.7 ms at
44.1 kHz — so waiting on USB inside the MIDI path would have traded a lost
dump for an underrun. Messages are queued whole or dropped whole, never
written in part, for the stream-state reason above.

PicoFaceCP and PicoFaceYC had the same unchecked call and move across too.

## Verification

Host test against a mock of TinyUSB's packet accounting:

- a full 241-byte dump arrives byte-exact
- twelve dumps in a row stay byte-exact across the ring wraparound
- an over-long burst drops whole messages; every message on the wire is complete
- an unmounted host accumulates no backlog

All three firmwares build (DX, CP, YC).

## Not covered

- **Not yet tried on hardware.**
- The reported **crackle** on sync is not explained by this and needs a re-test
  once the dump completes.
- The receive direction looks sound by inspection (256-byte reassembly, checksum
  verified, USB RX flow-controlled by NAK). The report that the device's patch
  does not update is most likely downstream of the broken read-back — plausible,
  not proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)