### PR TITLE
The documentation catches up with the D-50

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,9 +35,9 @@ codebase. Same board, same core, one firmware image per instrument.
 The JV-880 and the D-50 are the exceptions to "download and flash": they only
 build where the respective ROM set is present, and those ROMs are not
 distributable, so neither is in the release binaries. Without them the
-configure step skips them and the eight above are unaffected. The JV-880 runs
-on the hardware; see the flash note below for the one build option it needs on
-a small board. The D-50 is new and has not been on the hardware yet.
+configure step skips them and the eight above are unaffected. Both run on the
+hardware; see the flash note below for the one build option the JV-880 needs
+on a small board.
 
 ## Hardware
 
@@ -62,7 +62,7 @@ Raspberry Pi Pico 2 and many other RP2350 boards provide:
 | YC, DX, J6, MD, SM, OB | 90-190 KB | fits anywhere |
 | PicoFaceCP | 4.22 MB | does not fit |
 | PicoFaceJV | 4.34 MB | only with `-DPICOFACEJV_4MB=ON` (3.76 MB, banks A+B) |
-| PicoFaceD5 | 1.19 MB | fits |
+| PicoFaceD5 | 0.86 MB | fits |
 | PicoFaceRD | 5.07 MB | does not fit |
 
 CP carries the Rhodes, Clavinet and E-piano sample sets, RD the MKS-20 sample
@@ -151,22 +151,22 @@ instrument's README names the document so it can be obtained separately.
 ## Status
 
 **All ten instruments build from a single configure run, each with its own USB
-PID.** Eight are in the release binaries and confirmed on the hardware; the
-JV-880 runs on the hardware but needs a local ROM set, and the D-50 is new -
-it builds and its engine is verified on the host, but it has not been on the
-hardware yet. Open points are listed in
-[docs/ARCHITECTURE.md](docs/ARCHITECTURE.md), section 8.
+PID, and all ten run on the hardware.** Eight are in the release binaries; the
+JV-880 and the D-50 need a local ROM set and are therefore built locally only.
+Open points are listed in [docs/ARCHITECTURE.md](docs/ARCHITECTURE.md),
+section 8.
 
 ## License
 
 **GNU General Public License, version 3 or later** - see [LICENSE](LICENSE).
 Copyright (C) 2026 Michi71.
 
-That is what every one of the seven single-instrument repositories this
-collection was assembled from already declared: all seven shipped the identical
-GPL-3 licence text, and every instrument README states GPL-3. It is also the
-lowest common denominator of what the engines are built on. Where an instrument
-derives from someone else's work:
+The collection was assembled in August 2026 from seven single-instrument
+repositories -- YC, CP, DX, RD, J6, MD and SM; OB, JV and D5 were written here
+afterwards, which is why the number is seven and not ten. Each of those seven
+already shipped the identical GPL-3 licence text, and every instrument README
+states GPL-3. It is also the lowest common denominator of what the engines are
+built on. Where an instrument derives from someone else's work:
 
 | Part | Upstream it derives from | That upstream's license |
 |---|---|---|
