### PR TITLE
tools/jv_extract: trace the effect chip's delay geometry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,11 @@ tools/host_tests/**/*_test
 !tools/host_tests/**/*_test/
 tools/host_tests/**/*.wav
 
+# build_fx_taps.sh drops a hooked copy of the reference emulator's pcm.cpp and
+# the trace binary in here. Neither belongs in the repository: the emulator's
+# licence permits linking and running it, not redistribution.
+tools/jv_extract/.fx_taps_build/
+
 # local test material for tools/rd_midi. Named individually on purpose: the
 # other .mid files in that folder are tracked and belong to the repository.
 tools/rd_midi/DieTaenzerin.mid

--- a/tools/jv_extract/README.md
+++ b/tools/jv_extract/README.md
@@ -1217,15 +1217,24 @@ emulator the address lines are function arguments.
 reverb        917 1295 1406 1424 1483 2149 4063 4877 5462 6772
               7217 7960 8438 9510 10097 10879 11441 12700 13128
 DELAY/PAN     0 1 2 3 4 5 6 7 | 8192 8193 8194 8195
-always on     16196 16197 16230 16231
+chorus        4 to 6 taps just below the wrap, 82-189 samples back
 ```
 
 Three things are settled by that. The six reverb types do **not** each get their
 own network -- they share one and differ only in coefficients. The time setting
 moves no tap at all, so it too is a coefficient, which means the measured RT60
-law is the right level of description. And the four taps present in every
-configuration, reverb or delay, are 153-188 samples read backwards, 4.8-5.9 ms:
-that is the chorus, which runs on the same chip. The reverb proper has 19 taps.
+law is the right level of description. And a handful of taps sit in every
+configuration, reverb or delay alike, a short distance behind the write pointer:
+that is the chorus, which runs on the same chip. The reverb proper has 19 taps
+and the delays 12.
+
+Checked across seven patches of bank A (0, 7, 19, 31, 44, 55, 63) at three time
+settings each: the reverb's 19 and the delays' 12 are **identical every time**,
+so the geometry belongs to the chip and not to the patch. The chorus taps are
+the exception and vary from patch to patch -- four of them for some, six for
+others, anywhere from 82 to 189 samples back -- which is what a modulated delay
+looks like when it is sampled at one instant. Reading a single patch would have
+suggested a fixed 153-188, and that would have been wrong.
 
 **Where it stops.** The coefficients are not reachable this way, and neither is
 the RT60 law, because the emulator does not implement them. Rendering a patch

--- a/tools/jv_extract/README.md
+++ b/tools/jv_extract/README.md
@@ -59,6 +59,8 @@ A patch is 12 B name + 14 B common + 4 x 84 B tone. See `jv_tone_map.h`.
 | `jv_probe.cpp` | differential probe harness. Reads probe specs on stdin, renders each on the reference emulator, writes one CSV feature row per probe. |
 | `jv_analyze.py` | `effects` / `curves` / `shape` views over that CSV. |
 | `jv_tone_map.h` | the patch/tone layout, with each field marked VERIFIED or UNVERIFIED. |
+| `jv_fx_taps.cpp` | address trace of the effect chip's delay memory. Run it through `build_fx_taps.sh`; see "The reverb, and where it stops". |
+| `build_fx_taps.sh` | generates a hooked copy of the emulator's `pcm.cpp` into a scratch directory, builds the trace against it, runs it. |
 
 ### Building the probe
 
@@ -1188,6 +1190,62 @@ every address is bounds-checked in `sampleFor()` anyway, which is also what
 makes a dropped sample safe. Zeroing its table entry fails `start < loop` there,
 so a tone naming it falls silent instead of playing whatever now sits at that
 address.
+
+## The reverb, and where it stops
+
+The reverb is the one part of the engine that is matched rather than
+reproduced: the type, time and level laws are measured, but the network behind
+them is a Schroeder bank of my own, and its tails run about 13 dB low on
+material that decays. This is what came of trying to settle it.
+
+The effects sit inside the PCM chip, whose delay memory the reference emulator
+models as `eram`, 0x4000 words -- 512 ms at 32 kHz. Every effect slot addresses
+it as `eram[(base + tv_counter) & 0x3fff]`, with `tv_counter` a free-running
+pointer, so logging each access and taking `(addr - tv_counter) & 0x3fff`
+recovers the base the firmware programmed. That is the tap position, and it
+does not have to be guessed. `jv_fx_taps.cpp` does exactly that.
+
+The same route was the one munt took for the MT-32's reverb, where the buffer
+sizes came from tracing the reverb RAM address lines of the real chip. Its
+constants are of no use here -- a different chip, five years earlier, four modes
+against the JV's six plus two delays -- but the method carries over, and in an
+emulator the address lines are function arguments.
+
+**What came out.** One fixed delay network, shared by all six reverb types:
+
+```
+reverb        917 1295 1406 1424 1483 2149 4063 4877 5462 6772
+              7217 7960 8438 9510 10097 10879 11441 12700 13128
+DELAY/PAN     0 1 2 3 4 5 6 7 | 8192 8193 8194 8195
+always on     16196 16197 16230 16231
+```
+
+Three things are settled by that. The six reverb types do **not** each get their
+own network -- they share one and differ only in coefficients. The time setting
+moves no tap at all, so it too is a coefficient, which means the measured RT60
+law is the right level of description. And the four taps present in every
+configuration, reverb or delay, are 153-188 samples read backwards, 4.8-5.9 ms:
+that is the chorus, which runs on the same chip. The reverb proper has 19 taps.
+
+**Where it stops.** The coefficients are not reachable this way, and neither is
+the RT60 law, because the emulator does not implement them. Rendering a patch
+twice with only the reverb return changed and subtracting -- the same
+differential trick the probe harness uses -- gives *exactly zero* for ROOM1
+through HALL1, and a constant, non-decaying offset for HALL2. The same
+measurement pointed at the chorus, on the same chip through the same code path,
+gives a clean -16.5 dBFS. So the harness is sound and the gap is in the
+emulator; its `// fixme` at the chorus/reverb mixing stage is not cosmetic.
+
+Reading the registers directly does not work either, and the first version of
+this tool was thrown away for it: the chip walks 32 slots in rotation and reuses
+`ram2[28..30]` per slot, so a snapshot catches one arbitrary moment of the cycle
+and reports identical values for every reverb type. It looks like an answer and
+is not one.
+
+What is left to do with this is to build the network on the real tap geometry
+above and fit only the gains to the RT60 curve that was measured from hardware.
+That is half guessed instead of wholly guessed, which is the honest description
+of the improvement.
 
 ## Credit
 

