### PR TITLE
PicoFaceDX: document the Soundmondo operator 4 defect; let dumps outpace the display flush

### DIFF
--- a/core/src/picoface_main.cpp
+++ b/core/src/picoface_main.cpp
@@ -284,7 +284,14 @@ int main(void)
 
         // 2. Incremental display flush
         // Half tile rows, roughly 1.5 ms of I2C each, so the audio lead does not collapse.
-        if (picoface_ui_flush_row < 16) {
+        //
+        // Stands aside while MIDI still has bytes queued. The transmit queue is
+        // topped up once per pass, so a 1.5 ms I2C block between two passes
+        // paces a SysEx dump at roughly a TinyUSB FIFO per 1.5 ms: a 241-byte
+        // voice takes about six of those, some 9 ms, where USB itself would be
+        // done in four 1 ms frames. An editor reading a voice sees the gaps; the
+        // display catches up a few milliseconds later and nobody sees that.
+        if (picoface_ui_flush_row < 16 && usbMidiOut().empty()) {
             u8g2_UpdateDisplayArea(&g_u8g2, (picoface_ui_flush_row & 1) ? 8 : 0, (uint8_t)(picoface_ui_flush_row >> 1), 8, 1);
             picoface_ui_flush_row++;
         }

--- a/instruments/PicoFaceDX/doc/MIDI_IMPLEMENTATION.md
+++ b/instruments/PicoFaceDX/doc/MIDI_IMPLEMENTATION.md
@@ -190,6 +190,43 @@ of roughly a quarter second whenever an editor asked for a voice - on connect as
 well as on sync, and regardless of whether anything was plugged into the DIN
 socket. `MIDISerial` now queues too and tops up the FIFO from `process()`.
 
+### Known Soundmondo defect: operator 4 shown wrong after a sync (not this firmware)
+
+Verified against Soundmondo as served on 2026-08-08. After a voice sync,
+Soundmondo's reface DX voice editor can show wrong values for **operator 4
+only** - typically Level, Vel.s, FB level, and the right-hand key scaling pair -
+while operators 1-3 and the common block are correct. The device's transmission
+is fine: a wire capture of the full dump is byte-exact with valid checksums, and
+this firmware's blocks are byte-identical to what a real reface DX sends, which
+is therefore affected just the same.
+
+The defect is in Soundmondo's `components/reface-panel/reface-panel.js`, and it
+takes two of their bugs in combination. Applying an operator bulk block walks
+the 28 bytes in address order; at offset 9 (`KB.R`) the value is mirrored into a
+second model property, whose change observer runs this `switch`:
+
+```js
+case "osc2.3.kbr":
+  this.set("eg.3.kbr", this.osc2[3].kbr);
+                                    // no break - only in the op-4 case
+case "ksc.0.levellmin":
+...
+  console.lone("new levellmin:" + newVal);   // typo for console.log
+```
+
+The operator 1-3 cases have their `break`; only the operator 4 case falls
+through, into a line that misspells `console.log` and throws. The exception
+aborts the block walk, so every operator 4 field **after offset 9** keeps the
+editor's init-voice default, and the wrong fields are exactly those where the
+patch differs from the defaults - which is why the pattern looks arbitrary.
+Confirmed both ways by driving the live page's `dx-keyboard` element with a
+captured dump: with the typo present the display shows the defaults, with
+`console.lone = console.log` patched in the same payload displays correctly.
+
+Nothing in this firmware can compensate for it. Workaround for a Soundmondo
+session: paste `console.lone = console.log;` into the browser's DevTools
+console before syncing; it holds until the page is reloaded.
+
 ### Dump Request (RX) → TX-Antwort
 
 | Adresse | Antwort |


### PR DESCRIPTION
Follow-up to #6, which fixed the two transmit defects behind #2. Two commits,
no behavioural change to the MIDI protocol itself.

## 1. The operator 4 question, answered

After both transmit fixes one observation remained: Soundmondo showed wrong
values for **operator 4 only** after a sync — Level, Vel.s, FB level and the
right-hand key scaling pair — on every patch, while operators 1–3 and the
common block were correct.

It is not this firmware. Established in four independent steps:

- a wire capture of the full dump: nine messages, correct lengths, valid
  checksums, operator 4 carrying exactly the stored values (`velSens 0x78`,
  `outLevel 0x60`, `feedback 0x32`)
- the Yamaha Data List: our block layout and the 0-based operator numbering
  (`31 op 00`, `op: 00–03`) are per spec
- the ESP32 reference (`RDX-Reface-DX-emu`): struct, offsets, block order,
  byte count and checksum formula are byte-identical to ours
- Soundmondo's own `reface-panel.js`, driven in the live page with the captured
  dump

The defect is theirs, and it takes two bugs in combination:

```js
case "osc2.3.kbr":
  this.set("eg.3.kbr", this.osc2[3].kbr);
                                    // no break — only in the op-4 case
case "ksc.0.levellmin":
...
  console.lone("new levellmin:" + newVal);   // typo for console.log
```

Applying an operator block walks its 28 bytes in address order. At offset 9
(`KB.R`) the value is mirrored into a second model property; its observer falls
through the missing `break` into the misspelled `console.log` and throws. The
exception aborts the walk, so every operator 4 field **after offset 9** keeps
the editor's init-voice default — and the wrong fields are exactly those where
the patch differs from those defaults, which is why the pattern looked
arbitrary rather than like truncation.

Confirmed both ways: with the typo present the display shows defaults; with
`console.lone = console.log` patched in, the same payload displays correctly
(96 / 120 / 50 / −7 / −LIN).

A real reface DX sends byte-identical blocks and is affected the same way, so
nothing here can compensate for it. Documented in `MIDI_IMPLEMENTATION.md` with
the mechanism, the verification and the DevTools workaround.

## 2. Display flush stands aside for a queued dump

**Not a bug fix** — it was written while the timing hypothesis was still open,
and that hypothesis is dead. It stays because it is right on its own: the
display flush spends ~1.5 ms of I2C per main loop pass and the transmit queue
is topped up once per pass, so a 241-byte dump was paced at one TinyUSB FIFO
per 1.5 ms — about 9 ms, where USB itself delivers it in roughly four 1 ms
frames. An editor waiting on a voice sees those gaps; the display catching up a
few milliseconds later is invisible.

## Verification

Both commits are the state that ran on hardware (WeAct RP2350A + PCM5102)
throughout the investigation — no display artifacts, no audio issues, and the
sync itself confirmed working. `tools/host_tests/dx_sysex/` still passes both
directions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)