### PR TITLE
Build the D-50 without a patch bank again

### DIFF
--- a/instruments/PicoFaceD5/instrument.cmake
+++ b/instruments/PicoFaceD5/instrument.cmake
@@ -99,6 +99,15 @@ if(_d5_syx)
         endif()
         message(STATUS "PicoFaceD5: ${_d5_syx_out}")
     endif()
+else()
+    # Say so. A ROM set alone builds a working instrument, but one that plays
+    # eight hand-built presets instead of the factory sixty-four, and somebody
+    # who does not know a bank is a separate file has no way to tell that from
+    # the build (issue #29).
+    message(STATUS
+        "PicoFaceD5: no patch bank in ${_d5_roms} - building with the eight "
+        "fallback presets. Put a D-50 SysEx bulk dump (*.syx) there for the "
+        "factory patches; see instruments/PicoFaceD5/README.md")
 endif()
 
 picoface_add_instrument(

--- a/instruments/PicoFaceD5/src/D5_Bridge.cpp
+++ b/instruments/PicoFaceD5/src/D5_Bridge.cpp
@@ -20,11 +20,17 @@
 #define __not_in_flash_func(x) x
 #endif
 
+// The byte mapping is needed either way: it carries Roland's parameter curves,
+// which the panel uses for chorus depth and reverb balance whether or not a
+// bank was converted into the build. It lived inside the guard below until a
+// build without a bank dump -- ROM images present, no .syx -- failed to compile
+// on somebody else's machine (issue #29). Nothing here depends on the bank.
+#include "d5_engine/d5_patch_map.h"
+
 // A converted SysEx bank if the build found one, the hand-built patches
 // otherwise. The instrument plays either without knowing the difference.
 #if __has_include("d5_patch_data.h")
 #include "d5_patch_data.h"
-#include "d5_engine/d5_patch_map.h"
 #define D5_HAVE_BANK 1
 #endif
 


### PR DESCRIPTION
Fixes #29.

## What was broken

`instruments/PicoFaceD5/src/D5_Bridge.cpp` includes `d5_engine/d5_patch_map.h`
**inside** the `#if __has_include("d5_patch_data.h")` guard, as though it were
part of the converted bank. It is not -- it carries Roland's parameter curves,
and two call sites use them unconditionally:

```
196: patch_.set_reverb_balance(d5::kAmountCurve[...]);   // reverb balance page
238: patch_.set_chorus_depth(d5::kDepthCurve[choDepth_]); // chorus depth page
```

Both arrived when the panel learned to edit chorus and EQ. With a bank present
the guard happens to pull the header in, so it has compiled here every time.
Without one it does not, and the build stops exactly where the reporter's did.

So: **a build with the ROM set but no `.syx` bank has been broken**, which is
the first thing a new builder has.

## The reporter did nothing wrong

Worth recording, since he suspected his dumps:

- his PCM images are 512 KiB rather than 256 KiB — that is the normal read-out
  that holds the chip twice, and `d5_rom.py` folds it. This repository is
  developed against files of exactly that shape and name, folding to the
  reference CRCs `1461C0FB` / `E50599BF`.
- his EPROM is v2.10, which is in the known-good table (`D1387C54`).

## Fix

1. The include moves out of the guard, where it belonged.
2. Configure now **says** when no bank was found. A ROM set alone builds a
   working instrument that plays the eight fallback presets instead of the
   factory sixty-four, and there was no way to tell that from the output:

```
-- PicoFaceD5: no patch bank in .../roms - building with the eight fallback
   presets. Put a D-50 SysEx bulk dump (*.syx) there for the factory patches;
   see instruments/PicoFaceD5/README.md
```

## Verification

With the `.syx` files parked elsewhere, so the tree looks like his:

| | result |
|---|---|
| configure | ROM set converts, 100/100 samples resolved, bank notice printed |
| build | configures, compiles and links clean |
| size | 729,784 B flash / 227,912 B RAM (against 905,760 / 270,516 with the banks -- the difference is the 384-patch table) |
| normal build | unchanged |

This path cannot be covered by CI: it needs ROM images that are not ours to
ship. It was checked by hand, which is precisely how it slipped in the first
place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)