### PR TITLE
veeprom: a record belongs to the instrument that wrote it

### DIFF
--- a/core/include/veeprom.h
+++ b/core/include/veeprom.h
@@ -40,6 +40,8 @@
 #define VEEPROM_SLOTS         ((VEEPROM_NUM_SECTORS * VEEPROM_SECTOR_SIZE) / VEEPROM_RECORD_SIZE)
 #define VEEPROM_HDR_SIZE      16u
 #define VEEPROM_MAX_PAYLOAD   (VEEPROM_RECORD_SIZE - VEEPROM_HDR_SIZE)
+// Base magic, "PCFP". The value actually written and checked is this mixed
+// with the instrument name -- see veeprom_set_instrument().
 #define VEEPROM_MAGIC         0x50434650u   // "PCFP"
 
 // ----- Record header ----------------------------------------------------------
@@ -67,6 +69,25 @@ typedef void (*veeprom_unlock_fn)(void);
 void veeprom_set_lock_hooks(veeprom_lock_fn lock, veeprom_unlock_fn unlock);
 
 // ----- Public API -------------------------------------------------------------
+
+// Tie every record to one instrument. MUST be called before veeprom_init().
+//
+// The store sits at a fixed address at the top of flash and a .uf2 does not
+// erase it, so flashing a different instrument onto the same board leaves the
+// previous one's record in place. The header carries a schema version but no
+// instrument, and those versions collide across the collection -- PicoFaceJ6,
+// PicoFaceSM and PicoFaceDX all reached version 3 independently. The core
+// accepts a record whose version matches and whose length is at least what the
+// instrument needs, so a 72-byte J6 record satisfied PicoFaceSM's 54, and
+// PicoFaceSM read J6's programme number, MIDI channel and parameter array as
+// its own. Reported as "starts with a silent preset" (issue #18), and silence
+// is the polite outcome of that.
+//
+// The name is folded into the magic, so a record from another instrument fails
+// the same check a corrupt one does and its slot is reclaimed. Records written
+// before this existed no longer validate either: settings are lost once, which
+// is what a schema change has always cost here.
+void veeprom_set_instrument(const char* name);
 
 // Scan flash and locate the latest valid record. Must be called once at boot.
 void veeprom_init(void);

--- a/core/src/picoface_main.cpp
+++ b/core/src/picoface_main.cpp
@@ -170,6 +170,8 @@ int main(void)
     // Installed before init(), so an instrument may already use the veeprom
     // while starting up.
     veeprom_set_lock_hooks(pf_flash_lock, pf_flash_unlock);
+    // Before the scan: it decides which records this instrument may see at all.
+    veeprom_set_instrument(inst.name());
     veeprom_init();
 
     inst.init();   // engine first - it determines its own sample rate

--- a/core/src/veeprom.cpp
+++ b/core/src/veeprom.cpp
@@ -29,6 +29,10 @@ static uint32_t s_lastSeq = 0;
 static veeprom_lock_fn s_lock = 0;
 static veeprom_unlock_fn s_unlock = 0;
 
+// The magic actually written and checked: the base value mixed with the
+// instrument name. See veeprom_set_instrument() in the header for why.
+static uint32_t s_magic = VEEPROM_MAGIC;
+
 #ifdef VEEPROM_HOST_TEST
 
 uint8_t  veeprom_sim_flash[VEEPROM_NUM_SECTORS * VEEPROM_SECTOR_SIZE];
@@ -52,6 +56,7 @@ void veeprom_sim_reset(void) {
     memset(veeprom_sim_erase_count, 0, sizeof(veeprom_sim_erase_count));
     s_lastSlot = -1;
     s_lastSeq = 0;
+    s_magic = VEEPROM_MAGIC;   // a fresh boot has no instrument set yet
 }
 
 #else
@@ -115,11 +120,17 @@ uint32_t veeprom_crc32(const void* data, size_t len) {
     return crc ^ 0xFFFFFFFFu;
 }
 
