### PR TITLE
Docs: flash requirement in CP and RD, and the collection is nine

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -235,7 +235,8 @@ Voice mode has no CC: the value is an enumeration, not a 0..127 quantity.
 PicoFaceOB is the first instrument whose sound generation does not come from
 this project: it is ported from
 [OB-Xf](https://github.com/surge-synthesizer/OB-Xf). Two things therefore set it
-apart from the other seven.
+apart from the other eight. PicoFaceJV came later and is not a second case: its
+PCM data is the user's own, but the engine playing it was written here.
 
 **License.** OB-Xf is GPL-3.0-or-later, and so is this repository as a whole
 (root `LICENSE`). What sets PicoFaceOB apart is not the licence itself but its

--- a/instruments/PicoFaceCP/README.md
+++ b/instruments/PicoFaceCP/README.md
@@ -79,6 +79,11 @@ reface owner's manual, "reface CP" section - not shipped with this repository.
 The board is the same for every instrument in the collection; the pin map lives
 in [core/include/project_config.h](../../core/include/project_config.h).
 
+The image is **4.22 MB** — the six sample sets are most of it — so this one does
+not fit a 4 MB board such as a base Pico 2, and there is no reduced variant. An
+oversized `.uf2` stops copying without saying why. See
+[How much flash an instrument needs](../../README.md#how-much-flash-an-instrument-needs).
+
 ---
 
 ## Layout

--- a/instruments/PicoFaceCP/README.md
+++ b/instruments/PicoFaceCP/README.md
@@ -4,7 +4,7 @@
   <img src="../../img/picofacecp.png" alt="PicoFaceCP prototype hardware" width="800">
 </p>
 
-**A Yamaha reface CP emulation**, one of the eight instruments in
+**A Yamaha reface CP emulation**, one of the nine instruments in
 [PicoVintageSynthCollection](../../README.md).
 
 The [mda-EPiano](https://sourceforge.net/projects/mda-vst/) sound engine drives

--- a/instruments/PicoFaceDX/README.md
+++ b/instruments/PicoFaceDX/README.md
@@ -4,7 +4,7 @@
   <img src="../../img/picofacedx.png" alt="PicoFaceDX prototype hardware" width="800">
 </p>
 
-A Yamaha reface DX FM synth clone, one of the eight instruments in
+A Yamaha reface DX FM synth clone, one of the nine instruments in
 [PicoVintageSynthCollection](../../README.md). Four operators, twelve
 algorithms, two effect slots.
 
@@ -125,7 +125,7 @@ Confirmed working: with it, Soundmondo connects and loads voices directly.
 
 It is **off by default** and meant for a session with such an editor, not for
 distribution: it borrows Yamaha's vendor ID, and it gives up the per-instrument
-PID that lets a host tell the eight images of this collection apart. The option
+PID that lets a host tell the nine images of this collection apart. The option
 is cached, so switching it back off needs a reconfigure *and* a rebuild:
 
 ```bash

--- a/instruments/PicoFaceJ6/README.md
+++ b/instruments/PicoFaceJ6/README.md
@@ -1,6 +1,6 @@
 # PicoFaceJ6 — Roland Juno-60
 
-An emulation of the Roland Juno-60, one of the eight instruments in
+An emulation of the Roland Juno-60, one of the nine instruments in
 [PicoVintageSynthCollection](../../README.md).
 
 **Status:** running firmware for the RP2350, plus a macOS host test that

--- a/instruments/PicoFaceMD/README.md
+++ b/instruments/PicoFaceMD/README.md
@@ -1,6 +1,6 @@
 # PicoFaceMD — Moog Minimoog Model D
 
-An emulation of the Moog Minimoog Model D, one of the eight instruments in
+An emulation of the Moog Minimoog Model D, one of the nine instruments in
 [PicoVintageSynthCollection](../../README.md).
 
 **Status:** running firmware for the RP2350, plus a macOS host test that

--- a/instruments/PicoFaceOB/README.md
+++ b/instruments/PicoFaceOB/README.md
@@ -1,6 +1,6 @@
 # PicoFaceOB
 
-An Oberheim OB-X emulation, one of the eight instruments in
+An Oberheim OB-X emulation, one of the nine instruments in
 [PicoVintageSynthCollection](../../README.md). The sound generation is a port of
 **OB-Xf** (https://github.com/surge-synthesizer/OB-Xf), the successor of OB-Xd.
 

--- a/instruments/PicoFaceRD/README.md
+++ b/instruments/PicoFaceRD/README.md
@@ -38,6 +38,11 @@ compatible 16 MB stand-in — the Waveshare RP2350 Plus has no board file in the
 pinned SDK, and all pins used here are addressed explicitly, so the only thing
 taken from the board file is the 16 MB flash size (which matches).
 
+The 16 MB is not decoration here: the image is **5.07 MB**, mostly sample packs,
+so this one does not fit a 4 MB board such as a base Pico 2, and there is no
+reduced variant. An oversized `.uf2` stops copying without saying why. See
+[How much flash an instrument needs](../../README.md#how-much-flash-an-instrument-needs).
+
 ## User interface
 
 Encoder **Select** switches the page (with wrap-around), encoders **A** and **B** edit the two page parameters. Continuous values are shown in percent and step 1 % per detent.

--- a/instruments/PicoFaceRD/README.md
+++ b/instruments/PicoFaceRD/README.md
@@ -5,7 +5,7 @@
 </p>
 
 A Roland **MKS-20 / MK-80** ("S/A synthesis") digital piano clone, one of the
-eight instruments in [PicoVintageSynthCollection](../../README.md). Instead of emulating the original hardware cycle-exactly at runtime, it plays a **descriptor-driven re-implementation** of the S/A engine: the original firmware's voice programming was captured note-by-note on a host-side reference emulator, distilled into compact per-note descriptors, and is replayed on-device with chip-exact envelope arithmetic. The result is validated against the reference emulator with a cross-correlation matrix of 1920 cells (median r = 0.9997).
+nine instruments in [PicoVintageSynthCollection](../../README.md). Instead of emulating the original hardware cycle-exactly at runtime, it plays a **descriptor-driven re-implementation** of the S/A engine: the original firmware's voice programming was captured note-by-note on a host-side reference emulator, distilled into compact per-note descriptors, and is replayed on-device with chip-exact envelope arithmetic. The result is validated against the reference emulator with a cross-correlation matrix of 1920 cells (median r = 0.9997).
 
 ## Features
 
@@ -30,7 +30,7 @@ and [doc/hardware/PROTOTYPE.md](doc/hardware/PROTOTYPE.md) describes a complete
 
 This instrument is the one that pushes the platform hardest: it runs at 480 MHz
 with flash at 120 MHz QSPI, set through `PICOFACE_SYS_CLOCK_HZ` and
-`PICOFACE_QMI_M0_TIMING_TARGET` in its `instrument.cmake`. The other seven run
+`PICOFACE_QMI_M0_TIMING_TARGET` in its `instrument.cmake`. The other eight run
 at 444 MHz.
 
 Note: the build uses the SDK board definition `sparkfun_promicro_rp2350` as a

--- a/instruments/PicoFaceSM/README.md
+++ b/instruments/PicoFaceSM/README.md
@@ -5,7 +5,7 @@
 </p>
 
 
-An emulation of the ARP Solina String Ensemble, one of the eight instruments in
+An emulation of the ARP Solina String Ensemble, one of the nine instruments in
 [PicoVintageSynthCollection](../../README.md).
 
 **Status:** running firmware for the RP2350, plus a macOS host test that

--- a/instruments/PicoFaceYC/README.md
+++ b/instruments/PicoFaceYC/README.md
@@ -1,6 +1,6 @@
 # PicoFaceYC
 
-A Yamaha reface YC combo/home organ clone, one of the eight instruments in
+A Yamaha reface YC combo/home organ clone, one of the nine instruments in
 [PicoVintageSynthCollection](../../README.md). The organ engine is a
 wavetable-based additive footage synthesis architecture written for this
 project, following the tone generation concepts of setBfree.


### PR DESCRIPTION
Follow-up to #22. Two commits, both documentation.

## `9bf96ef` — the flash requirement where someone actually reads it

#22 put the size table in the collection README, but a link straight to `instruments/PicoFaceCP` or `instruments/PicoFaceRD` bypasses it — and those are two of the three images that do not fit 4 MB. One paragraph each in their Hardware sections with the measured size and a link back to the table.

The measurements agree with the footprint lines both READMEs already carried (4,431,496 and 5,318,096 bytes), which is a useful cross-check rather than a second source of truth.

## `ddcc882` — the counts

b5e0988 moved the collection README to nine instruments and left the per-instrument docs behind:

| Where | Was | Now |
|---|---|---|
| CP, DX, J6, MD, OB, SM, YC, RD | "one of the eight instruments" | nine |
| PicoFaceDX, USB section | unique PID "lets a host tell the eight images apart" | nine |
| PicoFaceRD, Hardware | "The other seven run at 444 MHz" | eight — RD is still the only instrument overriding `PICOFACE_SYS_CLOCK_HZ`, checked against every `instrument.cmake` |
| ARCHITECTURE.md §6b | PicoFaceOB set apart "from the other seven" | eight |

Counts that describe history are untouched: the seven original single-instrument repositories really were seven, in the README's licensing paragraph and in ARCHITECTURE.md §2 and §6.

The OB sentence also got a clause saying PicoFaceJV is not a second ported engine — its PCM data is the user's own, but the engine was written here. Easy to drop if that reads as scope creep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)