### PR TITLE
Configure the two MIDI pads for the DIN circuit

### DIFF
--- a/core/include/midi_serial.h
+++ b/core/include/midi_serial.h
@@ -27,7 +27,8 @@ public:
     using SysExCallback = void (*)(const uint8_t*, uint16_t);
     using ActivityCallback = void (*)(void);
 
-    void init();     // uart1 at 31250 baud 8N1 on PIN_MIDI_RX / PIN_MIDI_TX, RX interrupt enabled
+    void init();     // uart1 at 31250 baud 8N1 on PIN_MIDI_RX / PIN_MIDI_TX, pads set for the
+                     // DIN circuit, RX interrupt enabled
     void process();  // drain the ring and dispatch; call from the same place as MIDIInputUSB::process()
 
     // --- transmit ---

--- a/core/src/midi_serial.cpp
+++ b/core/src/midi_serial.cpp
@@ -55,6 +55,23 @@ void MIDISerial::init()
     uart_init(MIDI_UART, kMidiBaud);
     gpio_set_function(PIN_MIDI_TX, GPIO_FUNC_UART);
     gpio_set_function(PIN_MIDI_RX, GPIO_FUNC_UART);
+
+    // Two pad settings the function select does not make -- it deliberately
+    // leaves the pad controls alone -- and that hardware/README.md asks of the
+    // firmware by name, because neither is visible from the schematic.
+    //
+    // RX: the RP2350 comes out of reset with its internal pull-down enabled on
+    // every GPIO (PADS_BANK0 reset value 0x116, PDE=1), and that would divide
+    // the 4k7 pull-up the H11L1's open collector and the bus MIDI RX share.
+    gpio_disable_pulls(PIN_MIDI_RX);
+
+    // TX: MIDI out is a current loop, and the pads come up at 4 mA (DRIVE_RESET
+    // = DRIVE_VALUE_4MA). The 33R/33R output pair puts about 4.1 mA worst case
+    // through the pin, more in the typical case -- at or over what the default
+    // is rated for, so VOL climbs and the loop current falls by an amount that
+    // depends on the part and the temperature.
+    gpio_set_drive_strength(PIN_MIDI_TX, GPIO_DRIVE_STRENGTH_12MA);
+
     uart_set_hw_flow(MIDI_UART, false, false);
     uart_set_format(MIDI_UART, 8, 1, UART_PARITY_NONE);
     uart_set_fifo_enabled(MIDI_UART, true);

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -348,13 +348,14 @@ Still needed:
   4k7 rather than the usual few hundred ohms because the bus MIDI RX joins the
   same node through a diode: every module then loads the hub's driver with
   only ~0.6 mA, ten of them with ~6 mA, and the low level at the module stays
-  around 0.5 V. Firmware should call `gpio_disable_pulls(PIN_MIDI_RX)` — the
+  around 0.5 V. The firmware calls `gpio_disable_pulls(PIN_MIDI_RX)` — the
   pad's default pull-down would otherwise divide that pull-up. Out: 33R from
   3V3 to pin 4, 33R from TX to pin 5, sleeve grounded. CA-033's pair is
   33R/10R; 33/33 gives about 4.1 mA worst case into a standard receiver, the
-  same class as the 47/47 the Teensy design ships with. The firmware should
-  raise GP4's drive strength to 12 mA — the default 4 mA is below the loop
-  current.
+  same class as the 47/47 the Teensy design ships with. The firmware raises
+  GP4's drive strength to 12 mA — the default 4 mA is below the loop current.
+  Both settings are made in `MIDISerial::init()`; neither is visible from the
+  schematic, which is why they are written down on both sides.
 
 ## The main board layout
 


### PR DESCRIPTION
Two pad settings the MIDI init never made. `hardware/README.md` has asked for
both by name since the schematic was drawn — the firmware just never caught up,
and `gpio_set_function` does not make them on its own. The SDK says so in as
many words: *"this doesn't affect e.g. pullup/pulldown, as these are in pad
controls"*.

## RX — the internal pull-down is on

Every RP2350 GPIO comes out of reset with its pull-down enabled:
`PADS_BANK0_GPIO0_RESET = 0x116`, `PDE_RESET = 0x1`. On `PIN_MIDI_RX` that sits
under the 4k7 pull-up (R2) that the H11L1's open-collector output needs, and
which the bus MIDI RX also shares through the BAT85. It still reads as a one —
this was never a fault — but it divides a pull-up chosen deliberately weak, and
the README already said not to.

```c
gpio_disable_pulls(PIN_MIDI_RX);
```

## TX — 4 mA is under the loop current

The pads come up at 4 mA nominal drive (`DRIVE_RESET = DRIVE_VALUE_4MA`). The
3.3 V output pair is 33R a side (R3/R4), which the README puts at about 4.1 mA
worst case into a standard receiver — at or over what the default setting is
rated for. VOL climbs, the loop current falls, and how far depends on the part
and the temperature.

```c
gpio_set_drive_strength(PIN_MIDI_TX, GPIO_DRIVE_STRENGTH_12MA);
```

## Two notes on the request as it came in

- It is `gpio_disable_pulls`, not `pio_disable_pulls`: DIN MIDI is on **uart1**,
  not on PIO. There is no `pio_disable_pulls` in the SDK.
- The constant is `GPIO_DRIVE_STRENGTH_12MA`.

## Checked

Built `PicoFaceSM` and disassembled `MIDISerial::init()` — both calls are in
the image (`gpio_disable_pulls` inlines to `gpio_set_pulls`):

```
1000752e:  bl  gpio_set_function
10007536:  bl  gpio_set_function
10007540:  bl  gpio_set_pulls
10007548:  bl  gpio_set_drive_strength
```

This is in `core`, so it lands in all ten instruments. Nothing to hear — it
shows up on a scope or on a long cable, not in the audio.