+void veeprom_set_instrument(const char* name) {
+    uint32_t h = 2166136261u;                       // FNV-1a over the name
+    for (const char* p = name; p && *p; ++p) h = (h ^ (uint8_t)*p) * 16777619u;
+    s_magic = VEEPROM_MAGIC ^ h;
+}
+
 static bool slot_valid(int slot) {
     const uint8_t* p = read_ptr((uint32_t)slot * VEEPROM_RECORD_SIZE);
     VeepromHdr hdr;
     memcpy(&hdr, p, sizeof(hdr));
-    if (hdr.magic != VEEPROM_MAGIC) return false;
+    if (hdr.magic != s_magic) return false;
     if (hdr.len > VEEPROM_MAX_PAYLOAD) return false;
     if (hdr.crc != veeprom_crc32(p + VEEPROM_HDR_SIZE, hdr.len)) return false;
     return true;
@@ -183,7 +194,7 @@ bool veeprom_save(const void* payload, uint16_t len, uint16_t version) {
     memset(buf, 0xFF, VEEPROM_RECORD_SIZE);
 
     VeepromHdr hdr;
-    hdr.magic = VEEPROM_MAGIC;
+    hdr.magic = s_magic;
     hdr.seq = s_lastSeq + 1;
     hdr.version = version;
     hdr.len = len;

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -284,6 +284,8 @@ After merging project_config.h, pico_hw.h and pico_hw.cpp into the core, the fol
 | midi_input_usb.cpp | PicoFaceYC |
 | veeprom.cpp | PicoFaceRD |
 
+RD's `veeprom.cpp` differs in exactly one point too: `RD_CLOCK_504` selects a second QMI timing value after the flash write. Everything else is a copy, and every fix to the core file has to be made twice until the timing constant becomes a define. The instrument tag added for issue #18 is in both.
+
 YC's `midi_input_usb.cpp` differs in exactly one point: it turns a note-on with velocity 0 into a note-off. The core's DIN parser does that anyway, YC's `RefaceMidi::onNoteOn()` does not - that is where the handling belongs, and then the file can go.
 
 `settings.cpp`, `midi_reface.cpp` and `pico_frontpanel.cpp` were listed here until YC was converted. The first two still live under `instruments/PicoFaceYC/src/`, but no longer replace anything, because the core has no sources by those names any more. `pico_frontpanel.cpp` is gone without replacement.

--- a/instruments/PicoFaceRD/src/veeprom.cpp
+++ b/instruments/PicoFaceRD/src/veeprom.cpp
@@ -29,6 +29,10 @@ static uint32_t s_lastSeq = 0;
 static veeprom_lock_fn s_lock = 0;
 static veeprom_unlock_fn s_unlock = 0;
 
+// The magic actually written and checked: the base value mixed with the
+// instrument name. See veeprom_set_instrument() in the header for why.
+static uint32_t s_magic = VEEPROM_MAGIC;
+
 #ifdef VEEPROM_HOST_TEST
 
 uint8_t  veeprom_sim_flash[VEEPROM_NUM_SECTORS * VEEPROM_SECTOR_SIZE];
@@ -52,6 +56,7 @@ void veeprom_sim_reset(void) {
     memset(veeprom_sim_erase_count, 0, sizeof(veeprom_sim_erase_count));
     s_lastSlot = -1;
     s_lastSeq = 0;
+    s_magic = VEEPROM_MAGIC;   // a fresh boot has no instrument set yet
 }
 
 #else
@@ -119,11 +124,17 @@ uint32_t veeprom_crc32(const void* data, size_t len) {
     return crc ^ 0xFFFFFFFFu;
 }
 
+void veeprom_set_instrument(const char* name) {
+    uint32_t h = 2166136261u;                       // FNV-1a over the name
+    for (const char* p = name; p && *p; ++p) h = (h ^ (uint8_t)*p) * 16777619u;
+    s_magic = VEEPROM_MAGIC ^ h;
+}
+
 static bool slot_valid(int slot) {
     const uint8_t* p = read_ptr((uint32_t)slot * VEEPROM_RECORD_SIZE);
     VeepromHdr hdr;
     memcpy(&hdr, p, sizeof(hdr));
-    if (hdr.magic != VEEPROM_MAGIC) return false;
+    if (hdr.magic != s_magic) return false;
     if (hdr.len > VEEPROM_MAX_PAYLOAD) return false;
     if (hdr.crc != veeprom_crc32(p + VEEPROM_HDR_SIZE, hdr.len)) return false;
     return true;
@@ -187,7 +198,7 @@ bool veeprom_save(const void* payload, uint16_t len, uint16_t version) {
     memset(buf, 0xFF, VEEPROM_RECORD_SIZE);
 
     VeepromHdr hdr;
-    hdr.magic = VEEPROM_MAGIC;
+    hdr.magic = s_magic;
     hdr.seq = s_lastSeq + 1;
     hdr.version = version;
     hdr.len = len;

--- a/tools/host_tests/veeprom/veeprom_test.cpp
+++ b/tools/host_tests/veeprom/veeprom_test.cpp
@@ -190,6 +190,40 @@ static void test_wear_leveling_1000(void) {
     CHECK(out[0] == (uint8_t)(999 & 0xFF), "payload[0] == 999 & 0xFF");
 }
 
+// Issue #18: PicoFaceSM booted into silence on a board that had run PicoFaceJ6.
+// Both instruments are at settings version 3 and a .uf2 does not erase the
+// store, so J6's 72-byte record survived the flash and satisfied the core's
+// "version matches, length is at least what I need" test for SM's 54 bytes.
+// SM read J6's programme number and parameter array as Solina parameters.
+static void test_foreign_instrument_ignored(void) {
+    // PicoFaceJ6 stores its settings and the board is then flashed with SM.
+    veeprom_sim_reset();
+    veeprom_set_instrument("PicoFaceJ6");
+    veeprom_init();
+    uint8_t j6[72];
+    for (int i = 0; i < 72; i++) j6[i] = (uint8_t)(i + 1);
+    CHECK(veeprom_save(j6, sizeof(j6), 3), "j6 saves its record");
+
+    // Same flash, same settings version, different instrument: nothing to see.
+    veeprom_set_instrument("PicoFaceSM");
+    veeprom_init();
+    uint8_t buf[240];
+    uint16_t len = 0, ver = 0;
+    CHECK(!veeprom_load(buf, sizeof(buf), &len, &ver), "sm does not read j6 record");
+
+    // SM writes its own, and that one comes back.
+    uint8_t sm[54];
+    memset(sm, 0xC3, sizeof(sm));
+    CHECK(veeprom_save(sm, sizeof(sm), 3), "sm saves over the stale sector");
+    CHECK(veeprom_load(buf, sizeof(buf), &len, &ver), "sm reads its own record");
+    CHECK(len == 54 && memcmp(buf, sm, 54) == 0, "sm record intact");
+
+    // And J6, flashed back on, still finds nothing of SM's.
+    veeprom_set_instrument("PicoFaceJ6");
+    veeprom_init();
+    CHECK(!veeprom_load(buf, sizeof(buf), &len, &ver), "j6 does not read sm record");
+}
+
 int main(void) {
     test_empty_flash();
     test_roundtrip();
@@ -200,6 +234,7 @@ int main(void) {
     test_torn_write_ignored();
     test_oversize_rejected();
     test_wear_leveling_1000();
+    test_foreign_instrument_ignored();
     printf("Summary: %d failures\n", fails);
     return fails;
 }


### PR DESCRIPTION
Fixes #18.

PicoFaceJ6 and PicoFaceSM start silent and stay silent until a program change. Only one reporter sees it, and that reporter flashes every instrument onto the same board — which turns out to be the whole story.

## Cause

The settings store sits at a fixed address in the top two flash sectors and a `.uf2` does not erase it, so the previous instrument's record survives a reflash. The record header carries a schema version but no instrument, and those versions collided — J6, SM and DX had each independently reached version 3.

`picoface_main.cpp` accepts a record whose version matches and whose length is *at least* what the instrument needs:

```cpp
if (veeprom_load(buf, sizeof(buf), &len, &ver) && ver == inst.settingsVersion() && len >= need)
```

J6's record is 72 bytes, SM needs 54. It passed, and PicoFaceSM read J6's programme number, MIDI channel and parameter array as Solina parameters. Silence is the polite outcome. The affected directions are J6 → SM, DX → J6 and DX → SM; the reverse ones were blocked by the length check, which is why the symptom looked selective.

DX's own restore path tests for an exact length and was never the victim — but it was the loudest source.

## Fix

The instrument name is folded into the record magic, so a foreign record fails the same check a corrupt one does and its slot is reclaimed on the next save. One check, at the single place the magic was already tested, and it covers instruments that do not exist yet — better than keeping nine version numbers globally distinct by hand.

The header stays at 16 bytes and the payload at 240, so no instrument's settings struct had to move.

## Cost

Records written before this no longer validate: **stored settings are lost once**, on all nine instruments. That is what a schema change has always cost here. J6's user patches are unaffected — separate sector, own identifier.

## Verification

- New host-test case in `tools/host_tests/veeprom/` replays the reported sequence: J6 saves, SM boots and finds nothing, SM writes its own, J6 flashed back finds nothing of SM's. All 9 existing cases still pass.
- Checked against a sabotaged `veeprom_set_instrument()` — the new case fails at two checks on the old behaviour, so it measures something.
- All nine instruments build, plus both opt-in targets (DX with reface USB identity, JV for 4 MB).
- Not tested on hardware yet.

RD keeps its own copy of `veeprom.cpp` for one QMI timing value and gets the same change; `ARCHITECTURE.md` now records that the two files must be kept in step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)