### PR TITLE
tools: the toolchain that builds PicoFaceCP's sample sets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ tools/jv_extract/jv_probe
 
 # PicoFaceJV needs a local JV-880 ROM set; it is not distributable.
 instruments/PicoFaceJV/roms/
+
+# Built by tools/cp_sampleprep/build_loop_finder.sh
+tools/cp_sampleprep/FindLoopPoints

--- a/instruments/PicoFaceCP/README.md
+++ b/instruments/PicoFaceCP/README.md
@@ -47,6 +47,14 @@ the desktop before flashing.
 Footprint in the collection build: 4,431,496 bytes of flash (the sample sets
 dominate), 178,104 bytes of RAM.
 
+Only `Rd I` plays mda-EPiano's own samples. The other five voices are sample
+sets built for this instrument and committed as headers
+(`Rd_IIData.h`, `WrData.h`, `ClvData.h`, `CPData.h`, `PnoData.h`); the
+toolchain that produces them is
+[tools/cp_sampleprep](../../tools/cp_sampleprep/README.md). The source
+recordings are not distributed — that README says why, and what a replacement
+set has to look like.
+
 ---
 
 ## Signal flow

--- a/tools/cp_sampleprep/README.md
+++ b/tools/cp_sampleprep/README.md
@@ -1,0 +1,190 @@
+<!--
+SPDX-License-Identifier: GPL-3.0-or-later
+SPDX-FileCopyrightText: 2026 Michi71
+-->
+
+# cp_sampleprep — where PicoFaceCP's sample sets come from
+
+Five of PicoFaceCP's six voices are not mda-EPiano's. `Rd II`, `Wr`, `Clv`,
+`Piano` and `CP` are sample sets of their own, built by this toolchain and
+committed as C headers:
+
+| Voice | Header | Flash |
+|---|---|---|
+| Rd I | `mdaEPianoData.h` | 825 kB — mda-EPiano's original set, not built here |
+| Rd II | `Rd_IIData.h` | 967 kB |
+| Wr | `WrData.h` | 773 kB |
+| Clv | `ClvData.h` | 779 kB |
+| CP | `CPData.h` | 580 kB |
+| Piano | `PnoData.h` | 293 kB |
+
+Those headers ship in the firmware and account for most of PicoFaceCP's
+4.22 MB image. The tools that produce them lived outside this repository until
+now, which meant the five generated voices could not be rebuilt from a
+checkout. That is what this directory fixes.
+
+## What is not here: the source recordings
+
+The WAV files these headers were built from are **not** in this repository and
+are not distributed.
+
+They were collected over a long stretch of time, mostly from freely available
+internet sources, and some were made by playing an emulator over MIDI and
+recording its audio output. Their exact origins can no longer be
+reconstructed, so they are not redistributed — the derived headers are what
+ships, and this pipeline is what turned one into the other.
+
+Anyone rebuilding a voice therefore brings their own recordings. The pipeline
+does not care where they came from; it cares about file naming, which is
+described below.
+
+## The chain
+
+Two stages, and one C++ helper that the first stage shells out to.
+
+```
+your WAVs ──▶ prepare_samples.py ──▶ converted WAVs + _instrument.json
+                     │                            │
+                     └── FindLoopPoints           ▼
+                                          build_instrument.py
+                                                  │
+                                                  ▼
+                                     <name>Data.h + <name>Keygroups.h
+```
+
+### Stage 1 — `prepare_samples.py`
+
+Brings arbitrary WAV sets to the format and level of the mda-EPiano samples,
+and cuts them to mda's "attack plus short loop" shape.
+
+1. **Downmix to mono** — any channel count is averaged.
+2. **Resample to 32 kHz** (`scipy.resample_poly`) — mda's native rate; the
+   engine interpolates up to 44.1 kHz at playback.
+3. **Normalise to the pitch-dependent mda target peak.** mda's own samples get
+   quieter towards the top of the keyboard, and that is part of its character.
+   The curve `peak_dBFS(note) = a + b·note` is fitted from mda's root samples
+   rather than guessed; on this repository's data it comes out as
+   `-8.335 - 0.01738·note`.
+4. **Trim**, in one of four modes. `loop` is the default and the interesting
+   one: it pre-cuts to a window ending in strong sustain shortly after the
+   bloom peak, tries several window candidates, and runs `FindLoopPoints` on
+   each. The result is attack plus a short looped sustain region, roughly
+   0.25–0.8 s.
+5. **Write** 16-bit mono PCM at 32 kHz, plus `_mapping.json` and
+   `_instrument.json`.
+
+Loop quality is scored by the C++ tool: ≤0.01 excellent, ≤0.05 good, ≤0.15
+acceptable, >0.30 unusable (the sample is then kept without a loop).
+Degenerate short loops — half periods, high-partial endings — are rejected via
+`min_loop_periods`.
+
+### Stage 2 — `build_instrument.py`
+
+Turns the descriptor into the two headers the engine includes. Every
+referenced sample is concatenated once into a single `int16_t` array, global
+`pos`/`end`/`loop` are computed in mda's semantics (`while (pos > end) pos -=
+loop`), and the keygroup table is emitted with **three velocity layers per
+region**, matching the engine's `k += 3` and its thresholds at 48/80.
+
+Regions get `root` and `high` on their first layer only, as mda does. A layer
+with no sample of its own points at the nearest available velocity tag — same
+data, no extra flash.
+
+### The helper — `FindLoopPoints`
+
+Zero-crossing pattern matching, built from `src/FindLoopPoints.cpp`:
+
+```bash
+./build_loop_finder.sh
+```
+
+It was reviewed when it was wired into the Python pipeline, and it has three
+quirks. None of them affects this use, but all three would bite someone
+reaching for it as a general tool:
+
+- `main()` hard-codes `sampleRate = 32000` instead of reading the fmt chunk.
+  The search itself works purely in samples, so the rate only reaches the
+  ms/Hz display — cosmetic, and the pipeline feeds 32 kHz anyway.
+- `readWav()` mis-parses `channels` and `sampleRate` from the fmt chunk
+  (skipping 4 bytes where it should skip 2). Those values are never used
+  afterwards and the `data` samples are read correctly.
+- `estimatedPeriod` is a **half** period — the distance to the previous
+  opposite-going zero crossing. Loop lengths are still whole multiples of the
+  full period, because loop start and end are the same crossing type, so the
+  loops are correct; only the meaning of `num_periods` is halved and the
+  displayed Hz doubled.
+
+The finding that shaped the pipeline: the finder takes the **last** zero
+crossing as its loop-end reference. On a long decaying note that lands in a
+near-silent, inharmonic tail and the loop is miserable. Hence the pre-cut
+window ending in strong sustain — the tool is never shown the tail.
+
+## Running it
+
+```bash
+./build_loop_finder.sh
+python3 prepare_samples.py configs/rhodes_suitcase.json
+python3 build_instrument.py build_host/cp_samples/converted/rhodes_suitcase/_instrument.json
+```
+
+Paths in the configs are relative to the repository root, and point into
+`build_host/`, which is git-ignored. Put your recordings in
+`build_host/cp_samples/source/<instrument>/` and the generated headers appear
+under `build_host/cp_samples/converted/<instrument>/generated/`.
+
+Dependencies: `pip install soundfile scipy numpy`, plus a C++17 compiler for
+the loop finder.
+
+### File naming
+
+`<NNN>-<VVV>.wav` — MIDI note and velocity, e.g. `060-087.wav`. A `smpl` chunk
+carrying `Midi Note` and loop points is used in preference when present;
+otherwise the note comes from the filename.
+
+The engine has three velocity layers with thresholds at 48/80. A set may carry
+one, two, three or more velocity steps; each engine layer takes the sample
+whose velocity is closest to that layer's centre (24 / 64 / 104).
+
+> `velocity_thresholds` in a config are the **engine's** switch points, not
+> your samples' velocities. Leave them at `[48, 80]` unless you have
+> reprogrammed `noteon()`. The sample velocities are read from the filenames.
+> `engine.layer_to_tag` overrides the mapping if the automatic choice is wrong
+> — `[30, 30, 94]` makes the medium layer play the soft sample instead of the
+> hard one.
+
+### Adding a voice
+
+1. Recordings into `build_host/cp_samples/source/<name>/`.
+2. Copy a config, adjust `source_dir`, `output_dir` and the `trim.*` fields.
+3. Run both stages.
+4. Copy the two generated headers into `instruments/PicoFaceCP/include/`,
+   add the repository's SPDX lines at the top (the generator does not emit
+   them), and wire the voice into `mdaEPianoInstruments.h`.
+
+Note the engine constraint the generator prints: `KGRP kgrp[34]` in
+`mdaEPiano.h` sizes mda's own table. A 19-region set needs 57 keygroups, so
+the array has to grow.
+
+## What changed on the way in
+
+The pipeline used to read mda's reference peaks from 34 exported WAV files
+plus the plugin's `.cpp`. Neither path exists in this repository, which would
+have made the tool unusable exactly where it now lives.
+
+`load_mda_curve()` therefore reads the peaks out of `mdaEPianoData.h` and the
+keygroup table out of `mdaEPiano.cpp`, both of which are in the repository.
+That is not obviously equivalent: the committed data is pre-baked with the
+loop crossfade applied, where the original plugin built its array at runtime.
+Checked against the old WAVs before the switch — the fitted `a` and `b` agree
+to every printed digit, and the resulting target peak differs by **0.000000 dB
+across notes 21–108**. The crossfade lives in the loop region; an e-piano
+sample's peak is in the attack.
+
+Nothing else was touched. In particular the generators' **output templates are
+unchanged**, including their German comments, so regenerating a voice
+reproduces the committed headers rather than a reformatted version of them.
+
+An earlier chain — `InstrumentBuilder`, `SamplesToInstrumentTxt`,
+`PresetIndexBuilder` and the shell scripts driving them — was superseded by
+these two Python stages and is not part of this import. The committed headers
+all carry `Auto-generiert von build_instrument.py`.

--- a/tools/cp_sampleprep/build_instrument.py
+++ b/tools/cp_sampleprep/build_instrument.py
@@ -1,0 +1,203 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Michi71
+
+"""
+build_instrument.py  --  stage 2: descriptor (_instrument.json) to C headers.
+
+Writes the two files PicoFaceCP's engine includes:
+
+  - <name>Data.h       : const int16_t <name>Data[] = { ... };  the samples,
+                         every referenced one concatenated exactly once
+  - <name>Keygroups.h  : the keygroup table (pos/end/loop/root/high) as a
+                         const struct array, plus an mda-style assignment
+                         snippet for the constructor
+
+The engine plays pos..end and wraps at 'loop', in mda's semantics:
+   while (pos > end) pos -= loop;   ->  loop = end + 1 - loop_start, a LENGTH
+rather than a position. Getting that backwards is the classic way to make a
+sample set that plays but throbs.
+
+Three velocity layers per region (engine: k += 3, thresholds 48/80). root and
+high are set on a region's first layer only, as mda does.
+
+Usage:
+    python3 build_instrument.py <converted>/<instr>/_instrument.json
+    python3 build_instrument.py <converted>/<instr>/_instrument.json --outdir DIR
+
+The output templates are deliberately unchanged from the version that produced
+the committed headers, German comments included, so a regenerated voice
+differs from what ships only where the data differs. See README.md.
+"""
+import os, re, sys, json, argparse, wave
+import numpy as np
+
+
+def load_int16_mono(path):
+    """liest ein mono 16-bit WAV als int16-ndarray."""
+    w = wave.open(path, "rb")
+    if w.getnchannels() != 1:
+        raise SystemExit(f"{path}: erwartet mono, hat {w.getnchannels()} Kanaele")
+    n = w.getnframes()
+    data = np.frombuffer(w.readframes(n), dtype=np.int16).copy()
+    w.close()
+    return data
+
+
+def format_data_array(symbol, samples):
+    """int16-Array wie bei mda (20 Werte/Zeile) formatieren."""
+    out = [f"const int16_t {symbol}[] = {{"]
+    for i in range(0, len(samples), 20):
+        chunk = samples[i:i+20]
+        out.append("  " + ",".join(str(int(v)) for v in chunk) + ",")
+    # letzte Zeile ohne Komma + schliessende Klammer
+    if out[-1].endswith(","):
+        out[-1] = out[-1][:-1]
+    out.append("};")
+    return "\n".join(out)
+
+
+def build(desc, outdir):
+    name       = desc["name"]
+    symbol     = desc["data_symbol"]           # z.B. "Rd_IIData" (bereits C-sicher)
+    base       = symbol[:-4] if symbol.endswith("Data") else symbol  # z.B. "Rd_II"
+    sr         = desc["sample_rate"]
+    regions    = desc["regions"]
+    samples_db = desc["samples"]
+    nlayers    = desc["engine"]["velocity_layers"]
+    thresholds = desc["engine"]["velocity_thresholds"]
+    guard = re.sub(r"\W", "_", name).upper()
+
+    # 1) eindeutige Samples sammeln (Reihenfolge: Vorkommen)
+    unique = []
+    seen = set()
+    for r in regions:
+        for s in r["layers"]:
+            if s not in seen:
+                seen.add(s); unique.append(s)
+
+    # 2) Daten-Array aufbauen + Pos/End/Loop je Sample
+    all_samples = []
+    offset = 0
+    posmap = {}   # sample_name -> (pos, end, loop)
+    for s in unique:
+        info = samples_db[s]
+        wav = load_int16_mono(info["file"])
+        pos = offset                       # kumulative Sample-Position (nicht Listenindex!)
+        frames = len(wav)
+        end = pos + frames - 1
+        ls = info["loop_start"]
+        loop = (frames - ls) if (ls is not None and 0 <= ls < frames) else frames
+        posmap[s] = (pos, end, loop)
+        all_samples.append(wav)
+        offset += frames
+    all_samples = np.concatenate(all_samples) if all_samples else np.zeros(0, dtype=np.int16)
+    # Padding: die Engine liest waves[pos+1] (Linear-Interpolation); am Ende des
+    # letzten Samples waere pos+1 sonst out-of-bounds. Wie beim mda-Original
+    # (dort ~11 Samples Padding) legen wir Padding-Nullen an.
+    PADDING = 8
+    if len(all_samples):
+        all_samples = np.concatenate([all_samples, np.zeros(PADDING, dtype=np.int16)])
+
+    # 3) Keygroup-Einträge: pro Region nlayers Eintraege (k += nlayers),
+    #    root/high nur auf dem ersten Eintrag jeder Region.
+    kgrp = []   # (root, high, pos, end, loop)
+    for r in regions:
+        for li in range(nlayers):
+            s = r["layers"][li]
+            p, e, lp = posmap[s]
+            root = r["root"] if li == 0 else 0
+            high = r["high"] if li == 0 else 0
+            kgrp.append((root, high, p, e, lp))
+
+    nkgrp = len(kgrp)
+    total_frames = len(all_samples)
+
+    # Keygroup-Tabelle + globale Pos/End in den Deskriptor eintragen (JSON)
+    desc["keygroups"] = []
+    for i, (root, high, p, e, lp) in enumerate(kgrp):
+        desc["keygroups"].append({
+            "index": i, "region": i // nlayers, "layer": i % nlayers,
+            "root": root, "high": high, "pos": p, "end": e, "loop": lp,
+            "loop_start_global": e + 1 - lp,
+        })
+    for nm, (p, e, lp) in posmap.items():
+        desc["samples"][nm].update({"pos": p, "end": e, "loop_global": lp,
+                                    "loop_start_global": e + 1 - lp})
+    desc["data"] = {"symbol": symbol, "samples": total_frames, "bytes": total_frames * 2,
+                    "nkgrp": nkgrp, "nregions": len(regions)}
+    os.makedirs(outdir, exist_ok=True)
+    json_path = os.path.join(outdir, f"{base}_instrument.json")
+    with open(json_path, "w") as fh:
+        json.dump(desc, fh, indent=2)
+
+    # 4) Daten-Header
+    data_h = os.path.join(outdir, f"{base}Data.h")
+    with open(data_h, "w") as fh:
+        fh.write(f"/* Auto-generiert von build_instrument.py - NICHT MANUELL AENDERN\n"
+                 f"   Instrument: {name}   Sample-Rate: {sr} Hz   Samples: {total_frames}\n"
+                 f"   Daten groesse: {total_frames*2} Bytes ({total_frames*2/1024:.1f} kB) */\n"
+                 f"#ifndef {guard}_DATA_H\n#define {guard}_DATA_H\n"
+                 f"#include <stdint.h>\n\n")
+        fh.write(format_data_array(symbol, all_samples))
+        fh.write(f"\n#define {guard}_DATA_SAMPLES {total_frames}\n")
+        fh.write(f"#endif /* {guard}_DATA_H */\n")
+
+    # 5) Keygroup-Header
+    kg_h = os.path.join(outdir, f"{base}Keygroups.h")
+    with open(kg_h, "w") as fh:
+        fh.write(f"/* Auto-generiert von build_instrument.py - NICHT MANUELL AENDERN\n"
+                 f"   Instrument: {name}   Keygroups: {nkgrp} ({len(regions)} Regionen x "
+                 f"{nlayers} Velocity-Layer)\n"
+                 f"   Engine: k += {nlayers};  Velocity-Schwellen {thresholds}\n"
+                 f"   mda-KGRP-Semantik: loop = loop-Laenge (end+1-loop_start)\n"
+                 f"   -> kgrp[] muss >= {nkgrp} sein (mda hat 34). */\n"
+                 f"#ifndef {guard}_KEYGROUPS_H\n#define {guard}_KEYGROUPS_H\n"
+                 f"#include <stdint.h>\n\n")
+        fh.write("/* spiegelt struct KGRP aus mdaEPiano.h */\n")
+        fh.write(f"static const struct {{ int32_t root; int32_t high; int32_t pos;\n"
+                 f"                         int32_t end; int32_t loop; }} {base}Kgrp[{nkgrp}] = {{\n")
+        for i, (root, high, p, e, lp) in enumerate(kgrp):
+            fh.write(f"  /* {i:2d} */ {{ {root:3d}, {high:3d}, {p:7d}, {e:7d}, {lp:6d} }},\n")
+        fh.write("};\n")
+        fh.write(f"#define {guard}_NKGRP {nkgrp}\n\n")
+
+        # mda-Stil Zuweisungs-Snippet zum Einfuegen in den Konstruktor
+        fh.write(f"/* === mda-Stil: zum Einfuegen in den mdaEPiano-Konstruktor ===\n"
+                 f"   waves = (short*){symbol};\n")
+        fh.write(f"   kgrp muss >= {nkgrp} sein (z.B. KGRP kgrp[{max(nkgrp, 34)}];)\n")
+        fh.write(f"   noteon: while(note > (kgrp[k].high + s)) k += {nlayers};  "
+                 f"dann if(vel>{thresholds[0]}) k++; if(vel>{thresholds[1]}) k++;\n\n")
+        for i, (root, high, p, e, lp) in enumerate(kgrp):
+            if i % nlayers == 0:
+                fh.write(f"  kgrp[{i:2d}].root={root:3d}; kgrp[{i:2d}].high={high:3d}; "
+                         f"kgrp[{i:2d}].pos={p:7d}; kgrp[{i:2d}].end={e:7d}; kgrp[{i:2d}].loop={lp:6d};\n")
+            else:
+                fh.write(f"  kgrp[{i:2d}].pos={p:7d}; kgrp[{i:2d}].end={e:7d}; kgrp[{i:2d}].loop={lp:6d};\n")
+        fh.write("*/\n")
+        fh.write(f"#endif /* {guard}_KEYGROUPS_H */\n")
+
+    print(f"Instrument: {name}")
+    print(f"  Regionen      : {len(regions)}   (Roots {regions[0]['root']}..{regions[-1]['root']})")
+    print(f"  Velocity-Layer: {nlayers}   Keygroups: {nkgrp}")
+    print(f"  Daten         : {total_frames} Samples = {total_frames*2/1024:.1f} kB "
+          f"({len(unique)} eindeutige Sample-Sets)")
+    print(f"  -> {data_h}")
+    print(f"  -> {kg_h}")
+    print(f"  Engine-Hinweis: kgrp[] >= {nkgrp} (mda hat 34); noteon 'k += {nlayers}'.")
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                  formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("descriptor", help="_instrument.json (von prepare_samples.py)")
+    ap.add_argument("--outdir", default=None,
+                    help="Ziel-Ordner (Default: <Dir-des-JSON>/generated)")
+    args = ap.parse_args()
+    desc = json.load(open(args.descriptor))
+    outdir = args.outdir or os.path.join(os.path.dirname(os.path.abspath(args.descriptor)),
+                                         "generated")
+    build(desc, outdir)
+
+if __name__ == "__main__":
+    main()

--- a/tools/cp_sampleprep/build_loop_finder.sh
+++ b/tools/cp_sampleprep/build_loop_finder.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Michi71
+#
+# build_loop_finder.sh -- build the one C++ tool the Python pipeline shells out to.
+#
+# prepare_samples.py calls this binary once per candidate window; its default
+# path is tools/cp_sampleprep/FindLoopPoints, which is where this writes it.
+# Override with the loop_finder.binary field in a config.
+set -e
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+CXX="${CXX:-c++}"
+
+"$CXX" -O2 -std=c++17 -o "$HERE/FindLoopPoints" "$HERE/src/FindLoopPoints.cpp" -lm
+
+echo "[ok]   $HERE/FindLoopPoints" >&2

--- a/tools/cp_sampleprep/configs/clavinet.json
+++ b/tools/cp_sampleprep/configs/clavinet.json
@@ -1,0 +1,32 @@
+{
+  "name": "Clv",
+  "source_dir": "build_host/cp_samples/source/clavinet",
+  "output_dir": "build_host/cp_samples/converted/clavinet",
+  "target_sr": 32000,
+  "normalize": {
+    "mode": "mda_curve"
+  },
+  "trim": {
+    "mode": "loop",
+    "win_ms": 8,
+    "hop_ms": 1,
+    "smooth_ms": 40,
+    "loop_after_peak_ms": 150,
+    "loop_min_window_ms": 250,
+    "loop_max_window_ms": 500,
+    "num_periods": 10,
+    "min_loop_samples": 30
+  },
+  "loop_finder": {
+    "binary": "tools/FindLoopPoints",
+    "min_score": 0.15
+  },
+  "bit_depth": 16,
+  "engine": {
+    "velocity_layers": 3,
+    "velocity_thresholds": [
+      48,
+      80
+    ]
+  }
+}

--- a/tools/cp_sampleprep/configs/piano.json
+++ b/tools/cp_sampleprep/configs/piano.json
@@ -1,0 +1,32 @@
+{
+  "name": "Pno",
+  "source_dir": "build_host/cp_samples/source/piano",
+  "output_dir": "build_host/cp_samples/converted/piano",
+  "target_sr": 32000,
+  "normalize": {
+    "mode": "mda_curve"
+  },
+  "trim": {
+    "mode": "loop",
+    "win_ms": 8,
+    "hop_ms": 1,
+    "smooth_ms": 40,
+    "loop_after_peak_ms": 150,
+    "loop_min_window_ms": 250,
+    "loop_max_window_ms": 500,
+    "num_periods": 10,
+    "min_loop_samples": 30
+  },
+  "loop_finder": {
+    "binary": "tools/FindLoopPoints",
+    "min_score": 0.15
+  },
+  "bit_depth": 16,
+  "engine": {
+    "velocity_layers": 3,
+    "velocity_thresholds": [
+      48,
+      80
+    ]
+  }
+}

--- a/tools/cp_sampleprep/configs/rhodes_suitcase.json
+++ b/tools/cp_sampleprep/configs/rhodes_suitcase.json
@@ -1,0 +1,32 @@
+{
+  "name": "Rd II",
+  "source_dir": "build_host/cp_samples/source/rhodes_suitcase",
+  "output_dir": "build_host/cp_samples/converted/rhodes_suitcase",
+  "target_sr": 32000,
+  "normalize": {
+    "mode": "mda_curve"
+  },
+  "trim": {
+    "mode": "loop",
+    "win_ms": 8,
+    "hop_ms": 1,
+    "smooth_ms": 40,
+    "loop_after_peak_ms": 150,
+    "loop_min_window_ms": 250,
+    "loop_max_window_ms": 500,
+    "num_periods": 10,
+    "min_loop_samples": 30
+  },
+  "loop_finder": {
+    "binary": "tools/FindLoopPoints",
+    "min_score": 0.15
+  },
+  "bit_depth": 16,
+  "engine": {
+    "velocity_layers": 3,
+    "velocity_thresholds": [
+      48,
+      80
+    ]
+  }
+}

--- a/tools/cp_sampleprep/configs/wurlitzer_200a.json
+++ b/tools/cp_sampleprep/configs/wurlitzer_200a.json
@@ -1,0 +1,32 @@
+{
+  "name": "Wr",
+  "source_dir": "build_host/cp_samples/source/wurlitzer_200a",
+  "output_dir": "build_host/cp_samples/converted/wurlitzer_200a",
+  "target_sr": 32000,
+  "normalize": {
+    "mode": "mda_curve"
+  },
+  "trim": {
+    "mode": "loop",
+    "win_ms": 8,
+    "hop_ms": 1,
+    "smooth_ms": 40,
+    "loop_after_peak_ms": 150,
+    "loop_min_window_ms": 250,
+    "loop_max_window_ms": 500,
+    "num_periods": 10,
+    "min_loop_samples": 30
+  },
+  "loop_finder": {
+    "binary": "tools/FindLoopPoints",
+    "min_score": 0.15
+  },
+  "bit_depth": 16,
+  "engine": {
+    "velocity_layers": 3,
+    "velocity_thresholds": [
+      48,
+      80
+    ]
+  }
+}

--- a/tools/cp_sampleprep/configs/yamaha_cp80.json
+++ b/tools/cp_sampleprep/configs/yamaha_cp80.json
@@ -1,0 +1,32 @@
+{
+  "name": "CP",
+  "source_dir": "build_host/cp_samples/source/yamaha_cp80",
+  "output_dir": "build_host/cp_samples/converted/yamaha_cp80",
+  "target_sr": 32000,
+  "normalize": {
+    "mode": "mda_curve"
+  },
+  "trim": {
+    "mode": "loop",
+    "win_ms": 8,
+    "hop_ms": 1,
+    "smooth_ms": 40,
+    "loop_after_peak_ms": 150,
+    "loop_min_window_ms": 250,
+    "loop_max_window_ms": 500,
+    "num_periods": 10,
+    "min_loop_samples": 30
+  },
+  "loop_finder": {
+    "binary": "tools/FindLoopPoints",
+    "min_score": 0.15
+  },
+  "bit_depth": 16,
+  "engine": {
+    "velocity_layers": 3,
+    "velocity_thresholds": [
+      48,
+      80
+    ]
+  }
+}

--- a/tools/cp_sampleprep/prepare_samples.py
+++ b/tools/cp_sampleprep/prepare_samples.py
@@ -1,0 +1,500 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Michi71
+
+"""
+prepare_samples.py  --  stage 1: arbitrary WAV sets to mda-shaped samples.
+
+Brings any WAV sample set to the format and level of mda-EPiano's own samples,
+and cuts it to mda's characteristic "attack plus short loop" shape with loop
+points found by the FindLoopPoints helper.
+
+Per sample:
+  1. Read (any channel count / rate) -> downmix to mono
+  2. Resample -> target_sr (default 32 kHz, mda's native rate; the engine
+     interpolates up to 44.1 kHz at playback)
+  3. Normalise to the pitch-dependent mda target peak
+        peak_dBFS(note) = a + b * note
+     fitted from mda's own root samples, so the set inherits mda's habit of
+     getting quieter towards the top of the keyboard. Per-sample peak norm.
+  4. Trim:
+       mode="loop"      : pre-cut to a window ending in strong sustain shortly
+                          after the bloom peak, then hand each candidate window
+                          to the FindLoopPoints binary, which locates the loop,
+                          cuts at its end and returns loopStart. Result is
+                          attack plus a looped sustain region, mda style.
+       mode="transient" : attack and bloom only, to the smoothed maximum plus
+                          post_peak_ms. No loop.
+       mode="fixed_len" : blunt cut to a fixed length.
+       mode="none"      : no trim.
+  5. Write 16-bit mono PCM at target_sr, plus _mapping.json and
+     _instrument.json (note / pos / end / loop / score per sample)
+
+Loop scores come from the C++ tool: <=0.01 excellent, <=0.05 good, <=0.15
+acceptable, >0.30 unusable -- the sample is then kept without a loop.
+
+Usage:
+    python3 prepare_samples.py CONFIG.json
+    python3 prepare_samples.py configs/            # every config in the folder
+
+Source recordings are not part of this repository; see README.md for why, and
+for the file naming this expects.
+"""
+import os, re, sys, json, glob, shutil, argparse, subprocess, tempfile
+import numpy as np
+import soundfile as sf
+from scipy.signal import resample_poly
+
+DEFAULTS = {
+    "target_sr": 32000,
+    "normalize": {"mode": "mda_curve", "fixed_dbfs": -9.39},
+    "trim": {
+        "mode": "loop",           # "loop" | "transient" | "fixed_len" | "none"
+        # gemeinsame Parameter
+        "win_ms": 8, "hop_ms": 1, "smooth_ms": 40,
+        "min_ms": 80, "max_ms": 500, "fade_out_ms": 6,
+        # transient / fixed_len
+        "post_peak_ms": 50, "fixed_len_ms": 500,
+        # loop-Modus
+        "loop_after_peak_ms": 150,   # Fensterende = Bloom-Peak + x
+        "loop_min_window_ms": 250,
+        "loop_max_window_ms": 500,
+        "loop_absolute_max_ms": 800,   # harte Grenze; sehr tiefe Toene duerfen
+                                       # darueber liegen, damit der Bloom erhalten bleibt
+        "num_periods": 10,
+        "min_loop_samples": 30,
+        "min_loop_periods": 1,       # Loop muss >= N volle Perioden lang sein
+                                      # (1 = eine Periode; Faktor 0.8 toleriert
+                                      #  Inharmonizitaet, sortiert aber Halbperioden aus)
+    },
+    "loop_finder": {
+        "binary": "tools/cp_sampleprep/FindLoopPoints",  # relative to the repo root
+        "min_score": 0.15,                   # > galt als "akzeptabel" im C-Tool
+    },
+    "bit_depth": 16,
+}
+
+REPO_ROOT = None
+
+
+# ===========================================================================
+# mda-Referenzkurve  peak_dBFS(note) = a + b*note
+# ===========================================================================
+CP_DIR = os.path.join("instruments", "PicoFaceCP")
+
+
+def load_mda_curve(repo_root):
+    # Was 34 exported WAVs plus the plugin source. Neither travelled with this
+    # tool into PicoVintageSynthCollection, and the WAVs were themselves an
+    # export of mdaEPianoData.h -- which is in the repository. Reading the
+    # peaks straight out of the header removes the last data dependency, so
+    # this runs on a plain checkout.
+    #
+    # The header data is pre-baked with the loop crossfade applied, unlike the
+    # array the original plugin built at runtime, so the two are not identical
+    # by construction. Checked against the WAVs before the switch: the fitted
+    # a and b agree to all printed digits and the target peak differs by
+    # 0.000000 dB over notes 21..108. The crossfade lives in the loop region;
+    # the peak of an e-piano sample is in the attack.
+    cpp = open(os.path.join(repo_root, CP_DIR, "src", "mdaEPiano.cpp")).read()
+    root, pos, end = {}, {}, {}
+    for name, table in (("root", root), ("pos", pos), ("end", end)):
+        for m in re.finditer(r"kgrp\[\s*(\d+)\s*\]\." + name + r"\s*=\s*(\d+)", cpp):
+            table[int(m.group(1))] = int(m.group(2))
+
+    header = open(os.path.join(repo_root, CP_DIR, "include", "mdaEPianoData.h")).read()
+    body = header[header.index("{") + 1: header.rindex("}")]
+    data = np.array([int(v) for v in re.findall(r"-?\d+", body)], dtype=np.int16)
+
+    notes, pdb = [], []
+    for i in sorted(root):
+        if i not in pos or i not in end:
+            continue
+        seg = data[pos[i]:end[i] + 1].astype(np.float64) / 32768.0
+        if seg.size == 0:
+            continue
+        notes.append(root[i]); pdb.append(20*np.log10(np.max(np.abs(seg)) + 1e-12))
+    notes = np.array(notes, float); pdb = np.array(pdb, float)
+    A = np.vstack([np.ones_like(notes), notes]).T
+    a, b = np.linalg.lstsq(A, pdb, rcond=None)[0]
+    return float(a), float(b), notes, pdb
+
+
+# ===========================================================================
+# WAV-Metadaten: Root-Note + Loop aus smpl/cue-Chunk (Fallback: Dateiname)
+# ===========================================================================
+def parse_smpl(path):
+    try:
+        info = sf.info(path).extra_info
+    except Exception:
+        info = ""
+    note = ls = le = None
+    m = re.search(r"Midi Note\s*:\s*(\d+)", info)
+    if m: note = int(m.group(1))
+    m = re.search(r"Start\s*:\s*(\d+)\s*End\s*:\s*(\d+)", info)
+    if m: ls, le = int(m.group(1)), int(m.group(2))
+    return note, ls, le
+
+def note_from_filename(name):
+    m = re.match(r"\D*(\d{2,3})\b", name)
+    return int(m.group(1)) if m else None
+
+
+# ===========================================================================
+# DSP-Hilfen
+# ===========================================================================
+def to_mono(data):
+    return data.mean(axis=1) if data.ndim > 1 else data.copy()
+
+def resample_to(mono, sr_in, sr_out):
+    g = np.gcd(sr_out, sr_in)
+    return resample_poly(mono, sr_out // g, sr_in // g)
+
+def rms_env(x, W, hop):
+    return np.array([np.sqrt(np.mean(x[k:k+W]**2)) if k+W <= len(x) else 0.0
+                     for k in range(0, len(x), hop)])
+
+def smooth(e, W):
+    return np.convolve(e, np.ones(max(1, W))/max(1, W), mode='same') if W > 1 else e
+
+def bloom_peak_ms(x, sr, p):
+    """Zeit (ms) des geglaetteten Energie-Maximums."""
+    hop = max(1, int(p["hop_ms"]*1e-3*sr)); W = max(1, int(p["win_ms"]*1e-3*sr))
+    sm = max(1, int(p["smooth_ms"]*1e-3*sr/hop))
+    e = smooth(rms_env(x, W, hop), sm)
+    if len(e) == 0:
+        return 0.0
+    return float(np.argmax(e) * hop / sr * 1000.0)
+
+def apply_fade_out(x, sr, ms):
+    n = int(ms*1e-3*sr)
+    if n <= 0 or n >= len(x):
+        return x
+    x[-n:] *= np.sin(np.pi/2 * np.linspace(1.0, 0.0, n))
+    return x
+
+
+# ===========================================================================
+# FindLoopPoints-Binary aufrufen
+# ===========================================================================
+def run_loop_finder(samples, sr, binary, num_periods, work):
+    """Schreibt samples als temp. WAV, ruft das C-Binary, liest das getrimmte
+    Ergebnis + loopStart zurueck. Liefert (trimmed_int16, loop_start, score)."""
+    tmp_wav = os.path.join(work, "in.wav")
+    sf.write(tmp_wav, samples.astype(np.float32), sr, subtype="PCM_16")
+    loop_file = os.path.splitext(tmp_wav)[0] + ".loop"
+    if os.path.exists(loop_file):
+        os.remove(loop_file)
+
+    cmd = [binary, tmp_wav, str(num_periods)]
+    try:
+        out = subprocess.run(cmd, capture_output=True, text=True, timeout=60).stdout
+    except Exception as e:
+        return None, None, None
+    if not os.path.exists(loop_file):
+        return None, None, None
+
+    trimmed, sr2 = sf.read(tmp_wav, dtype="int16")
+    trimmed = trimmed.astype(np.float64) / 32768.0   # int16 -> [-1,1]
+    loop_start = int(open(loop_file).read().strip() or 0)
+    m = re.search(r"Final score:\s*([0-9.eE+-]+)", out)
+    score = float(m.group(1)) if m else None
+    return trimmed, loop_start, score
+
+
+# ===========================================================================
+# Hauptverarbeitung eines Instruments
+# ===========================================================================
+def process_instrument(cfg, repo_root):
+    c = json.loads(json.dumps(DEFAULTS))   # tiefe Kopie
+    for k in ("target_sr", "normalize", "trim", "loop_finder", "bit_depth"):
+        if k in cfg:
+            if isinstance(cfg[k], dict) and isinstance(c[k], dict):
+                c[k] = {**c[k], **cfg[k]}
+            else:
+                c[k] = cfg[k]
+
+    src_dir = os.path.join(repo_root, cfg["source_dir"])
+    out_dir = os.path.join(repo_root, cfg.get("output_dir",
+                os.path.join(os.path.dirname(src_dir), "converted",
+                             cfg.get("name", os.path.basename(src_dir.rstrip("/"))))))
+    os.makedirs(out_dir, exist_ok=True)
+    sr_out = int(c["target_sr"])
+
+    norm = c["normalize"]
+    a = b = None
+    if norm["mode"] == "mda_curve":
+        a, b, notes, pdb = load_mda_curve(repo_root)
+        print(f"[{cfg.get('name','?')}] mda-Kurve: peak_dBFS = {a:.3f} {b:+.5f} * note  (n={len(notes)})")
+
+    p = c["trim"]
+    binary = c["loop_finder"]["binary"]
+    if not os.path.isabs(binary):
+        binary = os.path.join(repo_root, binary)
+    if p["mode"] == "loop" and not os.path.exists(binary):
+        print(f"[{cfg.get('name','?')}] WARN FindLoopPoints-Binary nicht gefunden ({binary}) -> auf 'transient' zurueckgefallen")
+        p["mode"] = "transient"
+
+    mapping = {}
+    files = sorted(glob.glob(os.path.join(src_dir, "*.wav")))
+    if not files:
+        print(f"[{cfg.get('name','?')}] keine WAVs in {src_dir}")
+        return
+    total_in = total_out = 0
+    work = tempfile.mkdtemp(prefix="sampleprep_")
+    try:
+        for f in files:
+            name = os.path.splitext(os.path.basename(f))[0]
+            data, sr = sf.read(f, dtype="float64", always_2d=True)
+            n0 = data.shape[0]; total_in += n0
+            mono = resample_to(to_mono(data), sr, sr_out)
+            scale = sr_out / sr
+
+            note, ls, le = parse_smpl(f)
+            if note is None:
+                note = note_from_filename(os.path.basename(f))
+
+            # Normalisierung
+            cur_peak = np.max(np.abs(mono))
+            if norm["mode"] == "mda_curve":
+                tgt_db = a + b*note
+            elif norm["mode"] == "fixed":
+                tgt_db = norm["fixed_dbfs"]
+            else:
+                tgt_db = 20*np.log10(cur_peak+1e-12)
+            mono *= 10**(tgt_db/20.0) / cur_peak if cur_peak > 1e-9 else 1.0
+            mono = np.clip(mono, -1.0, 1.0)
+
+            t_peak = bloom_peak_ms(mono, sr_out, p)
+
+            # ---- Trim ----------------------------------------------------
+            if p["mode"] == "loop":
+                # Kandidaten-Fenster: Suche ZENTRIERT auf "Bloom + after_peak"
+                # (Loop liegt im Sustain kurz nach dem Bloom). Das Fenster muss
+                # den Bloom-Peak enthalten -> definierende Transiente + Ziel-Pegel.
+                base = t_peak + p["loop_after_peak_ms"]
+                hi = max(p["loop_max_window_ms"], p["loop_absolute_max_ms"])
+                cand = []
+                for d in (0, 50, -50, 100, -100, 150, -150, 200):
+                    w = float(np.clip(base + d, p["loop_min_window_ms"], hi))
+                    cand.append(w)
+                cand = sorted(set(round(x) for x in cand), reverse=True)[:8]
+                good = 0.02            # exzellent -> Fruehabbruch
+                accept = c["loop_finder"]["min_score"]   # akzeptabel (Default 0.15)
+                hard = 0.30            # darueber: kein verwertbarer Loop
+                # Periodenlaenge aus Midi-Note (um degenerierte Kurz-Loops auszusortieren)
+                freq = 440.0 * 2 ** ((note - 69) / 12.0)
+                period = sr_out / freq if freq > 0 else 0
+                min_len = max(p["min_loop_samples"],
+                              int(0.8 * p["min_loop_periods"] * period)) if period > 0 else p["min_loop_samples"]
+                best = None  # (trimmed, loop_start, score, win_ms)
+                for wms in cand:
+                    pre = mono[:int(round(wms*1e-3*sr_out))].astype(np.float32)
+                    trimmed, loop_start, score = run_loop_finder(
+                            pre, sr_out, binary, p["num_periods"], work)
+                    ok = (trimmed is not None and loop_start is not None
+                          and 0 <= loop_start < len(trimmed)
+                          and (len(trimmed)-1 - loop_start) >= min_len)
+                    if ok and (best is None or (score is not None and score < best[2])):
+                        best = (trimmed, int(loop_start), score if score is not None else 9e9, wms)
+                        if best[2] <= good:      # exzellent -> sofort uebernehmen
+                            break
+                if best is not None and best[2] <= hard:
+                    final = best[0].astype(np.float64)
+                    loop_start = best[1]; loop_end = int(len(final)-1)
+                    score = best[2] if best[2] < 9e9 else None
+                    loop_pending = False
+                    flag = "  *POOR*" if (score is not None and score > accept) else ""
+                    extra = f"loop[{loop_start}..{loop_end}] ({loop_end-loop_start+1}sm, >={min_len}) score={score} win={best[3]}ms{flag}"
+                else:
+                    final = mono[:int(round(cand[0]*1e-3*sr_out))].astype(np.float64)
+                    final = apply_fade_out(final, sr_out, p["fade_out_ms"])
+                    loop_start = loop_end = None; loop_pending = True; score = None
+                    extra = "LOOP FAIL -> kein Loop (Fenster ohne Loop)"
+            elif p["mode"] == "transient":
+                end_ms = float(np.clip(t_peak + p["post_peak_ms"], p["min_ms"], p["max_ms"]))
+                final = mono[:int(round(end_ms*1e-3*sr_out))].copy()
+                final = apply_fade_out(final, sr_out, p["fade_out_ms"])
+                loop_start = loop_end = None; loop_pending = True; score = None
+                extra = f"transient@{t_peak:.0f}ms"
+            elif p["mode"] == "fixed_len":
+                final = mono[:int(round(p["fixed_len_ms"]*1e-3*sr_out))].copy()
+                final = apply_fade_out(final, sr_out, p["fade_out_ms"])
+                loop_start = loop_end = None; loop_pending = True; score = None
+                extra = f"fixed {p['fixed_len_ms']}ms"
+            else:
+                final = mono.copy()
+                loop_start = loop_end = None; loop_pending = True; score = None
+                extra = "no trim"
+
+            total_out += len(final)
+            out = os.path.join(out_dir, f"{name}.wav")
+            sf.write(out, final.astype(np.float32), sr_out, subtype=f"PCM_{c['bit_depth']}")
+
+            # Original-Loop (nur Info)
+            if ls is not None and le is not None:
+                ls_o = int(round(ls*scale)); le_o = int(round(le*scale))
+            else:
+                ls_o = le_o = None
+
+            new_peak = float(np.max(np.abs(final)))
+            mapping[name] = {
+                "root_note": note,
+                "sample_rate": sr_out,
+                "frames": int(len(final)),
+                "duration_ms": round(len(final)/sr_out*1000.0, 2),
+                "pos": 0, "end": int(len(final)-1),
+                "loop_start": loop_start, "loop_end": loop_end,
+                "loop_len": (loop_end - loop_start + 1) if loop_start is not None else None,
+                "loop_pending": loop_pending,
+                "loop_score": score,
+                "target_peak_dbfs": round(tgt_db, 2),
+                "peak_dbfs": round(20*np.log10(new_peak+1e-12), 2),
+                "bloom_peak_ms": round(t_peak, 1),
+                "orig_loop_target": [ls_o, le_o],
+            }
+            print(f"  {name:<10} note={note:>3}  {n0/sr:6.2f}s -> "
+                  f"{len(final)/sr_out*1000:5.0f}ms  peak {20*np.log10(cur_peak):+5.1f}"
+                  f"->{20*np.log10(new_peak):+5.1f}dB  bloom@{t_peak:4.0f}ms  {extra}")
+    finally:
+        shutil.rmtree(work, ignore_errors=True)
+
+    with open(os.path.join(out_dir, "_mapping.json"), "w") as fh:
+        json.dump(mapping, fh, indent=2)
+    write_instrument_descriptor(cfg, out_dir, mapping, sr_out)
+    print(f"\n[{cfg.get('name','?')}] {len(mapping)} Samples -> {out_dir}")
+    print(f"  Speicher: {total_in*2/1024:.0f} -> {total_out*2/1024:.0f} kB Audio "
+          f"({100*total_out/max(total_in,1):.1f}%)")
+    print(f"  Mapping: {os.path.join(out_dir,'_mapping.json')}")
+
+
+
+
+# ===========================================================================
+# Instrument-Deskriptor (fuer build_instrument.py) aus dem Mapping ableiten
+# ===========================================================================
+def parse_note_vel(name):
+    m = re.match(r"(\d{2,3})-(\d{2,3})", name)
+    return (int(m.group(1)), int(m.group(2))) if m else (None, None)
+
+def derive_layer_mapping(tags_sorted, layers, thresholds=(48, 80)):
+    """Ordnet jeder Engine-Velocity-Layer das verfuegbare Sample zu.
+
+    thresholds sind die Velocity-GRENZEN, bei denen die Engine (noteOn) die
+    Layer wechselt (mda: [48, 80] -> Layer0 0..48, Layer1 49..80, Layer2 81..127).
+    NICHT die Sample-Velocities!
+
+    Regel pro Layer: Sample, dessen Velocity in den Layer-Bereich faellt (bei
+    mehreren das dem Center naechste); falls keines im Bereich liegt, das
+    global naechste zum Center."""
+    if not tags_sorted:
+        return []
+    if layers <= 1:
+        return [tags_sorted[0]]
+    t = list(thresholds)
+    while len(t) < layers - 1:
+        t.append(127)
+    lo = [0] + [x + 1 for x in t[:layers-1]]           # Layer-Untergrenzen (exkl.)
+    hi = t[:layers-1] + [127]                            # Layer-Obergrenzen (inkl.)
+    centers = [(lo[i] + hi[i]) / 2.0 for i in range(layers)]
+    out = []
+    for i in range(layers):
+        inside = [v for v in tags_sorted if lo[i] <= v <= hi[i]]
+        pool = inside if inside else tags_sorted
+        out.append(min(pool, key=lambda v: abs(v - centers[i])))
+    return out
+
+def write_instrument_descriptor(cfg, out_dir, mapping, sr_out):
+    # Filename-Note + Velocity-Tag pro Sample
+    by_note = {}            # file_note -> {vel_tag: sample_name}
+    tags = set()
+    for nm, e in mapping.items():
+        fn, vel = parse_note_vel(nm)
+        if fn is None:
+            continue
+        by_note.setdefault(fn, {})[vel] = nm
+        tags.add(vel)
+    tags_sorted = sorted(tags)
+    eng = cfg.get("engine", {})
+    layers = eng.get("velocity_layers", 3)
+    thresh = eng.get("velocity_thresholds", [48, 80])
+    if "layer_to_tag" in eng:                       # manuelle Vorgabe (Liste von Velocity-Tags)
+        layer_to_tag = list(eng["layer_to_tag"])
+        if len(layer_to_tag) != layers:
+            raise SystemExit(f"layer_to_tag hat {len(layer_to_tag)} Eintraege, "
+                             f"velocity_layers={layers}")
+    else:
+        layer_to_tag = derive_layer_mapping(tags_sorted, layers, thresh)
+
+    regions = []
+    for fn in sorted(by_note):
+        avail = by_note[fn]                       # {vel_tag: sample_name}
+        layers_list = []
+        for intended in layer_to_tag:
+            chosen = min(avail, key=lambda t: abs(t-intended))
+            layers_list.append(avail[chosen])
+        regions.append({"root": fn, "layers": layers_list})
+    # high = naechste root - 1; letzte = 999
+    for i, r in enumerate(regions):
+        r["high"] = (regions[i+1]["root"] - 1) if i+1 < len(regions) else 999
+        r.pop("high", None) if False else None
+    for i, r in enumerate(regions):
+        r["high"] = (regions[i+1]["root"] - 1) if i+1 < len(regions) else 999
+
+    samples = {}
+    for nm, e in mapping.items():
+        fn, vel = parse_note_vel(nm)
+        samples[nm] = {
+            "file": os.path.join(out_dir, nm + ".wav"),
+            "frames": e["frames"],
+            "loop_start": e["loop_start"],
+            "loop_len": e.get("loop_len"),
+            "root_note": e["root_note"],
+            "file_note": fn,
+            "velocity_tag": vel,
+        }
+
+    desc = {
+        "name": cfg.get("name", "instrument"),
+        "data_symbol": re.sub(r"\W", "_", cfg.get("name", "instrument")) + "Data",
+        "sample_rate": sr_out,
+        "engine": {
+            "velocity_layers": layers,
+            "velocity_thresholds": cfg.get("engine", {}).get("velocity_thresholds", [48, 80]),
+            "noteon_step": layers,           # k += noteon_step  (mda: 3)
+        },
+        "velocity_tags": tags_sorted,
+        "layer_to_tag": layer_to_tag,
+        "regions": regions,
+        "samples": samples,
+        "note": "root = Filename-Note (Sample-Sets mit smpl-Midi-Note-Differenzen "
+                "werden auf die Filename-Note normiert). high = naechste root-1 (letzte=999). "
+                "Fehlende Velocity-Layer werden auf den verfuegbaren Tag mit naehester Velocity gemappt.",
+    }
+    path = os.path.join(out_dir, "_instrument.json")
+    with open(path, "w") as fh:
+        json.dump(desc, fh, indent=2)
+    print(f"  Instrument-Deskriptor: {path}  ({len(regions)} Regionen, "
+          f"{layers} Layer, Tags {tags_sorted} -> {layer_to_tag})")
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("config", help="JSON-Config-Datei oder Ordner mit Configs")
+    ap.add_argument("--repo", default=None, help="Repo-Root (Default: auto)")
+    args = ap.parse_args()
+    repo = args.repo or os.path.abspath(
+             os.path.join(os.path.dirname(__file__), "..", ".."))
+    if os.path.isdir(args.config):
+        cfgs = sorted(glob.glob(os.path.join(args.config, "*.json")))
+    else:
+        cfgs = [args.config]
+    for c in cfgs:
+        cfg = json.load(open(c))
+        if "name" not in cfg:
+            cfg["name"] = os.path.splitext(os.path.basename(c))[0]
+        print(f"\n==== Instrument: {cfg['name']} ====")
+        process_instrument(cfg, repo)
+
+if __name__ == "__main__":
+    main()

--- a/tools/cp_sampleprep/src/FindLoopPoints.cpp
+++ b/tools/cp_sampleprep/src/FindLoopPoints.cpp
@@ -1,0 +1,408 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Michi71
+
+#include <iostream>
+#include <fstream>
+#include <vector>
+#include <cmath>
+#include <algorithm>
+#include <limits>
+#include <cstring>
+
+struct WAVHeader {
+    char riff[4];
+    uint32_t size;
+    char wave[4];
+    char fmt[4];
+    uint32_t fmtSize;
+    uint16_t format;
+    uint16_t channels;
+    uint32_t sampleRate;
+    uint32_t byteRate;
+    uint16_t blockAlign;
+    uint16_t bitsPerSample;
+    char data[4];
+    uint32_t dataSize;
+};
+
+std::vector<int16_t> readWav(const std::string& path, int& sampleRate) {
+    std::ifstream file(path, std::ios::binary);
+    if (!file) throw std::runtime_error("Cannot open WAV file");
+
+    char riff[4], wave[4];
+    file.read(riff, 4);
+    file.seekg(4, std::ios::cur);
+    file.read(wave, 4);
+
+    if (std::strncmp(riff, "RIFF", 4) != 0 || std::strncmp(wave, "WAVE", 4) != 0)
+        throw std::runtime_error("Not a valid WAV file");
+
+    std::vector<int16_t> samples;
+    while (!file.eof()) {
+        char chunkId[4];
+        uint32_t chunkSize;
+        file.read(chunkId, 4);
+        if (file.eof()) break;
+        file.read(reinterpret_cast<char*>(&chunkSize), 4);
+
+        if (std::strncmp(chunkId, "fmt ", 4) == 0) {
+            file.seekg(4, std::ios::cur);
+            uint16_t channels;
+            file.read(reinterpret_cast<char*>(&channels), 2);
+            file.read(reinterpret_cast<char*>(&sampleRate), 4);
+            file.seekg(chunkSize - 10, std::ios::cur);
+        }
+        else if (std::strncmp(chunkId, "data", 4) == 0) {
+            int numSamples = chunkSize / 2;
+            samples.resize(numSamples);
+            file.read(reinterpret_cast<char*>(samples.data()), chunkSize);
+            break;
+        }
+        else {
+            file.seekg(chunkSize, std::ios::cur);
+        }
+    }
+
+    return samples;
+}
+
+void writeWav(const std::string& path, const std::vector<int16_t>& samples, int sampleRate) {
+    std::ofstream file(path, std::ios::binary);
+    
+    WAVHeader header;
+    std::memcpy(header.riff, "RIFF", 4);
+    std::memcpy(header.wave, "WAVE", 4);
+    std::memcpy(header.fmt, "fmt ", 4);
+    header.fmtSize = 16;
+    header.format = 1;
+    header.channels = 1;
+    header.sampleRate = sampleRate;
+    header.bitsPerSample = 16;
+    header.blockAlign = header.channels * header.bitsPerSample / 8;
+    header.byteRate = sampleRate * header.blockAlign;
+    std::memcpy(header.data, "data", 4);
+    header.dataSize = samples.size() * sizeof(int16_t);
+    header.size = 36 + header.dataSize;
+    
+    file.write(reinterpret_cast<const char*>(&header), sizeof(header));
+    file.write(reinterpret_cast<const char*>(samples.data()), header.dataSize);
+}
+
+enum class ZeroCrossingType {
+    RISING,
+    FALLING
+};
+
+struct ZeroCrossing {
+    int position;
+    ZeroCrossingType type;
+    float slope;
+};
+
+std::vector<ZeroCrossing> findZeroCrossings(const std::vector<int16_t>& samples, int start, int end) {
+    std::vector<ZeroCrossing> crossings;
+    
+    for (int i = start; i < end - 1 && i < samples.size() - 1; i++) {
+        if (samples[i] <= 0 && samples[i + 1] > 0) {
+            float slope = samples[i + 1] - samples[i];
+            crossings.push_back({i, ZeroCrossingType::RISING, slope});
+        }
+        else if (samples[i] >= 0 && samples[i + 1] < 0) {
+            float slope = samples[i + 1] - samples[i];
+            crossings.push_back({i, ZeroCrossingType::FALLING, slope});
+        }
+    }
+    
+    return crossings;
+}
+
+struct ZeroCrossingPattern {
+    ZeroCrossingType type;
+    int distance1;
+    int distance2;
+    int distance3;
+};
+
+ZeroCrossingPattern extractPattern(const std::vector<ZeroCrossing>& crossings, int index) {
+    ZeroCrossingPattern pattern;
+    pattern.type = crossings[index].type;
+    pattern.distance1 = 0;
+    pattern.distance2 = 0;
+    pattern.distance3 = 0;
+    
+    if (index >= 1) {
+        pattern.distance1 = crossings[index].position - crossings[index - 1].position;
+    }
+    if (index >= 2) {
+        pattern.distance2 = crossings[index].position - crossings[index - 2].position;
+    }
+    if (index >= 3) {
+        pattern.distance3 = crossings[index].position - crossings[index - 3].position;
+    }
+    
+    return pattern;
+}
+
+float comparePatterns(const ZeroCrossingPattern& p1, const ZeroCrossingPattern& p2) {
+    if (p1.type != p2.type) {
+        return std::numeric_limits<float>::max();
+    }
+    
+    float diff1 = (p1.distance1 > 0) ? std::abs(p1.distance1 - p2.distance1) / (float)p1.distance1 : 0.0f;
+    float diff2 = (p1.distance2 > 0) ? std::abs(p1.distance2 - p2.distance2) / (float)p1.distance2 : 0.0f;
+    float diff3 = (p1.distance3 > 0) ? std::abs(p1.distance3 - p2.distance3) / (float)p1.distance3 : 0.0f;
+    
+    float score = diff1 * 3.0f + diff2 * 2.0f + diff3 * 1.0f;
+    
+    return score;
+}
+
+struct LoopPoint {
+    int loopStart;
+    int loopEnd;
+    float score;
+    int periodSamples;
+    int numPeriods;
+};
+
+LoopPoint findLoopByPatternMatching(const std::vector<int16_t>& samples, 
+                                    const std::vector<ZeroCrossing>& allCrossings,
+                                    const ZeroCrossing& endCrossing,
+                                    const ZeroCrossingPattern& endPattern,
+                                    float estimatedPeriod,
+                                    int sampleRate, 
+                                    int targetPeriods,
+                                    bool verbose = true) {
+    
+    float targetDistance = estimatedPeriod * targetPeriods;
+    int searchCenter = endCrossing.position - (int)targetDistance;
+    int searchRadius = (int)(estimatedPeriod * 2.0f);
+    
+    int searchStart = std::max(0, searchCenter - searchRadius);
+    int searchEnd = searchCenter + searchRadius;
+    
+    if (verbose) {
+        std::cout << "\n=== Testing " << targetPeriods << " periods ===\n";
+        std::cout << "Target distance: " << targetDistance << " samples\n";
+        std::cout << "Search range: " << searchStart << " - " << searchEnd << "\n";
+    }
+    
+    LoopPoint best;
+    best.loopStart = searchCenter;
+    best.loopEnd = endCrossing.position;
+    best.score = std::numeric_limits<float>::max();
+    best.periodSamples = 0;
+    best.numPeriods = targetPeriods;
+    
+    for (int i = 0; i < allCrossings.size() - 4; i++) {
+        int pos = allCrossings[i].position;
+        
+        if (pos < searchStart || pos > searchEnd) continue;
+        
+        ZeroCrossingPattern candidatePattern = extractPattern(allCrossings, i);
+        float score = comparePatterns(endPattern, candidatePattern);
+        
+        if (score < best.score) {
+            best.loopStart = pos;
+            best.loopEnd = endCrossing.position;
+            best.score = score;
+            best.periodSamples = endCrossing.position - pos;
+        }
+    }
+    
+    float actualPeriods = best.periodSamples / estimatedPeriod;
+    
+    if (verbose) {
+        std::cout << "Best match:\n";
+        std::cout << "  Loop start: " << best.loopStart << "\n";
+        std::cout << "  Loop length: " << best.periodSamples << " samples\n";
+        std::cout << "  Actual periods: " << actualPeriods << "\n";
+        std::cout << "  Score: " << best.score << "\n";
+    }
+    
+    return best;
+}
+
+LoopPoint findOptimalLoop(const std::vector<int16_t>& samples, int sampleRate, int initialPeriods) {
+    std::cout << "\n=== PATTERN-BASED LOOP FINDER ===\n";
+    
+    auto allCrossings = findZeroCrossings(samples, 0, samples.size());
+    
+    if (allCrossings.size() < 10) {
+        std::cerr << "Error: Not enough zero-crossings found!\n";
+        return {0, (int)samples.size() - 1, 999.0f, 0, 0};
+    }
+    
+    std::cout << "Found " << allCrossings.size() << " zero-crossings total\n";
+    
+    // Referenz-Pattern vom Sample-Ende
+    int endIndex = allCrossings.size() - 1;
+    ZeroCrossing endCrossing = allCrossings[endIndex];
+    ZeroCrossingPattern endPattern = extractPattern(allCrossings, endIndex);
+    
+    std::cout << "\n=== END PATTERN ===\n";
+    std::cout << "Position: " << endCrossing.position << "\n";
+    std::cout << "Type: " << (endCrossing.type == ZeroCrossingType::RISING ? "RISING" : "FALLING") << "\n";
+    std::cout << "Distance to prev: " << endPattern.distance1 << " samples\n";
+    std::cout << "Distance to 2nd prev: " << endPattern.distance2 << " samples\n";
+    std::cout << "Distance to 3rd prev: " << endPattern.distance3 << " samples\n";
+    
+    float estimatedPeriod = endPattern.distance1;
+    if (endPattern.distance1 < 20) {
+        estimatedPeriod = endPattern.distance2 / 2.0f;
+    }
+    
+    std::cout << "\nEstimated period: ~" << estimatedPeriod << " samples ("
+              << (estimatedPeriod / sampleRate * 1000.0f) << "ms, "
+              << (sampleRate / estimatedPeriod) << " Hz)\n";
+    
+    // Teste initial
+    std::cout << "\n=== OPTIMIZATION ===\n";
+    std::cout << "Starting with " << initialPeriods << " periods...\n";
+    
+    LoopPoint bestOverall = findLoopByPatternMatching(samples, allCrossings, endCrossing, 
+                                                       endPattern, estimatedPeriod, 
+                                                       sampleRate, initialPeriods, true);
+    
+    const float SCORE_THRESHOLD = 0.01f;
+    const int MAX_PERIODS = 30;
+    const int MIN_PERIODS = 3;
+    
+    if (bestOverall.score > SCORE_THRESHOLD) {
+        std::cout << "\n⚠ Score " << bestOverall.score << " > " << SCORE_THRESHOLD 
+                  << " - Optimizing...\n";
+        
+        // Teste verschiedene Periodenzahlen
+        for (int periods = initialPeriods + 1; periods <= MAX_PERIODS; periods++) {
+            auto candidate = findLoopByPatternMatching(samples, allCrossings, endCrossing,
+                                                        endPattern, estimatedPeriod,
+                                                        sampleRate, periods, false);
+            
+            std::cout << "  " << periods << " periods: score = " << candidate.score;
+            
+            if (candidate.score < bestOverall.score) {
+                bestOverall = candidate;
+                std::cout << " ← NEW BEST!";
+            }
+            std::cout << "\n";
+            
+            // Wenn Score gut genug, abbrechen
+            if (bestOverall.score <= SCORE_THRESHOLD) {
+                std::cout << "\n✓ Score " << bestOverall.score << " <= " << SCORE_THRESHOLD 
+                          << " - Good enough!\n";
+                break;
+            }
+        }
+        
+        // Falls immer noch schlecht, versuche weniger Perioden
+        if (bestOverall.score > SCORE_THRESHOLD && initialPeriods > MIN_PERIODS) {
+            std::cout << "\nTrying fewer periods...\n";
+            
+            for (int periods = initialPeriods - 1; periods >= MIN_PERIODS; periods--) {
+                auto candidate = findLoopByPatternMatching(samples, allCrossings, endCrossing,
+                                                            endPattern, estimatedPeriod,
+                                                            sampleRate, periods, false);
+                
+                std::cout << "  " << periods << " periods: score = " << candidate.score;
+                
+                if (candidate.score < bestOverall.score) {
+                    bestOverall = candidate;
+                    std::cout << " ← NEW BEST!";
+                }
+                std::cout << "\n";
+                
+                if (bestOverall.score <= SCORE_THRESHOLD) {
+                    std::cout << "\n✓ Score " << bestOverall.score << " <= " << SCORE_THRESHOLD 
+                              << " - Good enough!\n";
+                    break;
+                }
+            }
+        }
+    } else {
+        std::cout << "\n✓ Initial score " << bestOverall.score << " <= " << SCORE_THRESHOLD 
+                  << " - Already optimal!\n";
+    }
+    
+    float actualPeriods = bestOverall.periodSamples / estimatedPeriod;
+    
+    std::cout << "\n=== FINAL BEST MATCH ===\n";
+    std::cout << "Optimized periods: " << bestOverall.numPeriods << "\n";
+    std::cout << "Loop start: " << bestOverall.loopStart << " ("
+              << (bestOverall.loopStart / (float)sampleRate * 1000.0f) << "ms)\n";
+    std::cout << "Loop end: " << bestOverall.loopEnd << " ("
+              << (bestOverall.loopEnd / (float)sampleRate * 1000.0f) << "ms)\n";
+    std::cout << "Loop length: " << bestOverall.periodSamples << " samples ("
+              << (bestOverall.periodSamples / (float)sampleRate * 1000.0f) << "ms)\n";
+    std::cout << "Actual periods: " << actualPeriods << "\n";
+    std::cout << "Final score: " << bestOverall.score << "\n";
+    
+    return bestOverall;
+}
+
+int main(int argc, char** argv) {
+    if (argc < 2) {
+        std::cerr << "Usage: FindLoopPoints <sample.wav> [num_periods]\n";
+        std::cerr << "  num_periods: Starting number of periods (default: 10)\n";
+        std::cerr << "               Will auto-optimize if score > 0.01\n";
+        std::cerr << "Example: FindLoopPoints 060-127.wav 10\n";
+        return 1;
+    }
+
+    std::string filename = argv[1];
+    int initialPeriods = (argc > 2) ? std::stoi(argv[2]) : 10;
+
+    int sampleRate = 32000;
+
+    int bytesread;
+    auto samples = readWav(filename, bytesread);
+    
+    std::cout << "===========================================\n";
+    std::cout << "Auto-Optimizing Pattern-Based Loop Finder\n";
+    std::cout << "===========================================\n";
+    std::cout << "File: " << filename << "\n";
+    std::cout << "Samples: " << samples.size() << " (" 
+              << (samples.size() / (float)sampleRate) << "s)\n";
+    std::cout << "Sample rate: " << sampleRate << " Hz\n";
+    std::cout << "Initial periods: " << initialPeriods << "\n";
+
+    auto loopPoint = findOptimalLoop(samples, sampleRate, initialPeriods);
+    
+    // Beschneide Sample am Loop-Ende
+    int originalSize = samples.size();
+    int newSize = loopPoint.loopEnd + 1;
+    
+    if (newSize < originalSize) {
+        samples.resize(newSize);
+        std::cout << "\n=== TRIMMING ===\n";
+        std::cout << "Original: " << originalSize << " samples\n";
+        std::cout << "Trimmed to: " << newSize << " samples\n";
+        std::cout << "Removed: " << (originalSize - newSize) << " samples\n";
+    }
+    
+    // Speichere
+    writeWav(filename, samples, sampleRate);
+    
+    std::string loopInfoFile = filename.substr(0, filename.find_last_of('.')) + ".loop";
+    std::ofstream loopOut(loopInfoFile);
+    loopOut << loopPoint.loopStart;
+    loopOut.close();
+    
+    std::cout << "\n=== OUTPUT ===\n";
+    std::cout << "Trimmed sample: " << filename << "\n";
+    std::cout << "Loop info: " << loopInfoFile << "\n";
+    std::cout << "Loop start: " << loopPoint.loopStart << "\n";
+    std::cout << "Loop end: " << (newSize - 1) << " (sample end)\n";
+
+    if (loopPoint.score < 0.01) {
+        std::cout << "\n✓✓✓ Excellent pattern match!\n";
+    } else if (loopPoint.score < 0.05) {
+        std::cout << "\n✓✓ Good pattern match\n";
+    } else if (loopPoint.score < 0.15) {
+        std::cout << "\n✓ Acceptable pattern match\n";
+    } else {
+        std::cout << "\n⚠ Could not find optimal loop point\n";
+        std::cout << "This sample may be problematic for looping\n";
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Five of PicoFaceCP's six voices are not mda-EPiano's. `Rd II`, `Wr`, `Clv`, `CP` and `Piano` are sample sets of their own, and their generated headers have been committed all along — 3.3 MB of the instrument's 4.22 MB image, each one stamped `Auto-generiert von build_instrument.py`. The tool named there lived in another repository, so those five voices could not be rebuilt from a checkout of this one.

| Voice | Header | Flash |
|---|---|---|
| Rd I | `mdaEPianoData.h` | 825 kB — mda's own, not built here |
| Rd II | `Rd_IIData.h` | 967 kB |
| Wr | `WrData.h` | 773 kB |
| Clv | `ClvData.h` | 779 kB |
| CP | `CPData.h` | 580 kB |
| Piano | `PnoData.h` | 293 kB |

## What is imported

Two Python stages and the one C++ helper the first shells out to:

- `prepare_samples.py` — downmix, resample to 32 kHz, normalise to mda's pitch-dependent level curve, trim to attack-plus-loop
- `build_instrument.py` — the data and keygroup headers, three velocity layers per region
- `src/FindLoopPoints.cpp` + `build_loop_finder.sh`
- the five configs, repointed at git-ignored `build_host/cp_samples/`

The README documents all of it in English, including the loop finder's three known quirks (hard-coded 32 kHz, mis-parsed fmt chunk, half-period counting) and the finding that shaped the pipeline: the finder takes the *last* zero crossing as its loop-end reference, which on a decaying note lands in a silent tail — hence the pre-cut window.

## The source recordings are not here

They were collected over years from freely available sources, some recorded by playing an emulator over MIDI, and their origins can no longer be reconstructed. They are not redistributed. The README states this plainly rather than leaving it implicit — a pipeline whose first step is "put your WAVs here" invites the question, and the answer should not be silence.

## The one change that was needed

`load_mda_curve()` read mda's reference peaks from 34 exported WAVs plus the plugin's `.cpp`. Neither path exists here, so the tool would have been unusable exactly where it now lives. It reads them out of `mdaEPianoData.h` and `mdaEPiano.cpp` instead, both in the repository.

That is not obviously equivalent — the committed data is pre-baked with the loop crossfade, where the original plugin built its array at runtime. Checked against the old WAVs before switching:

```
  from header : a = -8.334987  b = -0.017377
  from WAVs   : a = -8.334987  b = -0.017377
  max target-peak difference over notes 21..108: 0.000000 dB
```

The crossfade lives in the loop region; an e-piano sample's peak is in the attack.

## Deliberately not changed

The output templates, German comments included, so regenerating a voice reproduces the committed headers rather than a reformatted version of them. Inline comments were left alone too — translating 21 KB of working code I did not write is a bad trade for a large unreviewable diff. English: the README and both module docstrings.

An earlier chain (`InstrumentBuilder`, `SamplesToInstrumentTxt`, `PresetIndexBuilder` and four shell scripts) was superseded by these two stages and is not imported. Importing dead tooling and documenting it as live is worse than leaving it out.

## Verification

End to end on generated test tones, since no real samples are available to CI or to a fresh checkout: both stages run, the curve comes out at `-8.335 - 0.01738·note` as measured independently, and the generated headers compile. No firmware code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)