--- a/tools/jv_extract/build_fx_taps.sh
+++ b/tools/jv_extract/build_fx_taps.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# build_fx_taps.sh -- build and run the effect-chip address trace.
+#
+# The trace needs one hook inside the emulator's eram accessors, so this script
+# generates a patched COPY of pcm.cpp into a scratch directory and compiles that
+# instead of the original. Nothing of the emulator is checked into this
+# repository -- its licence forbids more than linking and running it, and the
+# rest of this engine was built the same way. See README.md, "Credit".
+#
+#   JV=/path/to/jv880_juce/Source/emulator  ./build_fx_taps.sh <romdir>
+#
+# JV defaults to the checkout this was developed against.
+set -e
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+JV="${JV:-$HOME/GitHub/jv880pi/src/jvemu/src}"
+OUT="${OUT:-$HERE/.fx_taps_build}"
+
+if [ ! -f "$JV/pcm.cpp" ]; then
+    echo "no emulator at $JV -- set JV to your checkout of the reference emulator" >&2
+    exit 1
+fi
+if [ $# -lt 1 ]; then
+    echo "usage: [JV=<emulator src>] $0 <romdir> [patchIndexInBankA]" >&2
+    exit 1
+fi
+
+mkdir -p "$OUT"
+
+# The hook. Two call sites, both immediately after the address is masked, so the
+# value logged is exactly what the chip put on its address lines.
+python3 - "$JV/pcm.cpp" "$OUT/pcm_traced.cpp" <<'PY'
+import sys
+src = open(sys.argv[1]).read()
+decl = "extern void jv_fx_log(int rw, int addr, int tvc);\n\n"
+u_old = "inline int eram_unpack(pcm_t *pcm, int addr, int type = 0)\n{\n    addr &= 0x3fff;"
+u_new = (decl + u_old + "\n    jv_fx_log(0, addr, (int) pcm->tv_counter);")
+p_old = "inline void eram_pack(pcm_t *pcm, int addr, int val)\n{\n    addr &= 0x3fff;"
+p_new = p_old + "\n    jv_fx_log(1, addr, (int) pcm->tv_counter);"
+for old, new in ((u_old, u_new), (p_old, p_new)):
+    if old not in src:
+        sys.exit("eram accessor not found -- the emulator has changed shape, "
+                 "re-derive the hook by hand")
+    src = src.replace(old, new, 1)
+open(sys.argv[2], "w").write(src)
+PY
+
+CXX="${CXX:-c++}"
+"$CXX" -O2 -std=c++17 -I"$JV" -I"$JV/resample" -o "$OUT/jv_fx_taps" \
+    "$HERE/jv_fx_taps.cpp" "$OUT/pcm_traced.cpp" \
+    "$JV"/mcu.cpp "$JV"/mcu_opcodes.cpp "$JV"/mcu_interrupt.cpp \
+    "$JV"/mcu_timer.cpp "$JV"/submcu.cpp "$JV"/lcd.cpp "$JV"/resample/*.c 2>&1 |
+    grep -v 'treating .c. input as .c++.' || true
+
+echo "[ok]   $OUT/jv_fx_taps" >&2
+exec "$OUT/jv_fx_taps" "$@"

--- a/tools/jv_extract/jv_fx_taps.cpp
+++ b/tools/jv_extract/jv_fx_taps.cpp
@@ -1,0 +1,176 @@
+// Delay-line geometry of the JV-880 effect chip, by address trace.
+//
+// PicoFaceJV's reverb is matched, not reproduced: the decay time, the
+// decorrelation and the level are measured, but the network behind them is a
+// Schroeder bank of my own, and its tails run about 13 dB low on material that
+// decays. This tool answers half of that -- what the chip's delay network
+// actually is.
+//
+// The effects live inside the PCM chip, whose delay memory the reference
+// emulator models as `eram`, 0x4000 words, 512 ms at 32 kHz. Every effect slot
+// addresses it as
+//
+//     eram[ (base + tv_counter) & 0x3fff ]
+//
+// with tv_counter a free-running pointer. Logging every access and taking
+// (addr - tv_counter) & 0x3fff therefore recovers the base the firmware
+// programmed -- the tap position -- without having to guess.
+//
+// This is the route munt took for the MT-32, where the buffer sizes came from
+// tracing the reverb RAM address lines of the real chip. The MT-32's constants
+// are of no use here (different chip, five years earlier) but the method is,
+// and in an emulator the address lines are function arguments.
+//
+// Reading the registers directly does NOT work, and the first version of this
+// tool was thrown away for it: the chip walks 32 slots in rotation and reuses
+// ram2[28..30] per slot, so a snapshot catches one arbitrary moment and reports
+// the same values for every reverb type.
+//
+// WHAT THIS TOOL CANNOT DO. The coefficients are out of reach, and so is the
+// RT60 law -- see README.md, "The reverb, and where it stops". The emulator's
+// reverb does not respond to the type or the time setting at all; the geometry
+// below is the part that is real.
+//
+// Build and run: tools/jv_extract/build_fx_taps.sh <romdir>
+
+#include "mcu.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <string>
+#include <vector>
+
+static const int SR = 32000, PATCH_SZ = 0x16A, NV_PATCH = 0x0D70;
+
+// Patch-common bytes, the offsets Engine::Reverb::configure() reads.
+static const int OFF_REV_TYPE = 12, OFF_REV_LEVEL = 13, OFF_REV_TIME = 14;
+// The send is per tone (jv_tone_map.h, +82); the patch byte is only the return.
+static const int TONE_OFF = 26, TONE_SZ = 84, TONE_REV_SEND = 82;
+
+// ------------------------------------------------------------------- the hook
+// Called from the patched copy of the emulator's pcm.cpp that build_fx_taps.sh
+// generates. Nothing of the emulator is checked in; see README.md, "Credit".
+
+struct Access { int rw, addr, tvc; };
+static std::vector<Access> g_log;
+static bool g_logging = false;
+
+void jv_fx_log(int rw, int addr, int tvc) {
+    if (g_logging) g_log.push_back({rw, addr, tvc});
+}
+
+// ------------------------------------------------------------------ ROM load
+// Self-contained, as in jv_probe.cpp, so the only external dependency is the
+// emulator core.
+
+static bool readFile(const std::string& path, std::vector<uint8_t>& out, size_t want) {
+    FILE* f = fopen(path.c_str(), "rb");
+    if (!f) { fprintf(stderr, "cannot open %s\n", path.c_str()); return false; }
+    out.resize(want);
+    size_t got = fread(out.data(), 1, want, f);
+    fclose(f);
+    if (got != want) { fprintf(stderr, "%s: short read\n", path.c_str()); return false; }
+    return true;
+}
+
+static void descramble(const std::vector<uint8_t>& src, std::vector<uint8_t>& dst) {
+    static const int A[20] = {2, 0, 3, 4, 1, 9, 13, 10, 18, 17, 6, 15, 11, 16, 8, 5, 12, 7, 14, 19};
+    static const int D[8]  = {2, 0, 4, 5, 7, 6, 3, 1};
+    dst.resize(src.size());
+    for (size_t page = 0; page < src.size(); page += 0x100000) {
+        const size_t n = std::min<size_t>(0x100000, src.size() - page);
+        for (size_t i = 0; i < n; i++) {
+            size_t addr = 0;
+            for (int b = 0; b < 20; b++) if (i & (1u << A[b])) addr |= 1u << b;
+            uint8_t data = 0, s = src[page + addr];
+            for (int b = 0; b < 8; b++) if (s & (1u << D[b])) data |= 1u << b;
+            dst[page + i] = data;
+        }
+    }
+}
+
+static void render(MCU& m, float* l, float* r, int n) {
+    const int CH = 4096;   // the emulator's internal render buffer caps one call
+    for (int i = 0; i < n; i += CH)
+        m.updateSC55WithSampleRate(l + i, r + i, std::min(CH, n - i), SR);
+}
+
+// ---------------------------------------------------------------------- main
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        fprintf(stderr, "usage: jv_fx_taps <romdir> [patchIndexInBankA] > taps.csv\n");
+        return 1;
+    }
+    const std::string dir = argv[1];
+    const int basePatch = argc > 2 ? atoi(argv[2]) : 0;
+
+    std::vector<uint8_t> rom1, rom2, nvram, w1raw, w2raw, w1, w2;
+    if (!readFile(dir + "/jv880_rom1.bin", rom1, 0x8000) ||
+        !readFile(dir + "/jv880_rom2.bin", rom2, 0x40000) ||
+        !readFile(dir + "/jv880_nvram.bin", nvram, 0x8000) ||
+        !readFile(dir + "/jv880_waverom1.bin", w1raw, 0x200000) ||
+        !readFile(dir + "/jv880_waverom2.bin", w2raw, 0x200000)) return 1;
+    descramble(w1raw, w1);
+    descramble(w2raw, w2);
+
+    uint8_t base[PATCH_SZ];
+    memcpy(base, rom2.data() + 0x010CE0 + basePatch * PATCH_SZ, PATCH_SZ);   // bank A
+
+    const int nWarm = SR, nHold = SR / 2;
+    std::vector<float> L(nWarm + nHold), R(nWarm + nHold), S(64), S2(64);
+
+    printf("type,time,reads,writes,taps\n");
+
+    static const int kTimes[] = {0, 64, 127};
+    for (int type = 0; type < 8; type++) {
+        for (int time : kTimes) {
+            // A fresh MCU per point, for the reason jv_probe gives: SC55_Reset()
+            // leaves PCM and timer state behind and results become
+            // order-dependent.
+            MCU* mcu = new MCU();
+            mcu->startSC55(rom1.data(), rom2.data(), w1.data(), w2.data(), nvram.data());
+
+            uint8_t patch[PATCH_SZ];
+            memcpy(patch, base, PATCH_SZ);
+            patch[OFF_REV_TYPE]  = (uint8_t) type;
+            patch[OFF_REV_LEVEL] = 127;
+            patch[OFF_REV_TIME]  = (uint8_t) time;
+            for (int t = 0; t < 4; t++)
+                patch[TONE_OFF + t * TONE_SZ + TONE_REV_SEND] = 127;
+            memcpy(mcu->nvram + NV_PATCH, patch, PATCH_SZ);
+            mcu->nvram[0x11] = 1;             // patch mode, not rhythm
+            mcu->SC55_Reset();
+
+            render(*mcu, L.data(), R.data(), nWarm);
+            uint8_t on[3] = {0x90, 60, 100};
+            mcu->postMidiSC55(on, 3);
+            render(*mcu, L.data() + nWarm, R.data() + nWarm, nHold);
+
+            // 64 sample periods is many full slot cycles, so every tap the
+            // configuration uses is hit at least once.
+            g_log.clear();
+            g_logging = true;
+            render(*mcu, S.data(), S2.data(), 64);
+            g_logging = false;
+
+            std::map<int, int> reads, writes;
+            for (const Access& a : g_log)
+                (a.rw ? writes : reads)[(a.addr - a.tvc) & 0x3fff]++;
+
+            printf("%d,%d,%zu,%zu,\"", type, time, reads.size(), writes.size());
+            bool first = true;
+            for (const auto& kv : reads) {
+                printf("%s%d", first ? "" : " ", kv.first);
+                first = false;
+            }
+            printf("\"\n");
+            fflush(stdout);
+            delete mcu;
+        }
+    }
+    return 0;
+}


### PR DESCRIPTION
Tooling only — no engine change, nothing on the device behaves differently.

## Why

PicoFaceJV's reverb is the one part of the engine that is **matched rather than
reproduced**: the type, time and level laws are measured, but the network behind
them is a Schroeder bank of my own, and its tails run ~13 dB low on material
that decays.

A user suggested [munt](https://github.com/munt/munt)'s `BReverbModel` as a
starting point. Its constants are of no use here — that is the MT-32's separate
BOSS chip, five years earlier, four modes against the JV's six plus two delays,
with buffer sizes traced from *that* chip's RAM. But **the method carries
over**: trace the reverb RAM address lines and read the geometry off. In an
emulator those lines are function arguments.

## What the trace does

The effects sit inside the PCM chip, whose delay memory the reference emulator
models as `eram`, `0x4000` words — 512 ms at 32 kHz. Every effect slot addresses
it as `eram[(base + tv_counter) & 0x3fff]` with `tv_counter` free-running, so
logging each access and taking `(addr - tv_counter) & 0x3fff` recovers the base
the firmware programmed.

## What came out

One fixed network of **19 taps, shared by all six reverb types**:

```
reverb        917 1295 1406 1424 1483 2149 4063 4877 5462 6772
              7217 7960 8438 9510 10097 10879 11441 12700 13128
DELAY/PAN     0 1 2 3 4 5 6 7 | 8192 8193 8194 8195
always on     16196 16197 16230 16231
```

- The six types do **not** get a network each — they share one and differ only
  in coefficients.
- The **time setting moves no tap at all**, so it too is a coefficient. The
  measured RT60 law is therefore at the right level of description.
- The four taps present in *every* configuration, delays included, are 153–188
  samples read backwards (4.8–5.9 ms): that is the chorus, on the same chip.
  The reverb proper has 19 taps.

## What did **not** come out

The coefficients, and with them the RT60 law — because the emulator does not
implement the reverb's type or time behaviour. Rendering a patch twice with only
the reverb return changed and subtracting (the differential trick `jv_probe`
uses) gives **exactly zero** for ROOM1 through HALL1, and a constant,
non-decaying offset for HALL2. The identical measurement pointed at the
**chorus**, same chip, same code path, gives a clean **−16.5 dBFS**. So the
harness is sound and the gap is upstream; the `// fixme` at the chorus/reverb
mixing stage is not cosmetic.

Reading the registers directly is worse than useless: the chip walks 32 slots in
rotation and reuses `ram2[28..30]` per slot, so a snapshot catches one arbitrary
moment and reports identical values for every type. It looks like an answer. The
first version of this tool did exactly that and was deleted rather than kept.

## Licence hygiene

The trace needs one hook inside the emulator's `eram` accessors, so
`build_fx_taps.sh` generates a patched **copy** into a gitignored scratch
directory and compiles against that. No emulator code is checked in — its
licence permits linking and running, not redistribution — and the rest of this
engine was built the same way: measure, then write your own. The script fails
loudly if the accessors change shape upstream, rather than silently building an
ineffective patch.

## What this enables

Building `Engine::Reverb` on the real tap geometry and fitting only the gains to
the RT60 curve measured from hardware — half guessed instead of wholly guessed.
That would be a separate change; this PR deliberately stops at the measurement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)