### PR TITLE
tools/jv_extract: name the chip, and why its reverb is out of reach

### DIFF
--- a/tools/jv_extract/README.md
+++ b/tools/jv_extract/README.md
@@ -1273,11 +1273,33 @@ first the note dominating, then dropping away. So the ~13 dB deficit is not a
 tuning error in the Schroeder bank: the curve it is tuned to does not describe a
 reverb.
 
-**This emulator cannot settle it.** What the JV-880's reverb actually does is
-not reachable from here, and no further sweep of it will help. Recordings from
-the hardware would be needed, and until there are any, the honest position is
-that the reverb is matched to a curve of unknown provenance and the geometry
-above is the only measured thing about it.
+**This emulator cannot settle it, and the reason is in the silicon.**
+[giulioz/roland-dsps](https://github.com/giulioz/roland-dsps), a survey of
+Roland's custom effect chips, names the one in this machine:
+
+> **GP** (Toshiba TC24SC201AF-002, 1990). Integrated 28-voices sample player
+> with TVF and **ROM-based DSP (chorus/reverb)**. Used in: SC-55, JV-80, many
+> many more.
+
+The JV-880 is the rack JV-80, so that is the chip, and the effects are not a
+wired-up network but a **program in a ROM inside it**. Of every chip in that
+survey the GP is the only one with no emulator of its own; it points at
+Nuked-SC55, which is where this project's reference emulator comes from.
+Nuked-SC55 models the hardware -- registers, addressing, the delay memory --
+but not the program running in it, because that ROM has not been read out.
+
+Which accounts for every observation above. The addressing works, so the taps
+are real and their geometry is worth having. There is no recirculation, because
+the feedback lives in the program. Type and time do nothing, because they are
+parameters to a program that is not running. The measurements were right; what
+was missing was the reason.
+
+So this is not "not reachable yet". Nothing done to the emulator will produce
+the reverb until that ROM is dumped -- optically, as has been done for some of
+the others in that survey, though not for this one. Until then the honest
+position is that the reverb is matched to a curve of unknown provenance, and the
+geometry above is the only measured thing about it. Recordings from hardware
+would be the way round it.
 
 Three lessons, each of which cost a wrong conclusion here. A differential
 measurement is only as good as its control: patch common 13, the reverb return,
@@ -1308,6 +1330,12 @@ The patch and tone field layout comes from
 (`Source/dataStructures.h`, by Giulio Zausa), which also carries the reference
 emulator this harness drives -- itself derived from
 [NukeYKT's Nuked-SC55](https://github.com/nukeykt/Nuked-SC55).
+
+The identification of the effect chip, and with it the explanation of why its
+reverb cannot be measured here, comes from the same author's
+[giulioz/roland-dsps](https://github.com/giulioz/roland-dsps). It carries no
+licence file, so nothing is taken from it but the reading; it is cited above as
+a source, which is all it is used for.
 
 That emulator is under a licence forbidding sale and commercial use, which is
 compatible with neither MIT nor GPL-3.0. It is therefore **not vendored into


### PR DESCRIPTION
Documentation only. Closes out the reverb investigation by supplying the one
thing the last three commits were missing: a reason.

## The chip

[giulioz/roland-dsps](https://github.com/giulioz/roland-dsps) — a survey of
Roland's custom effect chips, by the author of the reference emulator — names
the one in this machine:

> **GP** (Toshiba TC24SC201AF-002, 1990). Integrated 28-voices sample player
> with TVF and **ROM-based DSP (chorus/reverb)**. Used in: SC-55, JV-80, many
> many more.

The JV-880 is the rack JV-80, so that is the chip. **ROM-based** is the point:
the effects are a program inside the chip, not a wired-up network. And of every
chip in that survey, the GP is the only one with no emulator of its own — it
points at Nuked-SC55, which is where this project's reference emulator comes
from. Nuked-SC55 models the hardware (registers, addressing, delay memory) but
not the program running in it, because that ROM has not been read out.

## What it explains

Every observation from #13, #16 and #17 falls out of that one fact:

| observed | because |
|---|---|
| addressing works, taps are real | the hardware generates them |
| no recirculation | the feedback lives in the program |
| type and time do nothing | they parameterise a program that is not running |

The measurements were right. The reason was missing, which left the emulator
looking merely unfinished.

## What it changes

The conclusion moves from *"not reachable yet"* to *"not reachable"*. Nothing
done to the emulator will produce this reverb until that ROM is dumped
optically — as has been done for some others in the survey, but not for this
one. Recordings from hardware remain the way round it.

The tap geometry from #13 keeps its value: it comes from the hardware side,
which is exactly the part that *is* emulated.

## Licence

`roland-dsps` carries no licence file, so nothing is taken from it but the
reading. Cited in **Credit** as a source, which is all it is used for — the GP
is not represented there by code in any case.

🤖 Generated with [Claude Code](https://claude.com/claude-code)