### PR TITLE
Give the output stage its headroom back

### DIFF
--- a/instruments/PicoFaceD5/include/d5_engine/d5_patch_map.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_patch_map.h
@@ -559,8 +559,31 @@ inline PatchSpec patch_from_bytes(const uint8_t* patch, const int16_t* blob) {
     // the old linear reading across the bank -- this puts the median
     // patch back where the approved build had it, and the saturator
     // catches the few that the new law makes hotter.
-    p.upper.level = 0.58f;
-    p.lower.level = 0.58f;
+    //
+    // 0.37, because "the few" was 97 of 384. That constant was fitted to the
+    // MEDIAN of the bank and the top of the distribution was never checked:
+    // an eight-note chord at full velocity drove a quarter of the patches
+    // past full scale before the saturator, the worst (Synth Bass, 1-59) by
+    // 12.8 dB, which the knee turned into 16% distortion. Not a fault anyone
+    // hears as a fault -- a bass through a soft knee sounds driven, not broken
+    // -- which is why it survived until a listener on the internet called the
+    // demo video "a bit crackly" and the difference signal proved him right.
+    //
+    // The value is measured, not chosen. Distortion against how far a patch
+    // drives the knee: raw peak 0.64 -> 0.0%, 1.02 -> 2.2%, 1.63 -> 10.9%,
+    // 2.61 -> 24.0%. So the audibility threshold is full scale BEFORE the
+    // saturator, and the constant is the one that puts the bank's 95th
+    // percentile there under the demanding case (eight notes, velocity 127):
+    //
+    //          4 notes v127   8 notes v127   8 notes v100   over full scale
+    //   0.58      P95 1.14       P95 1.66       P95 1.17     97 of 384
+    //   0.37      P95 0.73       P95 1.06       P95 0.75     26 of 384
+    //
+    // -3.9 dB across the whole bank. Roland's own level relationships are
+    // untouched -- the spread from Glockenspiel to Power Key Bs is theirs and
+    // stays -- this only moves the ceiling out of the way of it.
+    p.upper.level = 0.37f;
+    p.lower.level = 0.37f;
 
     // Portamento is patch-common: switch pb[41], time pb[28], and mode
     // pb[20] -- 0 = upper only, 1 = lower only, 2 = both (the U/L/UL of

--- a/instruments/PicoFaceD5/include/d5_presets.h
+++ b/instruments/PicoFaceD5/include/d5_presets.h
@@ -47,7 +47,7 @@ inline PatchSpec preset_common() {
     p.key_mode = KeyMode::kWhole;
     p.balance = 0.0f;                     // upper tone only until patches use both
     p.volume = 0.9f;
-    p.upper.level = 0.55f;
+    p.upper.level = 0.35f;      // same headroom the bank path took, see d5_patch_map.h
     p.upper.voice.balance = 0.5f;
     // a partial pair with an attack that decays and a sustain that holds
     p.upper.voice.pcm_env[0].t[0] = 0.002f;


### PR DESCRIPTION
Hardware-tested by Michael before this PR was opened.

## What was wrong

The level basis was fitted to the **median** of the patch bank, and the top of
the distribution was never checked. Its own comment promised that the saturator
would "catch the few that the new law makes hotter". The few were **97 of 384**:
on an eight-note chord at full velocity a quarter of the bank arrived past full
scale before the limiter, and **Synth Bass (1-59)** arrived **12.8 dB over**,
coming out with **16.5 % distortion**.

Nobody hears that as a fault. A bass through a soft knee sounds driven, not
broken -- which is why it survived here until a commenter on the D-50 post said
the demo video sounded "a bit crackly".

He was right twice. Analysing the video's audio track:

- it **clips** at 4:00-4:10 -- 7385 samples pinned at full scale, in runs of up
  to 322 samples (6.7 ms)
- that passage sits at **-6.9 dB RMS against -18...-26 dB** for the rest of the
  film, a 15 dB jump, and it is 98 % below 200 Hz: a bass patch, i.e. exactly
  the class that runs into our limiter
- and, as a genuine relief, **zero discontinuities across all 308 seconds** --
  no dropped audio block, no underrun anywhere. The levels were wrong; the
  timing was not.

## The new constant is measured, not chosen

Distortion against how far a patch drives the knee (residual against the same
render level-matched from below the knee):

| raw peak before the saturator | distortion |
|---|---|
| 0.64 | 0.0 % |
| 1.02 | 2.2 % |
| 1.63 | 10.9 % |
| 2.61 | 24.0 % |

So the audibility threshold is full scale *before* the saturator. **0.58 -> 0.37**
is the value that puts the bank's 95th percentile there under the demanding
case (eight notes, velocity 127):

| level basis | 4 notes v127 | 8 notes v127 | over full scale (8/4 notes) |
|---|---|---|---|
| 0.58 | P95 1.14 | P95 1.66 | 97 / 35 |
| **0.37** | **P95 0.73** | **P95 1.06** | **26 / 4** |

Per-patch, four notes at full velocity: Power Key Bs 12.6 % -> 2.7 %, Stereo
Polysynth 11.6 % -> 5.3 %, Synth Bass 16.5 % -> 10.2 %.

**Synth Bass stays the outlier, and that is correct.** Its bytes say patch level
100 with both partials at TVA level 100 -- Roland built it as the loudest thing
in the bank. Removing its last 10 % would have cost the other 383 patches
another 5 dB, and one outlier is what a limiter is for.

**Roland's own level relationships are untouched.** The 44 dB from Glockenspiel
to Power Key Bs is his data. Compressing that range would make a tidier demo and
a less truthful machine.

The eight fallback presets (for a build without a bank dump) took the same
-3.9 dB, so the two paths stay level with each other.

## Verification, all 384 patches

| | result |
|---|---|
| `stress` | 0 NaN/Inf, quietest patch -59.3 dBFS |
| `tune2` | 329/384 on the key -- unchanged |
| `click2` | down to the single intentional flag (Reso Release) |
| `seqclick` | 12 flags -> 10 |
| `legato` | 0 NaN |
| `lfo` / `bend` / `glide` / `press` | unchanged, all passing |
| demo MIDI (`tools/d5_midi`) | peak 0.743 -> 0.479, no clipped samples |

Firmware unchanged in size: flash 905,760 B, RAM 270,516 B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)