@@ -179,6 +179,8 @@ derives from someone else's work:
 | PicoFaceMD | [BelaMiniMoogEmulation](https://github.com/lbros96/BelaMiniMoogEmulation) (ladder filter) | stated by its author to be under no copyright |
 | PicoFaceSM | [string-machine](https://github.com/jpcima/string-machine) (DSP models) | Boost Software License 1.0 |
 | PicoFaceOB | [OB-Xf](https://github.com/surge-synthesizer/OB-Xf) (engine) | GPL-3.0-or-later |
+| PicoFaceJV | own work, over the machine's own PCM data | - |
+| PicoFaceD5 | [munt](https://github.com/munt/munt) - the LA32's wave generation and the Boss reverb topology as that project *documents* them, no code | LGPL-2.1-or-later upstream, does not reach here; see below |
 
 `instruments/PicoFaceOB/` additionally carries its own `LICENSE`, identical in
 text, because that instrument's engine is a direct port of OB-Xf and its files
@@ -196,6 +198,17 @@ it out of the way of the code. Three kinds exist:
   MAME's `mame_utils.h` and `mcu_ops.h`, the SDK-derived `usb_descriptors.c`,
   `get_serial.*` and `tusb_config.h`): untouched, they keep the header they
   came with. The last four are MIT and BSD-3-Clause, not GPL.
+
+**On PicoFaceD5 and munt.** The D-50 and the MT-32 share the LA32 sound chip,
+and the MT-32 emulator [munt](https://github.com/munt/munt) has read that chip
+out and written down what it does: how a cutoff becomes the width of a cosine
+edge, how the resonance decays, and - from the same era's Boss reverb chip,
+whose data lines were traced by Lord_Nightmare, balrog and Mok - the topology
+the reverb here follows. munt is LGPL-2.1-or-later. Nothing was copied: the
+engine under `instruments/PicoFaceD5/include/d5_engine/` was written for this
+project from that written description and from the D-50's own firmware, which
+is why no file there carries an upstream copyright header. The description is
+what mattered, and a description is not the program.
 
 **On PicoFaceYC and the AGPL.** OpenB3 / BeatrixCPP, whose tone generation
 concepts the YC drawbar engine follows, is AGPL-3.0 - stricter than GPL-3, and

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -48,8 +48,8 @@ img/
     └── build.yml
 ```
 
-## 3. One hardware platform, nine instruments
-The board is the same for all nine instruments. Pin map and flash timing therefore live in the core: `core/include/project_config.h` and `core/include/pico_hw.h`. In the seven original repositories every single pin definition was already identical; the files differed only in comments, in one extra QMI timing constant for PicoFaceRD, and in one inline helper. The core versions are the union of all variants.
+## 3. One hardware platform, ten instruments
+The board is the same for all ten instruments. Pin map and flash timing therefore live in the core: `core/include/project_config.h` and `core/include/pico_hw.h`. In the seven original repositories every single pin definition was already identical; the files differed only in comments, in one extra QMI timing constant for PicoFaceRD, and in one inline helper. The core versions are the union of all variants.
 
 ### Why the core is still not a library
 
@@ -57,7 +57,7 @@ The core continues to publish lists of absolute source paths instead of a STATIC
 
 From that follows the include order `instruments/<NAME>/include` before `core/include`, so that an instrument's own variant of a header wins. After the merge that affects only five headers (see section 7).
 
-Counter-example: lib/audio, lib/encoder and lib/u8g2 stay STATIC and are built once for all nine targets.
+Counter-example: lib/audio, lib/encoder and lib/u8g2 stay STATIC and are built once for all ten targets.
 
 **Note on the audio library:** lib/audio/src/audio_subsystem.cpp originally included project_config.h and read PIN_I2S_DOUT and PIN_I2S_BCK from it. In the old projects this went unnoticed because a global `include_directories()` leaked the instrument include path into every target. The library now uses the standard macros PICO_AUDIO_I2S_DATA_PIN and PICO_AUDIO_I2S_CLOCK_PIN_BASE and no longer knows anything about the instrument configuration.
 
@@ -79,7 +79,7 @@ The core calls init(), then queries sampleRate() and initializes the audio pool 
 
 ## 4a. The runtime model
 
-**All nine instruments run in the same model:** core0 does audio, USB, MIDI and GUI, the core polls the encoders into an InputState and calls `uiTick()`. core1 belongs to the instrument - PicoFaceRD uses it as a voice worker, the other eight leave it idle.
+**All ten instruments run in the same model:** core0 does audio, USB, MIDI and GUI, the core polls the encoders into an InputState and calls `uiTick()`. core1 belongs to the instrument - PicoFaceRD uses it as a voice worker, the other nine leave it idle.
 
 Until the conversion of PicoFaceYC and PicoFaceCP there was a second model in which an instrument took over the entire user interface on core1 via `ownsUserInterface()`. The core then started core1 itself, initialized neither display nor encoders, and called `pumpCrossCore()` instead of `uiTick()`; for flash access the instrument supplied a pair of park hooks. With the last user gone, the five methods disappeared from `picoface::Instrument` and so did the corresponding branch in `picoface_main.cpp`. An instrument that needs core1 starts it from its own adapter, the way PicoFaceRD does.
 
@@ -108,7 +108,7 @@ PicoFaceDX only came in from its own repository after that conversion, and it st
 Like YC and CP, DX writes its own veeprom record and reports `settingsSize() == 0`; that record contains a complete patch. In addition, `RefaceMidi::txBytes()` now writes to the DIN output as well (section 6a); the original repository did not have one.
 
 ## 5. Build system
-`picoface_add_instrument()` in `cmake/PicoFaceInstrument.cmake` creates a complete firmware target per instrument. All settings are target-local (`target_compile_definitions` / `target_compile_options` instead of a global `add_compile_options`), because nine targets with conflicting defines have to coexist.
+`picoface_add_instrument()` in `cmake/PicoFaceInstrument.cmake` creates a complete firmware target per instrument. All settings are target-local (`target_compile_definitions` / `target_compile_options` instead of a global `add_compile_options`), because ten targets with conflicting defines have to coexist.
 
 | Keyword | Meaning |
 |---|---|
@@ -178,7 +178,7 @@ The parser handles running status, SysEx up to 256 bytes, and lets realtime byte
 
 ### Integration
 
-`MIDISerial::process()` runs for all nine instruments in `picoface_main.cpp`, right next to `MIDIInputUSB::process()`.
+`MIDISerial::process()` runs for all ten instruments in `picoface_main.cpp`, right next to `MIDIInputUSB::process()`.
 
 The core passes realtime bytes and bare receive activity through via the optional methods `realtime()` and `midiActivity()`. Both are needed for the active sensing supervision of the reface layer in YC, CP and DX - their 350 ms timeout silences all voices when 0xFE stops arriving. The defaults are empty; the other instruments ignore both.
 
@@ -327,9 +327,9 @@ These defines are deliberately not unified in the helper but set per instrument 
 
 - `core/src/picoface_main.cpp`: shared main() for both runtime models.
 - `core/src/ui/display.cpp`: u8g2 facade; flush() only arms the row-by-row output.
-- All nine adapters, all in the standard model. PicoFaceMD is the template.
-- All nine build from a single configure run and carry their own USB PID.
-- All nine tested on the hardware and working, PicoFaceRD including the 480 MHz clocking.
+- All ten adapters, all in the standard model. PicoFaceMD is the template.
+- All ten build from a single configure run and carry their own USB PID.
+- All ten tested on the hardware and working, PicoFaceRD including the 480 MHz clocking.
 - PicoFaceOB (section 6b) confirmed on the hardware on 2026-08-04, PicoFaceDX (section 4a) on 2026-08-05 - the last two. For DX that covers audio out, the factory presets sounding as they should, the whole of the user interface that used to run on core1 (preset switching, master volume, the settings write), and USB MIDI far enough that Soundmondo connects and loads voices into it.
 - PicoFaceJV added as the ninth instrument: a native JV-880 engine over the
   machine's own PCM data, every law measured differentially against a
@@ -339,6 +339,20 @@ These defines are deliberately not unified in the helper but set per instrument 
   and the other eight are unaffected. `-DPICOFACEJV_4MB=ON` fits it on a
   base 4 MB Pico 2 by shipping banks A and B only.
 - PicoFaceYC and PicoFaceCP converted to the standard model (section 4a) and confirmed on the hardware in that form. With that, the second runtime model has been removed from the core without replacement.
+- PicoFaceD5 added as the tenth instrument: a native LA engine over the D-50's
+  own PCM data. Its distinguishing feature is the source of its rules -- the
+  machine's program EPROM and the internal ROM of its uPD78312 were
+  disassembled, and the envelope arithmetic, pitch law, keyfollow and depth
+  tables, LFO and portamento behaviour, the TVA level basis and the sixteen-slot
+  voice allocator are implemented from that code rather than from measurement.
+  Six banks of 64 patches, MIDI including the hold pedal and Roland exclusive
+  (DT1 in, RQ1 answered), confirmed on the hardware. Like PicoFaceJV it needs a
+  local ROM set and is therefore not in the release binaries; unlike it, the
+  whole sample ROM is 512 KB, so it fits a 4 MB board.
+  Two things it does not take from the firmware, because the firmware does not
+  hold them: the effect chip's algorithms (chorus, equalizer and the 32 reverb
+  types stand on the MT-32's Boss reverb as munt documents it) and the absolute
+  clock of the envelope ramps, which is calibrated against recordings.
 
 | Instrument | Flash | RAM | PID | Original (flash/RAM) |
 |---|---|---|---|---|
@@ -351,11 +365,18 @@ These defines are deliberately not unified in the helper but set per instrument 
 | PicoFaceOB | 131,724 | 42,248 | 0x1056 | - (new) |
 | PicoFaceDX | 170,052 | 218,508 | 0x1057 | 164,964 / 216,012 |
 | PicoFaceJV | 4,549,088 | 146,808 | 0x1058 | - (new) |
+| PicoFaceD5 | 909,852 | 245,620 | 0x1059 | - (new) |
 
 Measured with `arm-none-eabi-size` (text / bss). 32 KB of PicoFaceOB's RAM are
 the six voices of the OB-Xf voice object, a good 5.3 KB each; on top of that come
 47.6 KB of `.data`, because that is where the RAM-resident render path and the
 BLEP tables live (section 6b).
+
+PicoFaceD5's RAM goes into two blocks: 24 voice objects (16 for the upper tone,
+8 for the lower, as the machine's own allocator divides them) and a 28 KB
+shadow of one patch bank, into which received Roland exclusive is written --
+patches sent from an editor live there rather than in flash, so that a stream
+of parameter changes costs no flash write.
 
 The surcharge compared to the individual projects is 2 to 4 KB of flash and around 940 bytes of RAM per instrument - essentially the vtable of the instrument interface and the extra indirection.
 
@@ -369,3 +390,6 @@ DX falls outside that range with 5,088 bytes of flash and 2,496 bytes of RAM, bu
 
 1. Hardware test of DIN MIDI (section 6a).
 2. YC's `midi_input_usb.cpp`, the last replaced core source next to RD's `veeprom.cpp` (section 7).
+3. PicoFaceD5: patches received over SysEx are held in RAM and do not survive a
+   power cycle, and the handshake variant of Roland's protocol (WSD/RQD/DAT)
+   is not spoken -- only the one-way DT1/RQ1 that editors use.

--- a/instruments/PicoFaceD5/README.md
+++ b/instruments/PicoFaceD5/README.md
@@ -2,8 +2,9 @@
 
 A native LA engine over the D-50's own PCM data: sampled attacks dovetailed
 with synthesized sustains, the seven structures with their ring modulator, the
-three LFOs and the pitch envelope, and the common block's equalizer, chorus
-and reverb.
+three tone-global LFOs and the pitch envelope, and the common block's
+equalizer, chorus and reverb. Sixteen voices on one tone, eight and eight when
+both play -- the machine's own polyphony, out of its own allocator.
 
 Like PicoFaceJV, this instrument **needs a local ROM set** and is therefore not
 in the release binaries. Without one the configure step skips it with a note
@@ -31,23 +32,80 @@ cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
 cmake --build build
 ```
 
-The result is 662 KB of flash - 512 KB of it sample data, 29 KB the patch
-bank - and 79 KB of RAM,
-which fits any RP2350 board including the 4 MB ones. Of the collection's four
-sample-based instruments this is the only one that does.
+The result is 884 KB of flash - 512 KB of it sample data, 168 KB the six patch
+banks - and 264 KB of RAM, which fits any RP2350 board including the 4 MB ones.
+Of the collection's four sample-based instruments this is the only one that
+does.
 
 ## Playing it
 
-| Encoder | Patch page | Mix page | Tune page |
-|---|---|---|---|
-| Select | switches pages | | |
-| A | patch | volume | master tune |
-| B | polyphony cap | reverb | MIDI channel |
+The select encoder walks nine pages; A and B are the two value knobs. Every
+parameter below the first two rows is a D-50 parameter in the D-50's own
+units, and the ranges are the firmware's own -- they are read out of the
+maximum-value table in its EPROM rather than guessed:
 
-The footer shows peak load, the I2S underrun counter and active/allowed
-voices, as everywhere in the collection. MIDI arrives over USB and DIN alike;
-channel volume, reverb send, chorus send, all-notes-off and pitch bend are
-recognised.
+| Page | Encoder A | Encoder B | D-50 parameter |
+|---|---|---|---|
+| Patch | patch | polyphony cap | - |
+| Mix | master volume | tone balance | pb33 |
+| Reverb | balance | type 1-32 | pb31 / pb30 |
+| Chorus | balance | type 1-8 | c45 / c42 |
+| Cho Mod | rate | depth | c43 / c44 |
+| EQ Low | frequency (shown in Hz) | gain +/-12 dB | c37 / c38 |
+| EQ High | frequency (shown in Hz) | gain +/-12 dB | c39 / c41 |
+| EQ Q | Q | - | c40 |
+| Tune | master tune | MIDI channel | - |
+
+The patch parameters follow the patch when it changes and are not written to
+the settings: they belong to the patch, not to the panel. Chorus and equalizer
+are per tone on the real machine; these pages edit both tones together and
+read the upper one back.
+
+The footer reads `P B U A/limit N`: peak load, the boot benchmark, the I2S
+underrun counter, sounding voices against what the governor allows, and the
+note counter -- which turns into `S<n>` while the CPU governor is trimming
+tails, n being how many it retired in the last second. Zero, or an `N`, means
+the render has room.
+
+### MIDI
+
+The D-50's own control-change list is short, and it is known exactly: its
+receive dispatcher indexes a table in the EPROM, and that table reads 1, 5, 6,
+7, 38, 64, 65, 98, 99, 100, 101, plus the mode messages 122-127. Implemented
+here: **CC1** (modulation lever), **CC5** and **CC65** (portamento time and
+switch), **CC6** with **CC100/101** (RPN 0, bender range), **CC7** (volume),
+**CC64** (hold pedal), all-notes-off, program change, pitch bend and channel
+pressure. CC38 and the NRPN pair are received by the original but have nothing
+here to act on.
+
+Two controls are ours and **not** on the original, worth knowing when
+comparing against real hardware: **CC91/CC93** move reverb and chorus balance
+(General MIDI sends, four years younger than this machine), and **CC0** picks
+the bank ahead of a program change, without which the six banks cannot be
+reached at all.
+
+### SysEx
+
+Roland's one-way exclusive, `F0 41 <device> 14 <command> <address> <data>
+<checksum> F7`, is spoken in both directions:
+
+- **DT1 into the temporary area** (address `00 00 00`, 448 bytes in the same
+  seven 64-byte blocks a bulk dump carries) -- a single parameter or a whole
+  patch. This is how an editor programs the instrument, and it takes effect
+  while notes are sounding: no delay line is cleared and no LFO phase
+  restarted, so a stream of edits does not click.
+- **DT1 into internal memory** (`02 00 00`, 448 bytes a slot) -- a librarian
+  can send a whole bank of 64. They are held in RAM, shadowing the flash bank,
+  and each announces itself with the name in its own bytes. They survive patch
+  changes but not a power cycle: the D-50 keeps its sixty-four in
+  battery-backed memory, ours would be flash, and a flash write per message
+  would stall the render and wear the part.
+- **RQ1** is answered with DT1 messages of 256 data bytes each, the same
+  chunking the machine itself uses, from the temporary area or from internal
+  memory -- so a bank can be pulled back out for backup.
+
+Not implemented: the handshake protocol (WSD/RQD/DAT/ACK/EOD) that some older
+librarians use instead of RQ1/DT1.
 
 ## The patches
 
@@ -85,22 +143,61 @@ one.
 
 ## How the engine works, and what is not the original
 
-The sample table - which PCM sound starts where, how long it is and whether it
-loops - is not in any ROM. The D-50 resolves it inside the MB87136, and that
-mask ROM cannot be read out. The table this instrument uses was reconstructed
-from the decoded audio and verified by ear over ten review rounds;
-[`tools/d5_extract/README.md`](../../tools/d5_extract/README.md) documents both
-the evidence and the two open points.
+**The firmware is the master template.** The D-50's program EPROM and the
+internal ROM of its uPD78312 were disassembled for this port, and where the
+machine's own code answers a question, that answer wins over any measurement
+taken by ear. Read out of it and implemented byte-exactly: the envelope
+arithmetic (a rate index per segment, a time law that compensates the level
+distance so inner segments are time-constant, a release that is rate-constant
+because its distance lookup is computed and then overwritten -- dead code in
+the ROM), the pitch constant and its neutral coarse value, the keyfollow and
+depth tables, the LFO rate law and its two-phase delay, portamento, aftertouch
+and the bender modes, the TVA level basis, and the voice allocation: one pool
+of sixteen slots, all sixteen to the upper tone in whole mode, and a free list
+that makes the machine **drop** a new note when it is empty rather than steal a
+held one.
 
-Two more places where this deliberately differs from the machine:
+The sample table -- which PCM sound starts where, how long it is and whether it
+loops -- is not in the program ROM either; the D-50 resolves it inside the
+MB87136. It was reconstructed from the decoded audio, and later **confirmed
+from the firmware**: a bank window in the EPROM holds a start-page and a
+length-class byte per wave, which reproduce all 76 known geometries exactly and
+resolve the 24 combination waves as loops over larger regions of the same
+material. The wave-name table next to them matches this instrument's own
+numbering 100 out of 100.
+[`tools/d5_extract/README.md`](../../tools/d5_extract/README.md) documents the
+derivation.
 
-- **Root pitch per sample.** The real table carries one; ours is measured from
-  the material, so individual samples can be an octave off until someone
-  calibrates them against a recording.
-- **The reverb.** The D-50 has a dedicated reverb chip whose 32 types are 188
-  coefficients each. This is an ordinary Schroeder reverb with the 32 slots
-  mapped onto room, plate, gate and long settings - reverb of the right
-  character and length, not the original's impulse response.
+Where this still differs from the machine:
+
+- **The reverb** is the biggest one. The D-50's reverb chip holds 32 types of
+  188 coefficients each, in silicon, and the firmware says nothing about them.
+  What stands in for it is the reverb of the MT-32 -- the same era, the same
+  Roland department, a Boss RRV-10 whose data lines the munt project read out
+  and modelled. Its topology is here (entrance delay, three series allpasses,
+  three parallel combs, left and right taken from different taps), with the 32
+  panel types mapped onto its room, hall and plate cores plus a tapped delay
+  line for the delay family, and their decay times calibrated against
+  recordings of the real machine. Reverb of the right era and character, not
+  the original's impulse response.
+- **Chorus and equalizer** sit in the same effect chip and are modelled the
+  same way: the panel's parameters do what they say, the algorithm is not the
+  chip's.
+- **The absolute envelope clock.** Every ratio in the envelope arithmetic comes
+  from the ROM; the one constant that scales all of them was calibrated against
+  four measurements in reference recordings, and is good to a few percent
+  rather than exact.
+- **Root pitch of the attack samples.** The sustained loops are exact (each is
+  one cycle, so the root is the sample rate divided by its length); the attacks
+  carry a measured estimate.
+- **Sixteen voices are allocated, not always rendered.** The allocator is the
+  machine's, but the RP2350 is not the LA32: on the heaviest patches -- two
+  resonant synth partials and a three-second release, Spacious Sweep being the
+  worst of the factory bank -- eleven or twelve of them fit inside the audio
+  block. Rather than let that turn into dropouts, a governor watches the block
+  load and retires the longest-ringing *released* tail with a 20 ms fade; held
+  keys are never touched. The original trims too when a phrase outruns its
+  sixteen slots, only later. The footer's `S` shows when it is happening.
 
 Everything else follows the machine's own documentation: the structure table
 and the parameter ranges come from the Advanced Course manual and the service
@@ -110,6 +207,7 @@ notes, which are named here rather than shipped.
 
 [`tools/d5_extract/`](../../tools/d5_extract/README.md) holds the ROM
 identification, the decoder, the sample table and its derivation, the blob
-generator, and a host harness that renders the engine to WAV -
-`--synth`, `--la`, `--structures`, `--mod` and `--fx` - so the sound can be
-judged without flashing anything.
+generator, the SysEx converter that turns bulk dumps into patch banks, the
+extractor that lifts five more banks out of the D-05 update image, and a host
+harness that renders the engine to WAV - `--synth`, `--la`, `--structures`,
+`--mod` and `--fx` - so the sound can be judged without flashing anything.

--- a/instruments/PicoFaceD5/include/d5_presets.h
+++ b/instruments/PicoFaceD5/include/d5_presets.h
@@ -1,16 +1,16 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Michi71
 
-// d5_presets.h -- the patches the instrument boots with.
+// d5_presets.h -- the fallback patches, for a build without a bank dump.
 //
-// These are NOT the D-50's factory sixty-four. Those exist as SysEx bulk dumps
-// and the format for reading them is fully documented in the machine's MIDI
-// implementation (patch 64 bytes, common 64, partial 64 per structure), so
-// importing them is a host-side tool waiting to be written, in the same shape
-// as tools/dx_syx_to_patches. Until then the instrument ships eight patches
-// built by hand from the engine's own parameters, chosen to cover the ground:
-// every structure appears at least once, both waveforms, ring modulation, the
-// pitch envelope and each effect.
+// These are NOT the D-50's factory patches. Those are read by
+// tools/d5_extract/d5_syx_to_patches.py out of SysEx bulk dumps and reach the
+// firmware as the generated d5_patch_data.h; when that header is present the
+// bridge uses it and nothing here is played. What remains here is the case
+// where somebody builds with the ROM set but without a single bank dump:
+// eight patches built by hand from the engine's own parameters, chosen to
+// cover the ground -- every structure appears at least once, both waveforms,
+// ring modulation, the pitch envelope and each effect.
 
 #pragma once
 

--- a/instruments/PicoFaceD5/include/d5_settings.h
+++ b/instruments/PicoFaceD5/include/d5_settings.h
@@ -20,11 +20,13 @@
 struct __attribute__((packed)) D5SettingsV2 {
     uint16_t patch;      // absolute index, 0..patchCount-1; 64 per bank
     uint8_t volume;      // 0..100
-    uint8_t voices;      // polyphony cap per tone, 1..8
+    uint8_t voices;      // polyphony cap per tone, 1..8; whole mode gets twice
     uint8_t midiCh;      // 0..15, 16 = Omni
     int8_t  masterTune;  // -50..+50 cents
-    uint8_t reverb;      // 0..100, scales the patch's own reverb balance
-    uint8_t chorus;      // 0..100, scales the patch's own chorus balance
+    // Reverb and chorus balance are the patch's own parameters and are re-read
+    // from it on every change. Written out for diagnostics, ignored on import.
+    uint8_t reverb;      // 0..100
+    uint8_t chorus;      // 0..100
 };
 
 static_assert(sizeof(D5SettingsV2) == 8, "D5SettingsV2 layout drifted");


### PR DESCRIPTION
Documentation only -- no engine change. The D-50 kept answering questions after
its READMEs were written, and three of them still described the machine as it
was before that.

## What was wrong

**README.md**

- It called the D-50 new and untested. It has been on the hardware for days.
- Image size 1.19 MB, from before the sample blob shrank. It is 0.86 MB.
- Under License it counted **seven instruments** -- what Michael noticed. The
  number is not a miscount, it is the number of single-instrument repositories
  the collection was assembled from in August (YC, CP, DX, RD, J6, MD, SM);
  OB, JV and D5 were written here afterwards. Checked against the history:
  initial commit `7f89333` carries six, DX arrives the same day as `ca20417`
  from its own repository. The sentence now names them and says when, so the
  seven reads as history instead of as an error.
- The derivation table was missing **PicoFaceJV** and **PicoFaceD5**, and with
  D5 a licence question that deserves its own paragraph: munt is LGPL-2.1+,
  and what this engine took from it is its *written description* of the LA32
  and of the Boss reverb topology, not code. Handled in the same shape as the
  existing AGPL paragraph for YC.

**instruments/PicoFaceD5/README.md** -- the furthest adrift, because it predates
the firmware disassembly:

- described an "ordinary Schroeder reverb"; that is now the Boss RRV-10's
  topology with the 32 factory types mapped onto it
- three UI pages; there are nine, each in the D-50's own parameter units
- no MIDI section at all, for an instrument that now speaks the machine's own
  control-change list, the hold pedal, and Roland exclusive in both directions
- sizes: 884 KB of flash, 264 KB of RAM
- new, and the honest part: **sixteen voices are allocated, not always
  rendered**. Eleven or twelve fit the heaviest factory patch inside the audio
  block, and the governor retires released tails rather than let that become a
  dropout. Held keys are never touched.

**docs/ARCHITECTURE.md**

- nine -> ten throughout
- a D-50 entry in section 8: what it takes from the firmware, and the two
  things it cannot (the effect chip's algorithms, the absolute envelope clock)
- its row in the size table: 909,852 / 245,620 / PID 0x1059, with a note on
  where those 245 KB go (24 voice objects plus the 28 KB SysEx bank shadow)
- two open points that belong on the record: patches received over SysEx live
  in RAM and do not survive a power cycle, and the handshake protocol
  (WSD/RQD/DAT) is not spoken

## Source comments

Two had aged with the docs and are corrected: `d5_presets.h` still announced
the SysEx importer as unwritten (it exists, and the hand-built eight are now
only the fallback for a build without a bank dump), and `d5_settings.h` still
described reverb and chorus as scaling the patch's own balance, which stopped
being true when they became absolute D-50 parameters.

## Verification

Firmware builds unchanged: flash 905,760 B, RAM 270,516 B (51.6 %). Nothing in
the render path was touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)