### PR TITLE
The ramp clock was a factor of sqrt(2) too fast

### DIFF
--- a/instruments/PicoFaceD5/include/d5_engine/d5_env.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_env.h
@@ -64,15 +64,40 @@ inline constexpr uint8_t kEnvLaw[102] = {
     4, 4, 4, 4, 4, 3, 3, 3, 3, 3, 3, 3, 2, 2, 2, 2, 2,
     2, 2, 1, 1, 1, 1, 1, 1, 1, 1, 0, 0, 0, 0, 0, 0, 0};
 
-// The chip ramp's absolute clock: kRampClock * 2^(-idx/8) units per
-// second. munt's MT-32 derivation gives 64000 at 32 kHz; the D-50
-// references demand exactly sqrt(2) more -- four independent measurements
-// (Soundtrack's opening swell slope AND depth, Staccato's release,
-// Pizzagogo's body segment) converge on X*CLK = 33500 +/- 1800 with the
-// dB unit pinned at 0.376 by the swell's 28.4 dB over 75 steps, so the
-// clock carries the factor: 64000 * 2^(4/8). Equivalently the D-50 reads
-// the increment exponent as (k+28)/8 where the MT-32 uses (k+24)/8.
-inline constexpr float kRampClock = 90509.7f;
+// The chip ramp's absolute clock: kRampClock * 2^(-idx/8) units per second.
+// 64000 at 32 kHz, which is munt's derivation for the same chip in the MT-32.
+//
+// This carried 64000 * sqrt(2) = 90509.7 for months, on four measurements that
+// were all taken on played phrases with the patch's reverb in them (Soundtrack's
+// swell, Staccato's release, Pizzagogo's body). Two of those four were later
+// retracted for measuring something else entirely -- Horn Section's "release"
+// was a type-8 reverb tail, Stereo Polysynth's was its filter closing -- and
+// the sqrt(2) rested on the remainder.
+//
+// A dry single note settles it. The release is rate-constant by construction
+// (no law term, see below), so it is the one segment that measures this clock
+// directly, and with reverb and chorus at zero it is a straight line in dB:
+//
+//   Soundtrack, C5, dry:  -18.25 dB/s, and the fit moves by 0.1 % whether it
+//                         is taken over 10, 20 or 50 ms windows
+//   this engine at 64000: -18.16 dB/s   (0.6 % out)
+//   at 90509.7:           -25.65 dB/s   (40 % out)
+//
+// A second dry note, Choir at C5, agrees: -206 dB/s measured, -240 at 64000
+// (16 % out, inside that recording's own +/-18 % spread -- 0.2 s of stepped,
+// vibrato-ridden fall is a far weaker measurement) and -337 at 90509.7, which
+// is 64 % out and outside any reading of it.
+//
+// So the factor that fell out is exactly the one we put in. What remains open
+// is the last digit: Soundtrack says 64000, Choir on its own would say 56000,
+// and only a slow-release patch recorded dry on real hardware would separate
+// them. The source here is Roland's own software model, not the machine.
+//
+// Overridable so a calibration run can sweep it without editing the source.
+#ifndef D5_RAMP_CLOCK
+#define D5_RAMP_CLOCK 64000.0f
+#endif
+inline constexpr float kRampClock = D5_RAMP_CLOCK;
 
 inline float env_ramp_seconds(int dist_units, int idx) {
     if (dist_units <= 0) return 0.0f;


### PR DESCRIPTION
`kRampClock`: **90509.7 -> 64000**. This slows every envelope phase in the
instrument by 41 %, so it wants a listening test before merging.

## Why the old value existed, and why it was wrong

`64000 * sqrt(2)` came from four measurements, and every one was taken on a
**played phrase with the patch's own reverb in it**. Two were retracted later
for measuring something else entirely — Horn Section's "release" was a type-8
reverb tail, Stereo Polysynth's was its filter closing rather than its
amplitude. The factor rested on the remainder, and nobody could do better: a
phrase in a hall cannot show an envelope.

## What settles it

Five dry single notes from a D-50 software emulation (reverb and chorus at 0,
all C5) -- see the note on that reference below, because it carries less weight
than it first appears to. The release skips the time law — its distance lookup is computed and
then overwritten, dead code in the ROM — so it is **rate-constant**, which makes
it the one segment that measures this clock directly.

| dry reference | release byte | measured | ±  | at 64000 | at 90509.7 |
|---|---|---|---|---|---|
| Choir | 46 | −206.4 | 18 % | −233.8 → 13 % | −337 → 63 % |
| **Ethnic Session** | 49 | **−122.7** | 4 % | **−121.6 → 0.9 %** | — |
| Nylon Atmosphere | 56 | −60.0 | 5 % | −50.9 → 15 % | — |
| **Soundtrack** | 67 | **−18.25** | **0.1 %** | **−18.1 → 0.6 %** | −25.7 → 41 % |
| Intruder FX | 71 | −12.70 | 3.5 % | −10.5 → 17 % | −16.6 → 31 % |

Soundtrack is the anchor: a straight line over 1.8 s whose fit moves by 0.1 %
whether taken over 10, 20 or 50 ms windows, residual 0.05 dB.

**A sixth measurement, on a different code path, confirms it independently.**
Ethnic Session's held portion contains a wobble-free inner decay — a
distance-compensated segment, which runs through the **time law** rather than
the release. It is the cleanest measurement in the set: **−2.283 dB/s, 0.4 %
spread, 0.03 dB residual.** Against it, this engine lands 2.1 % out at 60000,
3.5 % out at 64000, and **15.6 % out at 90509.7**.

So the factor that fell out is exactly the factor we put in, and 64000 is what
munt derives independently for the same chip in the MT-32.

### On the reference, plainly

The dry notes were played on a copy of Roland's D-50 plug-in whose provenance is
not clean -- it came from a cracked distribution, which I did not notice until
afterwards. That has two consequences, and neither is "ignore the result":

- **It cannot serve as an authority.** "Roland's own model says so" is not an
  argument available here, and this PR does not make it. The plug-in's binary
  was not examined and nothing was taken from it; the recordings are
  observations of audio, nothing more.
- **The conclusion does not rest on it.** Three things do: munt's independent
  derivation of 64000 for the same chip in the MT-32; the inner-segment
  measurement above, which lands in the same place through a different code
  path; and the fact that the sqrt(2) it replaces rested on four reverb-laden
  phrase measurements, two of which had already been retracted for measuring
  the wrong thing.

What would settle it properly is a licensed copy, or better, three dry notes off
real hardware. Until then this constant is well-supported and not authoritative,
and the 13-17 % residual on two of the five patches is exactly the kind of
question a proper reference would answer.

## What is left over, and what was retracted along the way

**Two of the five match within 1 %; three sit 13–17 % out, in both
directions.** Choir's 13 % is inside its own ±18 %, so it is consistent; Nylon
Atmosphere (15 % against ±5 %) and Intruder FX (17 % against ±3.5 %) are real
discrepancies. There is no ordering by release byte (49 ✓, 56 ✗, 67 ✓, 71 ✗)
and none by partial type — of the two that match, one sounds through a PCM
partial and one through synth partials. **I have no explanation and am not
offering a guess**, and with the reference as it stands I would not trust one
either.

For the record, three claims made during this investigation and then withdrawn:

- that the implied clock rises with the release byte. It does not; the fourth
  and fifth measurements broke the pattern, which rested on Choir — the least
  reliable point of the set.
- that the TVF slams shut in one sample. It does not: `build_tvf_env` never
  sets the envelope's levels (those come from the byte mapping), so a probe
  that called it on a fresh spec read struct defaults. Ethnic Session's TVF
  sustain byte is 0, so its filter is already closed before the key is
  released.
- that the `r[4] *= 3.0f` in the PCM branch was to blame. `Voice::note_on`
  overwrites `pcm_env` with the firmware-built envelope on every note, so that
  factor is dead code on the bank path — it only reaches the eight fallback
  presets. Its comment does still cite the retracted Stereo Polysynth anchor,
  and should be tidied up separately.

A fourth: a "4x too fast" reading on Ethnic Session that turned out to be my
own measurement. Its release ends after 0.219 s and I had fitted a fixed 0.44 s
window, so half of it was silence. Measured consistently — a fixed dB drop from
note-off, never a fixed time — it matches to 0.9 %.

## Verification, all 384 patches

| | result |
|---|---|
| `tune2` | **331/384**, up from 329 |
| `stress` | 0 NaN/Inf |
| `legato` | 0 NaN |
| `click2` | unchanged at 2 flags, both documented — **this is the one that would catch a broken release** |
| `seqclick` | **10 → 16** (see below) |
| `lfo` / `bend` / `glide` / `press` | unchanged, all passing |

**On seqclick.** The six additions are note-on jumps at about 3× the baseline,
6 of 7 on sawtooth-carrying patches — the same class as the flags already
accepted as real waveform edges (a sawtooth phase reset is a one-sample
discontinuity, on the real chip too). With releases 41 % longer, more voices are
still ringing when the next note resets its sawtooth, so the same edge lands on
a louder sum. **No new note-off flag appeared.** I have not individually
isolated all six.

## Audible consequences

Attacks softer, decays and releases longer, across all 384 patches. Tails grow
up to 30 % — Spacious Sweep 5.15 → 6.70 s — so more voices overlap and the CPU
governor trims more often. Firmware size unchanged: flash 905,760 B, RAM
270,516 B.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
