### PR TITLE
The top side of the panel is the front

### DIFF
--- a/hardware/README.md
+++ b/hardware/README.md
@@ -138,10 +138,11 @@ unpatched module. Checked rather than eyeballed: no silkscreen stroke falls
 within 0.3 mm of any opening or the board edge, and none of it disappears under
 a 15 mm knob or an 11 mm jack nut.
 
-**The F side is the face.** Silkscreen sits on `F.SilkS` and is not mirrored, so
-whichever side the fab prints as top is the side that faces the player. Worth
-saying to them explicitly when ordering, because a panel has no components to
-make the intent obvious. White on black is the usual choice.
+**The top side is the front.** Decided, and the board file is drawn to it: the
+legend sits on `F.SilkS` unmirrored, so the side the fab prints as top is the
+side that faces the player. Say it in the order anyway — a panel has no
+components to make the intent obvious, and a fab that guesses has a fifty-fifty
+chance of printing the legend on the inside. White on black is the usual choice.
 
 DRC reports six warnings and nothing else: the six hole footprints are generated
 in the board file rather than pulled from a library, so the library-parity check


### PR DESCRIPTION
Wording only, no geometry.

`hardware/README.md` had the front face down as something to decide before
ordering. It is decided: **top is the front**. The board file was already drawn
to it — the legend sits on `F.SilkS` unmirrored, and the fabrication note on
`Cmts.User` says "F side is the visible face" — so nothing moves and the
Gerbers are unchanged.

The paragraph still says to state it in the order, because that part does not
go away: a panel carries no components to make the intent obvious, and a fab
left to guess has even odds of printing the legend on the inside.