### PR TITLE
Credit the JV's reference emulator where people actually look

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,13 +212,31 @@ built on. Where an instrument derives from someone else's work:
 | PicoFaceYC | [OpenB3 / BeatrixCPP](https://github.com/pantherb/setBfree) - tone generation *concepts* only, no code | AGPL-3.0 upstream, does not reach here; see below |
 | PicoFaceCP | [mda-EPiano](https://sourceforge.net/projects/mda-vst/) (engine, in tree) | GPL-3.0-or-later |
 | PicoFaceDX | an ESP32 reface DX emulation (engine) | see that project |
-| PicoFaceRD | [giulioz/rdpiano](https://github.com/giulioz/rdpiano) + MAME (reference emulator, host side only) | GPL |
+| PicoFaceRD | [giulioz/rdpiano](https://github.com/giulioz/rdpiano) + MAME (reference emulator; in the tree, kept out of the image) | GPL |
 | PicoFaceJ6 | [junox](https://github.com/dzannotti/junox) (patch table, parameter scaling) | GPL-3 |
 | PicoFaceMD | [BelaMiniMoogEmulation](https://github.com/lbros96/BelaMiniMoogEmulation) (ladder filter) | stated by its author to be under no copyright |
 | PicoFaceSM | [string-machine](https://github.com/jpcima/string-machine) (DSP models) | Boost Software License 1.0 |
 | PicoFaceOB | [OB-Xf](https://github.com/surge-synthesizer/OB-Xf) (engine) | GPL-3.0-or-later |
-| PicoFaceJV | own work, over the machine's own PCM data | - |
+| PicoFaceJV | own engine over the machine's own PCM data, measured against [giulioz/jv880_juce](https://github.com/giulioz/jv880_juce) (host-side reference; tone field layout) | non-commercial; not vendored, see below |
 | PicoFaceD5 | [munt](https://github.com/munt/munt) - the LA32's wave generation and the Boss reverb topology as that project *documents* them, no code | LGPL-2.1-or-later upstream, does not reach here; see below |
+
+Two rows in that table need a sentence more than a table cell holds.
+
+**PicoFaceRD** carries the reference emulator's sources in the tree
+(`instruments/PicoFaceRD/src/rd_engine/mcu.cpp`, `sound_chip.cpp` and their
+headers, each with the derivation in its SPDX block). They are there as the A/B
+ground truth every engine change is checked against, not to run: the device
+plays `RdNewEngine`, and no `Mcu` or `SoundChip` symbol survives into the linked
+image.
+
+**PicoFaceJV** contains none of that emulator's code, and cannot: its licence
+forbids commercial use and fits neither MIT nor GPL-3. It was used as a host-side
+measuring instrument — the harness in `tools/jv_extract/` drives it to take the
+readings the engine was calibrated against, and the patch and tone field layout
+comes from its `dataStructures.h`. The engine itself is written from the ROM
+formats. `tools/jv_extract/README.md` records the reasoning; the work is Giulio
+Zausa's, and his emulator in turn derives from [NukeYKT's
+Nuked-SC55](https://github.com/nukeykt/Nuked-SC55).
 
 `instruments/PicoFaceOB/` additionally carries its own `LICENSE`, identical in
 text, because that instrument's engine is a direct port of OB-Xf and its files

--- a/instruments/PicoFaceJV/README.md
+++ b/instruments/PicoFaceJV/README.md
@@ -194,9 +194,22 @@ plus `--set tone:offset:value` to patch tone bytes before the note (mirroring
 `jv_probe`'s `#base` lines, so both sides can be driven identically) and
 `--trim <ratio>` for a global pitch trim.
 
+## Credit
+
+The engine is written from the ROM formats, but it was not written blind. The
+patch and tone field layout comes from `Source/dataStructures.h` in
+[giulioz/jv880_juce](https://github.com/giulioz/jv880_juce) by **Giulio Zausa**,
+and that project's emulator — itself derived from [NukeYKT's
+Nuked-SC55](https://github.com/nukeykt/Nuked-SC55) — is the reference every
+calibration here was measured against: the sweeps in `tools/jv_extract/` drive
+it and read the answers back off it. The identification of the effect chip, and
+with it the reason its reverb could not be measured, comes from the same
+author's [giulioz/roland-dsps](https://github.com/giulioz/roland-dsps).
+
 ## Licence
 
 The engine is original code and carries the repository's licence. It contains no
-emulator code: the reference emulator used to measure against is host-side only
-and is never vendored here — see the licence note in
-[tools/jv_extract/README.md](../../tools/jv_extract/README.md).
+emulator code, and cannot: that emulator's licence forbids commercial use and is
+compatible with neither MIT nor GPL-3, so it is not vendored, not built, and
+reaches no firmware image — it is a host-side measuring instrument. The full
+reasoning is in [tools/jv_extract/README.md](../../tools/jv_extract/README.md).


### PR DESCRIPTION
The attribution for PicoFaceJV was complete but in the wrong place.

`tools/jv_extract/README.md` has always carried it: **Giulio Zausa**,
[giulioz/jv880_juce](https://github.com/giulioz/jv880_juce), its descent from
[Nuked-SC55](https://github.com/nukeykt/Nuked-SC55),
[giulioz/roland-dsps](https://github.com/giulioz/roland-dsps) for the effect
chip, and the reasoning for why none of it is vendored — that emulator's licence
forbids commercial use and fits neither MIT nor GPL-3.

But that is a tools README a thousand lines deep. The attribution table in the
root README — which is where anyone actually checks — had this:

| Part | Upstream it derives from | That upstream's license |
|---|---|---|
| PicoFaceJV | own work, over the machine's own PCM data | - |

The engine *is* own work. It is written from the ROM formats, it contains no
emulator code, and it cannot contain any. But it was measured against his
emulator throughout, and its patch and tone field layout comes from that
project's `dataStructures.h`. A credits table that says "own work — " and
stops there is wrong, however carefully the detail is recorded elsewhere.

## What changes

- The **JV row** names jv880_juce as the host-side reference and the source of
  the field layout, with its licence.
- A **Credit** section in `instruments/PicoFaceJV/README.md`, which previously
  said "the reference emulator" without naming whose it was.
- Two paragraphs under the table for the detail a table cell cannot hold.

## The RD row too

It read "reference emulator, host side only". True of what runs, misleading
about what is in the tree — the rdpiano-derived sources *are* in
`instruments/PicoFaceRD/src/rd_engine/` (with the derivation in each SPDX
block), they are in the firmware's SOURCES, and they compile. What keeps them
out is the linker: no `Mcu` or `SoundChip` symbol survives into
`PicoFaceRD.elf`, which carries `RdNewEngine` instead.

Better to say all of that than half of it. Someone checking the claim will find
the object files before they find the stripped image, and a README that only
mentions the second half reads like it is hiding the first.

Documentation only.