### PR TITLE
README: name the architecture error for what it is

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,33 @@ cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release -DPICOFACE_INSTRUMENTS_F
 cmake --build build
 ```
 
+### If the very first cmake call dies with an architecture error
+
+On macOS a mixed package manager prefix produces this, and it reads like a
+problem with the project:
+
+```
+dyld: Library not loaded: /opt/local/lib/libarchive.13.dylib
+  Referenced from: /opt/local/bin/cmake
+  Reason: (mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64'))
+Abort trap: 6
+```
+
+It is not. The complaint comes from `dyld` about loading `cmake` itself, before
+any of this repository is read, and "need 'x86_64'" means the `cmake` binary is
+an Intel build sitting next to Apple Silicon libraries — a MacPorts or Homebrew
+prefix that was installed under Rosetta, or carried over from an Intel Mac
+without the migration. Check with:
+
+```bash
+uname -m                 # arm64 on Apple Silicon
+file $(which cmake)      # must say the same
+```
+
+If they disagree, reinstall the toolchain for the machine's own architecture
+(MacPorts documents a migration procedure for exactly this). Apple Silicon
+itself is fine: the collection is developed on it.
+
 ## Repository layout
 
 ```text


### PR DESCRIPTION
Documentation only. Addresses #14 — but not as a fix, because there is nothing
here to fix.

## What #14 actually is

Reported as "build fails on Apple Silicon", with this on an M2:

```
dyld[70152]: Library not loaded: /opt/local/lib/libarchive.13.dylib
  Referenced from: /opt/local/bin/cmake
  Reason: (mach-o file, but is an incompatible architecture (have 'arm64', need 'x86_64'))
Abort trap: 6
```

`dyld` fails while loading **cmake itself**. The process aborts before `main()`,
so no file in this repository has been read — `cmake -S . -B build` is merely
where the reporter happened to invoke it. And the direction is the tell:
*"have 'arm64', need 'x86_64'"* means the library is Apple Silicon and the cmake
binary wants Intel. Their `cmake` is an x86_64 build in a prefix otherwise full
of arm64 libraries: a MacPorts install that went through Rosetta, or came off an
Intel Mac without the migration.

Apple Silicon is not the cause. This collection is developed on it, against that
same `/opt/local` prefix, and builds all nine instruments:

```
uname -m                            arm64
/opt/local/bin/cmake                arm64
/opt/local/lib/libarchive.13.dylib  arm64
/opt/local/bin/ninja                arm64
```

## Why touch the README at all

The message names `cmake` and this project's build command in the same breath,
so it reads like the project's fault — and the reporter drew exactly that
conclusion. The next person will too.

So the build section now describes the failure, says why it happens before the
project is involved, and gives the two commands that settle it (`uname -m`
against `file $(which cmake)`). No build change, no code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)