### PR TITLE
tools/rd_extract: hardware refutes the flash-bottleneck conclusion

### DIFF
--- a/tools/rd_extract/README.md
+++ b/tools/rd_extract/README.md
@@ -70,6 +70,13 @@ the macro; `nm` on `PicoFaceRD.elf` shows no such symbol.
 tools/rd_extract/build_xip_probe.sh 0 12 200      # patch, voices, blocks
 ```
 
+**Patch numbers here are engine indices, 0-15.** The instrument displays
+`instrument() + 1`, so every number in this section is one below what the PATCH
+page shows. The two patches with no flash cost at all are indices 5 and 15,
+which are **`06 Vibraphone` and `16 Vibraphone`** on the device -- and that they
+are both vibraphones is the mechanism showing through: short, simple, heavily
+reused waveforms fit the cache, where a piano's spread across the ROM does not.
+
 **What it found.** At the 32 kHz base limit of twelve voices the engine issues
 119 wave-ROM loads per sample -- one per part, ten parts per note, as expected
 -- and the flash cost is enormous but wildly patch-dependent:
@@ -102,9 +109,35 @@ does not currently have.
 **What this does not show.** Only that the flash bottleneck disappears, not
 that those patches can run twenty-four voices: the arithmetic scales with voice
 count too, and this probe does not measure it. If it fails there, it will not
-be flash. The device can answer that today without any code change -- VOICES
-offers fixed polyphony, the footer shows peak load, so patch 15 at 24 voices
-against patch 3 at 24 voices settles it.
+be flash.
+
+The device can answer that without a code change, but not as casually as this
+paragraph used to suggest. Four patches measured on hardware at a VOICES
+setting of 24:
+
+| device | index | miss rate | peak load |
+|---|---|---|---|
+| 02 Piano 2 | 1 | 56.0 % | 100 % |
+| 03 Piano 3 | 2 | 59.5 % | 57 % |
+| 14 A. Piano 2 | 13 | 58.7 % | 90 % |
+| 15 Clavi | 14 | 68.3 % | 67 % |
+
+The lowest miss rate carries the highest load and the highest miss rate the
+second lowest, so within this group the miss rate predicts nothing. Neither
+does the sample rate: indices 1, 2 and 13 run at 20 kHz and index 14, the
+cheapest of the four, at 32 kHz.
+
+What was not controlled is how many voices actually sounded. `P` is a peak over
+whatever was played, while the probe assumes twenty-four voices sustaining, and
+patches differ enormously in how long a voice stays alive -- a piano's release
+keeps parts running where a clavinet's does not. The footer prints
+`A<active>/<limit>` next to `P`; without reading it the four numbers are not
+comparable to each other, let alone to this table.
+
+The comparison worth making is **`16 Vibraphone` against `15 Clavi`**, both at
+a fixed 24 voices, holding until `A` reaches the limit and reading `P` there.
+That is 0.0 % against 68.3 % miss rate with everything else equal -- the
+cleanest flash isolation the device allows.
 
 **On the numbers.** The miss rate is measured: a real address stream from the
 real engine through a stated cache geometry. The conversion to percent of
@@ -112,6 +145,11 @@ budget is an estimate with its assumptions in the source -- 96 CPU cycles per
 miss, from a 120 MHz QSPI fetch at the 4:1 clock ratio. Halve or double that
 and the absolute figures move; the ordering, and the factor of several hundred
 between patch 3 and patch 15, do not.
+
+The hardware numbers above sharpen that caveat. Among patches whose miss rates
+sit within ten points of each other the model says nothing useful about which
+will cost more, so "flash-bound %" is worth reading as a ranking between the
+extremes -- something against nothing -- and not as a per-patch budget.
 
 ## Regression runner (one command)
 

--- a/tools/rd_extract/README.md
+++ b/tools/rd_extract/README.md
@@ -81,39 +81,55 @@ reused waveforms fit the cache, where a piano's spread across the ROM does not.
 119 wave-ROM loads per sample -- one per part, ten parts per note, as expected
 -- and the flash cost is enormous but wildly patch-dependent:
 
-| patch | miss rate | flash-bound | | patch | miss rate | flash-bound |
-|---|---|---|---|---|---|---|
-| 3 | 85.7 % | **65.8 %** | | 8 | 43.0 % | 32.1 % |
-| 14 | 84.6 % | 65.0 % | | 11 | 37.3 % | 28.6 % |
-| 0 | 77.1 % | 58.7 % | | 7 | 16.2 % | 12.5 % |
-| 12 | 75.8 % | 58.1 % | | **5** | **0.2 %** | **0.2 %** |
-| 13 | 83.1 % | 63.8 % | | **15** | **0.1 %** | **0.1 %** |
+| patch | rate | miss rate | flash-bound | | patch | rate | miss rate | flash-bound |
+|---|---|---|---|---|---|---|---|---|
+| 3 | 32k | 85.6 % | **65.7 %** | | 8 | 20k | 43.7 % | 19.6 % |
+| 14 | 32k | 84.5 % | 64.9 % | | 11 | 32k | 37.1 % | 28.5 % |
+| 0 | 20k | 77.1 % | 36.7 % | | 7 | 32k | 17.1 % | 12.4 % |
+| 12 | 20k | 76.4 % | 35.8 % | | **5** | 20k | **0.1 %** | **0.1 %** |
+| 13 | 20k | 82.9 % | 39.8 % | | **15** | 20k | **0.1 %** | **0.0 %** |
 
-Two thirds of the cycle budget goes to stalls on the worst patches. On patches
-5 and 15 the cost is nil -- their wave data fits the cache and every voice
-reuses it -- and it stays nil as voices are added:
+The rate column matters and used to be missing: eleven of the sixteen patches
+render at 20 kHz and get half again as many cycles per sample as the five at
+32 kHz. The probe assumed 32 kHz for all of them, which overstated every
+20 kHz patch's flash-bound figure by a factor of 1.6. Fixed; the numbers above
+are the corrected ones.
+
+Miss rate is genuinely patch-dependent, and on patches 5 and 15 the cost is
+nil -- their wave data fits the cache and every voice reuses it -- and stays
+nil as voices are added:
 
 | voices | patch 15 | patch 5 | patch 3 |
 |---|---|---|---|
-| 12 | 0.1 % | 0.2 % | 65.8 % |
-| 16 | 0.1 % | 0.2 % | 82.8 % |
-| 24 | 0.1 % | 0.2 % | **95.7 %** |
-| 32 | 0.1 % | 0.2 % | 96.3 % |
+| 12 | 0.0 % | 0.1 % | 65.7 % |
+| 16 | 0.0 % | 0.1 % | 82.8 % |
+| 24 | 0.0 % | 0.1 % | **95.7 %** |
+| 32 | 0.0 % | 0.1 % | 96.3 % |
 
-So the base limit of twelve is set by patches like 3, which is already at 96 %
-of budget on stalls alone at twenty-four voices -- while patches 5 and 15 never
-touch flash at all. A per-patch base limit, derived offline from this
-measurement rather than guessed at runtime, is the lever the voice governor
-does not currently have.
+## What the hardware said, and what it cost this section
 
-**What this does not show.** Only that the flash bottleneck disappears, not
-that those patches can run twenty-four voices: the arithmetic scales with voice
-count too, and this probe does not measure it. If it fails there, it will not
-be flash.
+The paragraph that used to sit here said the probe showed only that the flash
+bottleneck disappears, not that a cache-clean patch can run twenty-four voices
+-- and proposed the device settle it, since VOICES offers fixed polyphony and
+the footer shows peak load. That test was run. It settled something else.
 
-The device can answer that without a code change, but not as casually as this
-paragraph used to suggest. Four patches measured on hardware at a VOICES
-setting of 24:
+The decisive pair, both held until the footer read `A24`:
+
+| device | index | rate | miss rate | peak load |
+|---|---|---|---|---|
+| **16 Vibraphone** | 15 | 20 kHz | **0.1 %** | **91 %** |
+| **15 Clavi** | 14 | 32 kHz | **68.3 %** | **67 %** |
+
+The patch that never touches flash is the expensive one. It issues 200.5
+wave-ROM loads per sample against the clavinet's 217.0, at a *lower* sample
+rate, with essentially every one of them a cache hit -- and it uses 91 % of its
+budget where the clavinet uses 67 % of its. The device computes load against
+each patch's own rate (`budget = length * 1e6 / s_sampleRates[instrument_]`),
+so the two percentages are directly comparable.
+
+That is not a caveat, it is a refutation. **Flash stalls are not what sets this
+engine's ceiling.** Four more patches, measured the same way, say the same
+thing from the other side:
 
 | device | index | miss rate | peak load |
 |---|---|---|---|
@@ -122,34 +138,30 @@ setting of 24:
 | 14 A. Piano 2 | 13 | 58.7 % | 90 % |
 | 15 Clavi | 14 | 68.3 % | 67 % |
 
-The lowest miss rate carries the highest load and the highest miss rate the
-second lowest, so within this group the miss rate predicts nothing. Neither
-does the sample rate: indices 1, 2 and 13 run at 20 kHz and index 14, the
-cheapest of the four, at 32 kHz.
+The lowest miss rate carries the highest load. Neither miss rate nor sample
+rate orders this list.
 
-What was not controlled is how many voices actually sounded. `P` is a peak over
-whatever was played, while the probe assumes twenty-four voices sustaining, and
-patches differ enormously in how long a voice stays alive -- a piano's release
-keeps parts running where a clavinet's does not. The footer prints
-`A<active>/<limit>` next to `P`; without reading it the four numbers are not
-comparable to each other, let alone to this table.
+**The 96-cycles-per-miss figure is refuted outright.** For device 15 the model
+claims 94.8 % of the budget on stalls alone, while the whole patch measures
+67 % -- and stalls cannot exceed the total. The true cost is under 68 cycles
+per miss, and since the arithmetic is clearly substantial, well under.
 
-The comparison worth making is **`16 Vibraphone` against `15 Clavi`**, both at
-a fixed 24 voices, holding until `A` reaches the limit and reading `P` there.
-That is 0.0 % against 68.3 % miss rate with everything else equal -- the
-cleanest flash isolation the device allows.
+What the probe measures -- the address stream, the hit and miss counts through
+a stated cache geometry -- stands. What it never measured is the arithmetic
+per part, which is now the obvious candidate for the difference: two patches
+with near-identical load counts and opposite cache behaviour, and the cheap
+one for the cache is the expensive one for the CPU. Envelope segment counts
+and part types differ per patch and none of that is in this tool.
 
-**On the numbers.** The miss rate is measured: a real address stream from the
-real engine through a stated cache geometry. The conversion to percent of
-budget is an estimate with its assumptions in the source -- 96 CPU cycles per
-miss, from a 120 MHz QSPI fetch at the 4:1 clock ratio. Halve or double that
-and the absolute figures move; the ordering, and the factor of several hundred
-between patch 3 and patch 15, do not.
+**So read the tables above as cache behaviour, not as a cycle budget.** They
+correctly say which patches thrash and which do not, and the factor of several
+hundred between the extremes is real. They do not predict load, and the
+"flash-bound %" column should be read as an upper bound that hardware has
+already shown to be loose.
 
-The hardware numbers above sharpen that caveat. Among patches whose miss rates
-sit within ten points of each other the model says nothing useful about which
-will cost more, so "flash-bound %" is worth reading as a ranking between the
-extremes -- something against nothing -- and not as a per-patch budget.
+A per-patch voice limit derived from these numbers -- floated in the paragraph
+this replaces -- would therefore have been tuned to the wrong variable. The
+lever is real; the measurement to derive it from is not this one.
 
 ## Regression runner (one command)
 

--- a/tools/rd_extract/rd_xip_probe.cpp
+++ b/tools/rd_extract/rd_xip_probe.cpp
@@ -103,15 +103,34 @@ int main(int argc, char** argv) {
     printf("  XIP misses          %10ld   (%.1f %% miss rate)\n", c.misses, 100.0 * missRate);
     printf("  misses per sample   %10.1f\n", (double) c.misses / (double) samples);
 
-    // Budget: at 32 kHz one sample is 480e6/32000 = 15000 CPU cycles across two
-    // cores. A miss fetches one line over QSPI at 120 MHz; a quad read costs
-    // roughly 8+8 QSPI clocks of overhead plus the data, call it 24, which at
-    // the 4:1 clock ratio is ~96 CPU cycles. Both numbers are stated so the
-    // estimate can be argued with.
-    const double cyclesPerSample = 480e6 / 32000.0;
+    // Budget: one sample is 480e6/rate CPU cycles across two cores, and the
+    // rate is per patch -- eleven of the sixteen run at 20 kHz and get half
+    // again as many cycles as the five at 32 kHz. This used to assume 32 kHz
+    // for all of them, which overstated every 20 kHz patch's flash-bound
+    // figure by a factor of 1.6.
+    static const int kRates[16] = {
+        20000, 20000, 20000, 32000,
+        32000, 20000, 20000, 32000,
+        20000, 20000, 20000, 32000,
+        20000, 20000, 32000, 20000,
+    };
+    const int rate = kRates[patch & 15];
+    const double cyclesPerSample = 480e6 / (double) rate;
+
+    // A miss fetches one line over QSPI at 120 MHz; a quad read costs roughly
+    // 8+8 QSPI clocks of overhead plus the data, call it 24, which at the 4:1
+    // clock ratio is ~96 CPU cycles.
+    //
+    // Hardware says that is too high. Device patch 15 (index 14, 32 kHz) is
+    // modelled at 94.8 % of budget on stalls alone, yet its measured PEAK LOAD
+    // at 24 sounding voices is 67 % -- and stalls cannot exceed the total. So
+    // the true cost per miss is under 68 cycles here, probably well under.
+    // The miss counts above are the measurement; this conversion is not.
     const double missCycles = (double) c.misses / (double) samples * 96.0;
-    printf("\n  cycle budget/sample %10.0f  (480 MHz, 32 kHz, both cores)\n", cyclesPerSample);
+    printf("\n  cycle budget/sample %10.0f  (480 MHz, %d kHz, both cores)\n",
+           cyclesPerSample, rate / 1000);
     printf("  estimated stall     %10.0f  cycles/sample at ~96 per miss\n", missCycles);
-    printf("  -> flash-bound      %10.1f %% of the budget\n", 100.0 * missCycles / cyclesPerSample);
+    printf("  -> flash-bound      %10.1f %% of the budget  (upper bound, see source)\n",
+           100.0 * missCycles / cyclesPerSample);
     return 0;
 }


### PR DESCRIPTION
The XIP probe's section proposed that the device settle whether a cache-clean patch can run 24 voices. Michael ran it. It settled something else, and two commits' worth of corrections fall out.

## The decisive measurement

Both patches held until the footer showed `A24`:

| device | index | rate | miss rate | peak load |
|---|---|---|---|---|
| **16 Vibraphone** | 15 | 20 kHz | **0.1 %** | **91 %** |
| **15 Clavi** | 14 | 32 kHz | **68.3 %** | **67 %** |

The patch that never touches flash is the expensive one. Fewer wave-ROM loads per sample (200.5 against 217.0), a lower sample rate, essentially every load a cache hit — and half again the cost. The firmware computes load against each patch's own rate (`budget = length * 1e6 / s_sampleRates[instrument_]`), so the two percentages are directly comparable.

Four more patches, same method, from the other side:

| device | index | miss rate | peak load |
|---|---|---|---|
| 02 Piano 2 | 1 | 56.0 % | 100 % |
| 03 Piano 3 | 2 | 59.5 % | 57 % |
| 14 A. Piano 2 | 13 | 58.7 % | 90 % |
| 15 Clavi | 14 | 68.3 % | 67 % |

The lowest miss rate carries the highest load. Neither miss rate nor sample rate orders that list.

## Two independent errors

**96 cycles per miss is refuted outright.** The model puts device 15 at 94.8 % of budget on stalls alone while the whole patch measures 67 %, and stalls cannot exceed the total. Under 68 cycles per miss, and given how much arithmetic is evidently there, well under.

**The probe used one denominator for sixteen patches.** It assumed 32 kHz throughout; eleven of the sixteen render at 20 kHz and get half again as many cycles per sample. Every 20 kHz patch's flash-bound figure was inflated by 1.6×. `rd_xip_probe.cpp` now carries the per-patch rate table and prints the rate it used:

| patch | was | now |
|---|---|---|
| 0 | 58.7 % | 36.7 % |
| 12 | 58.1 % | 35.8 % |
| 13 | 63.8 % | 39.8 % |
| 8 | 32.1 % | 19.6 % |

The five 32 kHz patches (3, 4, 7, 11, 14) are unchanged.

## Also in this branch: the patch numbering

The first commit fixes what sent the test to the wrong patches to begin with. Every number in that section is an engine index, the instrument displays `instrument() + 1`, and the README cheerfully suggested "patch 15 at 24 voices against patch 3" — which on the device is indices 14 and 2, both flash-heavy, neither of them the cache-clean patch the comparison was about.

The two clean patches are indices 5 and 15, on the device `06 Vibraphone` and `16 Vibraphone`. That they are both vibraphones is the mechanism showing through and is now in the text: short, heavily reused waveforms fit the cache where a piano's spread across the ROM does not.

## What survives

The address stream, the hit and miss counts through a stated cache geometry, and the factor of several hundred between the extremes. Those are measured and unchanged.

What does not survive is reading them as a cycle budget — and with it the per-patch voice limit the section floated, which would have been tuned to the wrong variable. Arithmetic per part is the obvious remaining candidate, and this tool has never measured it. The probe counted memory accesses and was allowed to answer a question about time.

Tooling and documentation only; no firmware code is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)