### PR TITLE
jv_extract: the MT-32 comparison had a number with no source

### DIFF
--- a/tools/jv_extract/README.md
+++ b/tools/jv_extract/README.md
@@ -1207,9 +1207,16 @@ does not have to be guessed. `jv_fx_taps.cpp` does exactly that.
 
 The same route was the one munt took for the MT-32's reverb, where the buffer
 sizes came from tracing the reverb RAM address lines of the real chip. Its
-constants are of no use here -- a different chip, five years earlier, four modes
+constants are of no use here -- a different chip in an older machine, four modes
 against the JV's six plus two delays -- but the method carries over, and in an
 emulator the address lines are function arguments.
+
+The chips are named in the same survey that identifies the JV's, cited below:
+the MT-32's reverb is a Hitachi HG61H20R36F, the JV's effect section a Toshiba
+TC24SC201AF-002 dated 1990. The survey gives no year for the Hitachi part, and
+the MT-32 shipped in 1987, so how far apart their designs are is not something
+this repository can state -- an earlier draft claimed five years and had no
+source for it.
 
 **What came out.** One fixed delay network, shared by all six reverb types:
 

--- a/tools/jv_extract/jv_fx_taps.cpp
+++ b/tools/jv_extract/jv_fx_taps.cpp
@@ -18,8 +18,9 @@
 //
 // This is the route munt took for the MT-32, where the buffer sizes came from
 // tracing the reverb RAM address lines of the real chip. The MT-32's constants
-// are of no use here (different chip, five years earlier) but the method is,
-// and in an emulator the address lines are function arguments.
+// are of no use here (Hitachi HG61H20R36F there, Toshiba TC24SC201AF-002 here,
+// four modes against six plus two delays) but the method is, and in an emulator
+// the address lines are function arguments.
 //
 // Reading the registers directly does NOT work, and the first version of this
 // tool was thrown away for it: the chip walks 32 slots in rotation and reuses


### PR DESCRIPTION
A Reddit reader suggested looking at the MT-32 emulators for the JV-880's reverb — *"there's a good chance JV-880 used the same reverb"* — which is the route this investigation already took. Writing the reply meant re-reading the paragraph that compares the two, and one clause in it did not survive that.

## What was wrong

> Its constants are of no use here — a different chip, **five years earlier**, four modes against the JV's six plus two delays

In `tools/jv_extract/README.md` and again in `tools/jv_extract/jv_fx_taps.cpp`. There was never a source for the interval.

[giulioz/roland-dsps](https://github.com/giulioz/roland-dsps) — the survey this repository already cites for identifying the JV's chip — names the MT-32's reverb as a **Hitachi HG61H20R36F** and gives **no year** for it. It dates the JV's **Toshiba TC24SC201AF-002** to 1990, and the MT-32 shipped in 1987. Three years between two machines, nothing at all between two designs, and the survey does not support the stronger claim either way.

Both places now name the two parts and drop the interval.

## What held up

Checked against `munt/mt32emu/src/BReverbModel.cpp` rather than from memory:

- The comment really does say **address lines** — *"Analysing of state of reverb RAM address lines gives exact sizes of the buffers of filters used"*, credited to Lord_Nightmare & balrog. (A summary I read first said "data lines"; the verbatim comment does not.)
- Four modes (`MODE_0`–`MODE_3`, the last a tap delay), against the JV's six reverbs plus two delays.

So the paragraph's substance — same method, unusable constants — stands. Only the number of unknown provenance is gone.

Nothing in the measurements, the tap geometry, or the conclusion about the GP chip's undumped ROM depends on this. It is one sentence of context that read as if it had been looked up when it had not.

`jv_fx_taps.cpp` is comment-only here and still compiles (`-fsyntax-only` against the reference emulator checkout). Not in CI — this tool needs the emulator and a ROM set, neither of which can be there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)