### PR TITLE
Say at the ROM table that the patches are a separate file

### DIFF
--- a/instruments/PicoFaceD5/README.md
+++ b/instruments/PicoFaceD5/README.md
@@ -26,6 +26,13 @@ combined 512 KB image of both chips is accepted in place of the pair. The
 build converts them once at configure time into a 512 KB blob of 16-bit
 samples, so the firmware needs no decoding table at runtime.
 
+**The patches are a separate file, and they are optional.** Those three images
+are the sound; the D-50's sixty-four factory *patches* live in a SysEx bulk
+dump, which goes in the same `roms/` folder as a `.syx`. Without one the
+instrument still builds and plays -- with eight hand-built presets instead of
+the factory bank, and the configure step says so. See
+[The patches](#the-patches) below.
+
 ```bash
 cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
       -DPICOFACE_INSTRUMENTS_FILTER=PicoFaceD5


### PR DESCRIPTION
Documentation only, from the follow-up on #29.

After his build was fixed, Charles Hobbs wrote: *"Thanks for the tip about the
.syx file... I had totally missed that. It might be helpful to make a note about
how one should add the (optional) .syx files here too."*

He is right, and the omission was structural. The README's **What it needs**
section listed the three ROM images; the factory patches were explained two
sections further down under **The patches**. Somebody following the setup in
order therefore ends up with a working D-50 containing eight presets and no
reason to suspect a factory bank exists at all. Both facts were on the page --
their order made one of them invisible.

The ROM table now says it outright: those three images are the sound, the
sixty-four patches are a separate SysEx dump that goes in the same `roms/`
folder, it is optional, and there is a link to the section that explains it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)