### PR TITLE
tools: measure RD's flash stalls, repair its regression runner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ tools/host_tests/**/*_test
 !tools/host_tests/**/*_test/
 tools/host_tests/**/*.wav
 
+# build_xip_probe.sh drops its host build of the RD engine here.
+tools/rd_extract/.xip_probe_build/
+
 # build_fx_taps.sh drops a hooked copy of the reference emulator's pcm.cpp and
 # the trace binary in here. Neither belongs in the repository: the emulator's
 # licence permits linking and running it, not redistribution.

--- a/instruments/PicoFaceRD/src/rd_engine/rd_new_engine.cpp
+++ b/instruments/PicoFaceRD/src/rd_engine/rd_new_engine.cpp
@@ -7,6 +7,12 @@
 #include <cstring>
 #include <cstdlib>
 
+#ifdef RD_XIP_TRACE
+// Host-only: defined by tools/rd_extract/build_xip_probe.sh, never by a
+// firmware build. See the call site in the sample read.
+extern void rd_xip_trace(unsigned waverom_addr);
+#endif
+
 // Sub-phase interpolation LUT. NOTE: a never-written non-const static gets
 // promoted to flash .rodata by GCC (verified in the linker map) -- RAM
 // residency is enforced by an explicit runtime copy into .bss at loadPack.
