### PR TITLE
The panel is 50.4 mm wide, not 50.8

### DIFF
--- a/hardware/README.md
+++ b/hardware/README.md
@@ -23,6 +23,13 @@ mechanical rather than cosmetic: the EC11 encoders have a 5 mm threaded bushing,
 and 1.6 mm of panel leaves 3.4 mm for the nut. A 2 mm panel leaves 3.0 mm, which
 works but has no margin.
 
+**Cut it to 50.4 mm, not 50.8.** 10 HP is 10 x 5.08 mm, and that nominal figure
+is the space the module occupies in the rack, not the width of the metal. A panel
+made to it has no room for the tolerances of its own edge, of its neighbours, or
+of the rails, and a full row will bind rather than sit flat. Roughly 0.4 mm under
+is the usual allowance. The height is not affected: 128.5 mm is already the
+Eurorack panel height, 3U less the clearance the rails need.
+
 The layout is [Panel/panel_10hp.svg](Panel/panel_10hp.svg) (CorelDRAW source
 next to it), measured against the real parts: the display on top, the SELECT
 encoder between the RUN and BOOT buttons, PARAM A and B in a second row, the


### PR DESCRIPTION
One paragraph in `hardware/README.md`, caught while reading the drawing back
before ordering — the last moment it is free.

## What was wrong

The panel width was given as **50.8 mm**, which is 10 x 5.08 mm. That is the
space the module occupies in a rack, not the width of the metal. A panel made to
the nominal figure has nowhere to put the tolerances of its own edge, of its
neighbours, or of the rails, so a full row binds instead of sitting flat.

**Cut it to 50.4 mm.** About 0.4 mm under nominal is the usual allowance.

The height needs no such correction and the file now says so: 128.5 mm is already
the Eurorack *panel* height, with the rail clearance taken off the 3U figure long
before this project.

Nothing else changes — the hole positions, the boards and the Gerbers are all
unaffected, since the panel outline is the only dimension involved.
