### PR TITLE
PicoFaceJ6: arpeggiator and hold do not come back on at power-on

### DIFF
--- a/instruments/PicoFaceJ6/src/J6_Controller.cpp
+++ b/instruments/PicoFaceJ6/src/J6_Controller.cpp
@@ -749,6 +749,22 @@ void J6_Controller::importSettings(const J6SettingsV1& s)
         ipc_send_param(J6_PARAM_PROGRAM, (uint16_t) program_);
 
     for (int i = 0; i < JUNO_TOTAL_COUNT; ++i) {
+        /*
+         * Everything except the two performance latches, which always come
+         * back off. On the original both are pieces of plastic you can see
+         * from across the room, so restoring their position is what hardware
+         * does; here they are three levels down a menu, and an instrument that
+         * arpeggiates the first chord after power-on -- or holds it -- with
+         * nothing on screen saying why is a trap rather than a feature.
+         *
+         * Rate, mode and range stay restored. Those are settings, and the next
+         * switch-on should find the arpeggiator configured the way it was
+         * left, just not running. The stored values are still written by
+         * exportSettings so the record layout and its version are unchanged;
+         * an existing record simply has two fields nobody reads.
+         */
+        if (i == JUNO_ARP_ON || i == JUNO_HOLD) continue;
+
         uint16_t q = s.param[i];
         if (q > 1000) q = 1000;
         shadow_[i] = (float) q / 1000.0f;

--- a/tools/host_tests/j6/j6_ui_test.cpp
+++ b/tools/host_tests/j6/j6_ui_test.cpp
@@ -408,6 +408,59 @@ static void test_edited_marker(J6_Controller& c)
 }
 
 /* ------------------------------------------------------------------------ */
+/* Reported as "the arpeggiator is enabled by default": it was not a default at
+ * all, the switch was simply part of the stored settings and came back on at
+ * every power-on once it had been used. HOLD sat in the same trap. */
+static void test_latches_not_restored(J6_Controller& c)
+{
+    group("Arpeggiator und Hold kommen nicht eingeschaltet zurueck");
+
+    /* What the veeprom would hold after switching both on and turning the rate
+     * up: a record with everything set, exported by the panel itself. */
+    J6SettingsV1 s{};
+    c.exportSettings(s);
+    s.param[JUNO_ARP_ON]   = 1000;   /* on                                 */
+    s.param[JUNO_HOLD]     = 1000;   /* likewise                           */
+    s.param[JUNO_ARP_RATE] = 800;    /* and clearly not the default 350    */
+    s.param[JUNO_ARP_MODE] = 1000;   /* down                               */
+
+    uint32_t drain;
+    while (j6_ipc_pop(&drain)) { }   /* the ring, as at power-on           */
+    c.importSettings(s);
+
+    bool sawArpOn = false, sawHold = false, sawRate = false, sawMode = false;
+    uint16_t rate = 0, mode = 0;
+    uint32_t pkt;
+    while (j6_ipc_pop(&pkt)) {
+        if (ipc_type(pkt) != IPC_CMD_J6_PARAM) continue;
+        switch (ipc_d1(pkt)) {
+            case JUNO_ARP_ON:   sawArpOn = true;                 break;
+            case JUNO_HOLD:     sawHold  = true;                 break;
+            case JUNO_ARP_RATE: sawRate  = true; rate = ipc_d2(pkt); break;
+            case JUNO_ARP_MODE: sawMode  = true; mode = ipc_d2(pkt); break;
+            default: break;
+        }
+    }
+
+    ck(!sawArpOn, "der Arp-Schalter wird der Engine gar nicht erst geschickt");
+    ck(!sawHold,  "Hold ebensowenig");
+
+    note("Rate %u, Mode %u", rate, mode);
+    ck(sawRate && rate == 800, "die Rate ueberlebt");
+    ck(sawMode && mode == 1000, "die Betriebsart auch");
+
+    /* And the panel agrees with the engine, so the ARP page does not show an
+     * "on" that nothing is playing. Both latches live on that one page. */
+    goToPage(c, "ARP", "ARP");
+    char a[24], b[24];
+    c.paramAText(a, sizeof(a));
+    c.paramBText(b, sizeof(b));
+    note("ARP-Seite zeigt \"%s\" / \"%s\"", a, b);
+    ck(strcmp(a, "On") != 0 && strcmp(a, "1") != 0, "die Arp-Anzeige steht nicht auf ein");
+    ck(strcmp(b, "On") != 0 && strcmp(b, "1") != 0, "die Hold-Anzeige auch nicht");
+}
+
+/* ------------------------------------------------------------------------ */
 static void test_every_page(J6_Controller& c)
 {
     group("Jede Seite laesst sich anzeigen und bedienen");
@@ -460,6 +513,7 @@ int main(void)
         test_truncation(c);
         test_write_page(c);
         test_edited_marker(c);
+        test_latches_not_restored(c);
         test_every_page(c);
     }
 


### PR DESCRIPTION
Fixes #8.

## It was never a default

`junoInstrumentDefault()` has returned 0 for `JUNO_ARP_ON` all along, and both
places that seed the instrument half — the engine's `init()` and the
controller's constructor — use it. A device whose switch has never been touched
starts with the arpeggiator off.

What actually happened: the switch is part of the **stored settings**.
`importSettings()` sweeps the whole parameter array, instrument half included,
so once the arpeggiator had been switched on it came back on at every power-on,
with nothing on screen saying why.

Faithful, in a sense — on a Juno-60 that switch is a piece of plastic you can
see from across the room, and restoring its position is what hardware does.
Here it sits three levels down a menu, and an instrument that arpeggiates the
first chord after switch-on is a trap rather than a feature. The reporter is
right.

## Change

`importSettings()` skips the two performance latches:

```c
if (i == JUNO_ARP_ON || i == JUNO_HOLD) continue;
```

`JUNO_HOLD` was in the same trap and is the same class of control — a latch
surviving a power cycle is at least as surprising as a running arpeggio — so it
goes too. Both live on the one ARP page.

**Rate, mode and range stay restored.** Those are settings: the next power-on
should find the arpeggiator configured the way it was left, just not running.

`exportSettings()` still writes both switches, so the record layout and
`J6_SETTINGS_VERSION` are unchanged — existing veeprom records stay valid and
simply carry two fields nobody reads any more. No migration.

## Verification

New case in the panel host test (`tools/host_tests/j6/`): imports a record with
both latches on and a rate clearly off the default (800 vs 350), then checks
that neither switch is ever sent to the engine, that rate and mode survive, and
that the ARP page reads "off" for both.

Verified to fail without the change:

```
ohne den Fix:  Arp-Schalter FEHLER, Hold FEHLER, Anzeige "on" / "on"
mit dem Fix:   beide ok,                          Anzeige "off" / "off"
```

Firmware builds; the whole J6 panel suite passes.

**Not covered:** not yet tried on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)