@@ -435,6 +441,13 @@ int32_t RD_HOT_FUNC(RdNewEngine::renderVoice)(Voice& v, uint32_t tOn, uint32_t t
         uint32_t volume = ~(((adder1_a >> 14) & 0b111111) | ((adder3_o & 0b1111) << 6) | (adder3_of ? ((adder3_o & 0b11110000) << 6) : 0)) & 0x3fff;
 
         // 4-byte packed entry: one 32-bit load, two entries per XIP line.
+        // This single load is the whole flash story: one per part per sample,
+        // so up to 120 of them at twelve voices. tools/rd_extract runs the
+        // address stream through a cache model to see how many of them miss;
+        // the hook is compile-time and absent from every firmware build.
+#ifdef RD_XIP_TRACE
+        rd_xip_trace(waverom_addr);
+#endif
         const uint32_t w = _bank[waverom_addr];
         uint32_t pa = (w & 0x3FFFu) | (ag3 ? 1u : 0u);
         uint32_t pb = ((w >> 15) & 0x1FFu) | (ag3 ? 0u : 1u);

--- a/tools/jv_extract/build_fx_taps.sh
+++ b/tools/jv_extract/build_fx_taps.sh
@@ -45,12 +45,15 @@ for old, new in ((u_old, u_new), (p_old, p_new)):
 open(sys.argv[2], "w").write(src)
 PY
 
+# Everything the compiler says goes to stderr, filtered but never to stdout:
+# stdout is the CSV, and a stray warning in the middle of it silently corrupts
+# the run. The emulator builds with a few of its own warnings.
 CXX="${CXX:-c++}"
-"$CXX" -O2 -std=c++17 -I"$JV" -I"$JV/resample" -o "$OUT/jv_fx_taps" \
+{ "$CXX" -O2 -std=c++17 -I"$JV" -I"$JV/resample" -o "$OUT/jv_fx_taps" \
     "$HERE/jv_fx_taps.cpp" "$OUT/pcm_traced.cpp" \
     "$JV"/mcu.cpp "$JV"/mcu_opcodes.cpp "$JV"/mcu_interrupt.cpp \
     "$JV"/mcu_timer.cpp "$JV"/submcu.cpp "$JV"/lcd.cpp "$JV"/resample/*.c 2>&1 |
-    grep -v 'treating .c. input as .c++.' || true
+    grep -v 'treating .c. input as .c++.'; } >&2 || true
 
 echo "[ok]   $OUT/jv_fx_taps" >&2
 exec "$OUT/jv_fx_taps" "$@"

--- a/tools/jv_extract/jv_fx_taps.cpp
+++ b/tools/jv_extract/jv_fx_taps.cpp
@@ -123,7 +123,7 @@ int main(int argc, char** argv) {
     const int nWarm = SR, nHold = SR / 2;
     std::vector<float> L(nWarm + nHold), R(nWarm + nHold), S(64), S2(64);
 
-    printf("type,time,reads,writes,taps\n");
+    printf("type,time,nreads,nwrites,reads,writes\n");
 
     static const int kTimes[] = {0, 64, 127};
     for (int type = 0; type < 8; type++) {
@@ -164,6 +164,14 @@ int main(int argc, char** argv) {
             printf("%d,%d,%zu,%zu,\"", type, time, reads.size(), writes.size());
             bool first = true;
             for (const auto& kv : reads) {
+                printf("%s%d", first ? "" : " ", kv.first);
+                first = false;
+            }
+            // Writes as well: a tap's length is its read base minus its write
+            // base, so reads alone give positions but no delays.
+            printf("\",\"");
+            first = true;
+            for (const auto& kv : writes) {
                 printf("%s%d", first ? "" : " ", kv.first);
                 first = false;
             }

--- a/tools/rd_extract/README.md
+++ b/tools/rd_extract/README.md
@@ -57,6 +57,62 @@ First validation (note-by-note, vel 110): r = 0.90–0.97, RMS ratio
   registers, sample-ROM reads become sequential). renderSample() remains as
   a 1-sample wrapper for the host tools.
 
+## How much of the render is waiting for flash
+
+`build_xip_probe.sh` answers that with a number instead of a hunch. It builds
+the engine for the host with `RD_XIP_TRACE` defined, which enables one hook at
+the wave-ROM read in `rd_new_engine.cpp`, captures every address, and runs the
+stream through a model of the RP2350's XIP cache (16 KB, two-way, 8-byte lines
+-- the geometry the 4-byte packing above assumes). No firmware build defines
+the macro; `nm` on `PicoFaceRD.elf` shows no such symbol.
+
+```bash
+tools/rd_extract/build_xip_probe.sh 0 12 200      # patch, voices, blocks
+```
+
+**What it found.** At the 32 kHz base limit of twelve voices the engine issues
+119 wave-ROM loads per sample -- one per part, ten parts per note, as expected
+-- and the flash cost is enormous but wildly patch-dependent:
+
+| patch | miss rate | flash-bound | | patch | miss rate | flash-bound |
+|---|---|---|---|---|---|---|
+| 3 | 85.7 % | **65.8 %** | | 8 | 43.0 % | 32.1 % |
+| 14 | 84.6 % | 65.0 % | | 11 | 37.3 % | 28.6 % |
+| 0 | 77.1 % | 58.7 % | | 7 | 16.2 % | 12.5 % |
+| 12 | 75.8 % | 58.1 % | | **5** | **0.2 %** | **0.2 %** |
+| 13 | 83.1 % | 63.8 % | | **15** | **0.1 %** | **0.1 %** |
+
+Two thirds of the cycle budget goes to stalls on the worst patches. On patches
+5 and 15 the cost is nil -- their wave data fits the cache and every voice
+reuses it -- and it stays nil as voices are added:
+
+| voices | patch 15 | patch 5 | patch 3 |
+|---|---|---|---|
+| 12 | 0.1 % | 0.2 % | 65.8 % |
+| 16 | 0.1 % | 0.2 % | 82.8 % |
+| 24 | 0.1 % | 0.2 % | **95.7 %** |
+| 32 | 0.1 % | 0.2 % | 96.3 % |
+
+So the base limit of twelve is set by patches like 3, which is already at 96 %
+of budget on stalls alone at twenty-four voices -- while patches 5 and 15 never
+touch flash at all. A per-patch base limit, derived offline from this
+measurement rather than guessed at runtime, is the lever the voice governor
+does not currently have.
+
+**What this does not show.** Only that the flash bottleneck disappears, not
+that those patches can run twenty-four voices: the arithmetic scales with voice
+count too, and this probe does not measure it. If it fails there, it will not
+be flash. The device can answer that today without any code change -- VOICES
+offers fixed polyphony, the footer shows peak load, so patch 15 at 24 voices
+against patch 3 at 24 voices settles it.
+
+**On the numbers.** The miss rate is measured: a real address stream from the
+real engine through a stated cache geometry. The conversion to percent of
+budget is an estimate with its assumptions in the source -- 96 CPU cycles per
+miss, from a 120 MHz QSPI fetch at the 4:1 clock ratio. Halve or double that
+and the absolute figures move; the ordering, and the factor of several hundred
+between patch 3 and patch 15, do not.
+
 ## Regression runner (one command)
 
     tools/rd_extract/run_regression.sh

--- a/tools/rd_extract/build_xip_probe.sh
+++ b/tools/rd_extract/build_xip_probe.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Michi71
+#
+# build_xip_probe.sh -- how much of the render is waiting for flash.
+#
+# Builds the engine for the host with RD_XIP_TRACE defined, which turns on the
+# one hook in rd_new_engine.cpp's sample read. No firmware build defines it, so
+# the hot path is untouched on the device.
+#
+#   ./build_xip_probe.sh [patch 0-15] [voices] [blocks]
+#
+# Defaults: patch 0, 12 voices (the 32 kHz base limit), 200 blocks of 64.
+set -e
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+R="$(cd "$HERE/../.." && pwd)/instruments/PicoFaceRD"
+OUT="${OUT:-$HERE/.xip_probe_build}"
+mkdir -p "$OUT"
+
+CXX="${CXX:-c++}"
+{ "$CXX" -O2 -std=c++17 -DRD_XIP_TRACE \
+    -I "$R/include" -I "$R/include/rd_engine" \
+    -o "$OUT/rd_xip_probe" \
+    "$HERE/rd_xip_probe.cpp" \
+    "$R/src/rd_engine/rd_new_engine.cpp" \
+    "$R/src/rd_engine/rd_packs_data.cpp" \
+    "$R/src/rd_engine/program_tables.cpp" \
+    "$R/src/rd_engine/rd_samples_pk4_a.cpp" \
+    "$R/src/rd_engine/rd_samples_pk4_b.cpp" \
+    "$R/src/rd_engine/rd_samples_pk4_m.cpp"; } >&2
+
+echo "[ok]   $OUT/rd_xip_probe" >&2
+exec "$OUT/rd_xip_probe" "$@"

--- a/tools/rd_extract/rd_xip_probe.cpp
+++ b/tools/rd_extract/rd_xip_probe.cpp
@@ -1,0 +1,117 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Michi71
+//
+// How much of PicoFaceRD's render time is waiting for flash?
+//
+// The engine reads one 32-bit wave-ROM word per part per sample
+// (`_bank[waverom_addr]`), and with ten parts per note and twelve voices that
+// is up to 120 loads per sample, each of which may miss the XIP cache. The
+// architecture notes call that miss stream the dominant cost. This counts it.
+//
+// The address stream is captured from the real engine (a compile-time hook in
+// rd_new_engine.cpp calls rd_xip_trace at exactly the access site) and run
+// through a model of the RP2350's XIP cache. The geometry is the one the engine's
+// own comment states -- "two entries per XIP line", so 8-byte lines -- at the
+// RP2350's 16 KB with two-way associativity.
+//
+// The cycle figure is an estimate and is labelled as one: it multiplies misses
+// by a QSPI fetch cost, and the true cost depends on bus arbitration this model
+// does not have. The miss RATE is the measurement; the stall fraction is what
+// follows from it under stated assumptions.
+
+#include "rd_new_engine.h"
+#include "rd_packs_data.h"
+
+#include <algorithm>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <vector>
+
+// ------------------------------------------------------------- address trace
+static std::vector<unsigned> g_addrs;
+static bool g_logging = false;
+
+void rd_xip_trace(unsigned addr) {
+    if (g_logging) g_addrs.push_back(addr);
+}
+
+// ------------------------------------------------------------- cache model
+struct Cache {
+    // RP2350: 16 KB XIP cache. Line = 8 bytes (two 4-byte wave entries), which
+    // is what the engine's packing comment assumes. Two-way set associative.
+    static const int kLineBytes = 8;
+    static const int kWays = 2;
+    static const int kSets = (16 * 1024) / (kLineBytes * kWays);
+
+    unsigned tag[kSets][kWays];
+    bool     valid[kSets][kWays];
+    int      lru[kSets];
+    long     hits = 0, misses = 0;
+
+    Cache() { memset(valid, 0, sizeof(valid)); memset(lru, 0, sizeof(lru)); }
+
+    void access(unsigned byteAddr) {
+        const unsigned line = byteAddr / kLineBytes;
+        const int set = (int)(line % kSets);
+        const unsigned t = line / kSets;
+        for (int w = 0; w < kWays; w++) {
+            if (valid[set][w] && tag[set][w] == t) { hits++; lru[set] = 1 - w; return; }
+        }
+        misses++;
+        const int victim = lru[set];
+        tag[set][victim] = t;
+        valid[set][victim] = true;
+        lru[set] = 1 - victim;
+    }
+};
+
+int main(int argc, char** argv) {
+    const int patch  = argc > 1 ? atoi(argv[1]) : 0;
+    const int voices = argc > 2 ? atoi(argv[2]) : 12;
+    const int blocks = argc > 3 ? atoi(argv[3]) : 200;
+
+    RdNewEngine eng;
+    // The bank is carried inside the pack header, so loadPack takes only the blob.
+    if (!eng.loadPack(rd_pack_ptrs[patch], rd_pack_sizes[patch])) {
+        fprintf(stderr, "pack %d did not load\n", patch);
+        return 1;
+    }
+    eng.setVoiceLimit((uint8_t) voices);
+
+    // A held chord across the keyboard, so every voice runs a different note
+    // and the parts do not share wave regions by accident.
+    for (int i = 0; i < voices; i++) eng.noteOn((uint8_t)(36 + i * 3), 100);
+
+    int32_t acc[64];
+    for (int b = 0; b < 8; b++) { memset(acc, 0, sizeof(acc)); eng.renderBlock(acc, 64); }   // settle
+
+    g_logging = true;
+    for (int b = 0; b < blocks; b++) { memset(acc, 0, sizeof(acc)); eng.renderBlock(acc, 64); }
+    g_logging = false;
+
+    const long samples = (long) blocks * 64;
+    Cache c;
+    for (unsigned a : g_addrs) c.access(a * 4u);   // entries are 4 bytes
+
+    const double perSample = (double) g_addrs.size() / (double) samples;
+    const double missRate  = c.misses ? (double) c.misses / (double)(c.hits + c.misses) : 0.0;
+
+    printf("patch %d, %d voices, %ld samples\n", patch, voices, samples);
+    printf("  wave-ROM loads      %10zu   (%.1f per sample)\n", g_addrs.size(), perSample);
+    printf("  XIP hits            %10ld\n", c.hits);
+    printf("  XIP misses          %10ld   (%.1f %% miss rate)\n", c.misses, 100.0 * missRate);
+    printf("  misses per sample   %10.1f\n", (double) c.misses / (double) samples);
+
+    // Budget: at 32 kHz one sample is 480e6/32000 = 15000 CPU cycles across two
+    // cores. A miss fetches one line over QSPI at 120 MHz; a quad read costs
+    // roughly 8+8 QSPI clocks of overhead plus the data, call it 24, which at
+    // the 4:1 clock ratio is ~96 CPU cycles. Both numbers are stated so the
+    // estimate can be argued with.
+    const double cyclesPerSample = 480e6 / 32000.0;
+    const double missCycles = (double) c.misses / (double) samples * 96.0;
+    printf("\n  cycle budget/sample %10.0f  (480 MHz, 32 kHz, both cores)\n", cyclesPerSample);
+    printf("  estimated stall     %10.0f  cycles/sample at ~96 per miss\n", missCycles);
+    printf("  -> flash-bound      %10.1f %% of the budget\n", 100.0 * missCycles / cyclesPerSample);
+    return 0;
+}

--- a/tools/rd_extract/run_regression.sh
+++ b/tools/rd_extract/run_regression.sh
@@ -14,11 +14,15 @@
 
 set -u
 
-# R points at the PicoFaceRD instrument directory, not at the repository root:
-# in the standalone repository these tools sat next to include/ and src/, in the
-# collection the engine lives under instruments/PicoFaceRD/. Everything below
-# still says "$R/include" and "$R/src", so this line is the only difference.
-REPO="$(cd "$(dirname "$0")/../.." && pwd)"
+# Two roots, because the move into the collection split what used to be one
+# tree: the engine went to instruments/PicoFaceRD/ ($R, still addressed as
+# "$R/include" and "$R/src" throughout), while these harnesses went to
+# tools/rd_extract/ at the repository root ($HERE). The first version of this
+# line kept only $R and left the harness sources under "$R/tools/rd_extract",
+# where nothing has been since the merge - so the runner failed on its very
+# first build and stayed that way.
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
 R="$REPO/instruments/PicoFaceRD"
 WORK="$REPO/build_host"
 mkdir -p "$WORK/packs"
@@ -57,13 +61,13 @@ build_tool() {
 build_tool rd_dump_packs \
     clang++ -O2 -std=c++17 -I "$R/include" -I "$R/include/rd_engine" \
     -o "$WORK/rd_dump_packs" \
-    "$R/tools/rd_extract/rd_dump_packs.cpp" \
+    "$HERE/rd_dump_packs.cpp" \
     "$R/src/rd_engine/rd_packs_data.cpp"
 
 build_tool rd_ab_test \
     clang++ -O2 -std=c++17 -I "$R/include" -I "$R/include/rd_engine" \
     -o "$WORK/rd_ab_test" \
-    "$R/tools/rd_extract/rd_ab_test.cpp" \
+    "$HERE/rd_ab_test.cpp" \
     "$R/src/rd_engine/mcu.cpp" \
     "$R/src/rd_engine/sound_chip.cpp" \
     "$R/src/rd_engine/mks20a_tables.cpp" \
@@ -81,7 +85,7 @@ build_tool rd_ab_test \
 build_tool rd_stress2 \
     clang++ -O2 -std=c++17 -I "$R/include" -I "$R/include/rd_engine" -I "$R/effects" \
     -o "$WORK/rd_stress2" \
-    "$R/tools/rd_extract/rd_stress2.cpp" \
+    "$HERE/rd_stress2.cpp" \
     "$R/src/RD_Synth_Bridge_v2.cpp" \
     "$R/src/rd_effects.cpp" \
     "$R/src/rd_engine/rd_new_engine.cpp" \


### PR DESCRIPTION
Host tooling only. Three independent commits; no engine behaviour changes and no
firmware image is affected.

## 1. Where RD's cycles actually go

RD needs 480 MHz and both cores for 12 voices at 32 kHz where PicoFaceJV does 24
on one core at 444. The suspicion was that RD is still close to emulation and
would gain from a rebuild along JV's lines.

**It is not.** RD has been descriptor-based since v2 — the same approach as JV.
And its pipeline is not simpler but heavier: the MKS-20's SA synthesis builds
every note from ten parts, and the pack data says all ten, always. Over 16 packs
and 5632 note entries: **exactly ten parts each, none empty**, the last slot
still carrying seven envelope segments on average. Twelve voices are therefore
120 part streams against JV's at most 96 tone streams.

Each part reads one wave-ROM word per sample, and that read is the whole flash
story. `build_xip_probe.sh` captures the address stream through a compile-time
hook and runs it through a model of the RP2350 XIP cache (16 KB, two-way,
8-byte lines — the geometry the 4-byte packing already assumes).

**The cost is enormous and wildly patch-dependent:**

| patch | miss rate | flash-bound | | patch | miss rate | flash-bound |
|---|---|---|---|---|---|---|
| 3 | 85.7 % | **65.8 %** | | 7 | 16.2 % | 12.5 % |
| 14 | 84.6 % | 65.0 % | | **5** | **0.2 %** | **0.2 %** |
| 0 | 77.1 % | 58.7 % | | **15** | **0.1 %** | **0.1 %** |

And on the flash-free patches it stays nil as voices are added — 12, 16, 24, 32
all measure the same — while patch 3 reaches **95.7 % on stalls alone at 24
voices**. So the base limit of twelve is set by the worst patch and applied to
all. A per-patch base limit, derived offline from this rather than guessed at
runtime, is a lever the voice governor does not have.

**What it does not show:** that those patches can *run* 24 voices. Arithmetic
scales with voice count too and the probe does not measure it — only that if it
fails there, it will not be flash. The device can settle that today with no code
change (VOICES offers fixed polyphony, the footer shows peak load).

The miss rate is measured; the conversion to percent of budget is an estimate
with its assumptions in the source (96 cycles/miss). Move that and the absolute
figures move — the ordering and the several-hundred-fold spread do not.

`RD_XIP_TRACE` is defined by the probe's build script and by nothing else; `nm`
on `PicoFaceRD.elf` confirms the symbol is absent.

## 2. The RD regression runner has been broken since the monorepo merge

Found while looking for a gate to check the hook against:

```
clang++: error: no such file or directory:
  '.../instruments/PicoFaceRD/tools/rd_extract/rd_dump_packs.cpp'
[FAIL] build rd_dump_packs
```

The merge split one tree in two. The engine went to `instruments/PicoFaceRD/`
and `$R` points there correctly for `$R/include` and `$R/src`. But these
harnesses went to `tools/rd_extract/` at the repository root and were left
addressed as `$R/tools/rd_extract/…`, where nothing has been since. It died on
its first build, every time, while the README offered it as the one-command gate
for RD work.

Repaired, and it passes — including against commit 1:

```
6 A/B cells, all exactly on their frozen correlations
3 stuck-voice stress cases, tailRMS 0.000000
REGRESSION PASS (9 checks)
```

## 3. Two fixes to the JV tap trace

Riding along because they were found using it, and are unrelated to the above:
compiler output was landing in the middle of the CSV (stderr merged into
stdout), and the trace printed read bases only — a tap's delay is read minus
write, so positions were reported without lengths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)