### PR TITLE
Show the build's real version, not 0.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -37,6 +37,10 @@ jobs:
         uses: actions/checkout@v6
         with:
           submodules: recursive
+          # Full history and tags: the firmware version comes from git describe,
+          # and a shallow clone has nothing to describe against. A release build
+          # would show a bare commit hash instead of its own version number.
+          fetch-depth: 0
 
       # The Ubuntu apt package gcc-arm-none-eabi ships an incomplete libstdc++
       # (missing headers such as <cstring>) and breaks this C++ build.

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,39 @@ set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
 list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake)
 
+# The version every instrument shows on its splash, taken from the repository
+# rather than declared. It used to be a per-instrument "0.1" that no release
+# ever moved, which made a screenshot in a bug report worthless: it named no
+# build.
+#
+# git describe gives exactly what is wanted. On a release tag it is the release
+# ("1.7.0"); anywhere else it says how far past it and which commit
+# ("1.7.0-4-ga39504b"); a build with uncommitted changes gets a trailing "+".
+# Sixteen or seventeen characters, and the splash font fits twenty-one.
+set(PICOFACE_VERSION "unknown")
+find_package(Git QUIET)
+if(GIT_FOUND AND EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git)
+    execute_process(
+        COMMAND ${GIT_EXECUTABLE} describe --tags --always --dirty=+
+        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+        OUTPUT_VARIABLE _pf_git_version
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+        RESULT_VARIABLE _pf_git_rc)
+    if(_pf_git_rc EQUAL 0 AND _pf_git_version)
+        string(REGEX REPLACE "^v" "" PICOFACE_VERSION "${_pf_git_version}")
+    endif()
+    # Reconfigure when the commit moves, or the string goes stale in a tree
+    # that is only ever rebuilt -- which is the workflow this exists to serve.
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+                 ${CMAKE_CURRENT_SOURCE_DIR}/.git/HEAD)
+    if(EXISTS ${CMAKE_CURRENT_SOURCE_DIR}/.git/packed-refs)
+        set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+                     ${CMAKE_CURRENT_SOURCE_DIR}/.git/packed-refs)
+    endif()
+endif()
+message(STATUS "PicoFace version: ${PICOFACE_VERSION}")
+
 # Fallback only: an unconditional set() would silently override both -D on the
 # command line and the environment variable.
 if(NOT DEFINED PICO_EXTRAS_PATH AND NOT DEFINED ENV{PICO_EXTRAS_PATH})

--- a/README.md
+++ b/README.md
@@ -119,6 +119,16 @@ cmake --build build
 
 The artifacts are then in `build/<instrument>.uf2`.
 
+**The splash screen names the build.** Every instrument shows a version taken
+from `git describe`, not a number typed into its `instrument.cmake`: on a
+release tag it is the release (`1.7.0`), anywhere else it says how far past that
+tag and from which commit (`1.7.0-4-ga39504b`), and a trailing `+` means the
+tree had uncommitted changes when it was built. The About page shows the same
+string. Quote it in a bug report and the image is identified exactly; the
+version used to read `0.1` in every build ever made, which identified nothing.
+
+A tarball without `.git` builds fine and shows `unknown`.
+
 Building a single instrument:
 
 ```bash

--- a/cmake/PicoFaceInstrument.cmake
+++ b/cmake/PicoFaceInstrument.cmake
@@ -32,8 +32,11 @@ function(picoface_add_instrument)
     if(NOT PF_PROGRAM_NAME)
         set(PF_PROGRAM_NAME "${PF_NAME}")
     endif()
+    # Instruments do not declare this: it is the repository's version, derived
+    # from git in the top-level CMakeLists so the splash names the build. An
+    # explicit VERSION argument still wins, for anything that needs its own.
     if(NOT PF_VERSION)
-        set(PF_VERSION "0.1")
+        set(PF_VERSION "${PICOFACE_VERSION}")
     endif()
     if(NOT PF_DIR)
         set(PF_DIR "${CMAKE_CURRENT_SOURCE_DIR}")

--- a/instruments/PicoFaceCP/instrument.cmake
+++ b/instruments/PicoFaceCP/instrument.cmake
@@ -7,7 +7,6 @@
 picoface_add_instrument(
     NAME PicoFaceCP
     PROGRAM_NAME "PicoFaceCP"
-    VERSION "0.1"
     USB_PID 0x1051
     DIR ${PICOFACE_CURRENT_INSTRUMENT_DIR}
 

--- a/instruments/PicoFaceCP/src/CP_Ui.cpp
+++ b/instruments/PicoFaceCP/src/CP_Ui.cpp
@@ -558,7 +558,12 @@ void CP_Ui::drawAbout(Display& d) const
     u8g2_DrawStr(u, 4, 14, "ABOUT");
     u8g2_DrawHLine(u, 0, 18, Display::kWidth);
     u8g2_DrawStr(u, 4, 36, kAboutName);
+    // Smaller than the name above it: the version is a git describe now, and
+    // "1.7.0-4-ga39504b" needs seventeen characters. At 8 px this line holds
+    // fifteen, and a clipped commit hash still reads like a whole one.
+    u8g2_SetFont(u, u8g2_font_6x10_tf);
     u8g2_DrawStr(u, 4, 52, kAboutVersion);
+    u8g2_SetFont(u, u8g2_font_8x13B_tf);
 
     u8g2_SetFont(u, u8g2_font_6x10_tf);
     if (cp_ipc_dropped != 0) {

--- a/instruments/PicoFaceD5/instrument.cmake
+++ b/instruments/PicoFaceD5/instrument.cmake
@@ -113,7 +113,6 @@ endif()
 picoface_add_instrument(
     NAME PicoFaceD5
     PROGRAM_NAME "PicoFaceD5"
-    VERSION "0.1"
     USB_PID 0x1059
     DIR ${_d5_dir}
 

--- a/instruments/PicoFaceDX/instrument.cmake
+++ b/instruments/PicoFaceDX/instrument.cmake
@@ -43,7 +43,6 @@ endif()
 picoface_add_instrument(
     NAME PicoFaceDX
     PROGRAM_NAME "PicoFaceDX"
-    VERSION "0.1"
     USB_PID ${_dx_usb_pid}
     DIR ${PICOFACE_CURRENT_INSTRUMENT_DIR}
 

--- a/instruments/PicoFaceDX/src/DX_Ui.cpp
+++ b/instruments/PicoFaceDX/src/DX_Ui.cpp
@@ -259,7 +259,12 @@ void DX_Ui::drawAbout(Display& d) const
     u8g2_DrawStr(u, 4, 14, "ABOUT");
     u8g2_DrawHLine(u, 0, 18, 128);
     u8g2_DrawStr(u, 4, 36, kAboutName);
+    // Smaller than the name above it: the version is a git describe now, and
+    // "1.7.0-4-ga39504b" needs seventeen characters. At 8 px this line holds
+    // fifteen, and a clipped commit hash still reads like a whole one.
+    u8g2_SetFont(u, u8g2_font_6x10_tf);
     u8g2_DrawStr(u, 4, 52, kAboutVersion);
+    u8g2_SetFont(u, u8g2_font_8x13B_tf);
     u8g2_SetFont(u, u8g2_font_6x10_tf);
     u8g2_DrawStr(u, 4, 62, "Press any button");
 }

--- a/instruments/PicoFaceJ6/instrument.cmake
+++ b/instruments/PicoFaceJ6/instrument.cmake
@@ -3,7 +3,6 @@
 picoface_add_instrument(
     NAME PicoFaceJ6
     PROGRAM_NAME "PicoFaceJ6"
-    VERSION "0.1"
     USB_PID 0x1053
     DIR ${PICOFACE_CURRENT_INSTRUMENT_DIR}
     SOURCES

--- a/instruments/PicoFaceJV/instrument.cmake
+++ b/instruments/PicoFaceJV/instrument.cmake
@@ -72,7 +72,6 @@ endif()
 picoface_add_instrument(
     NAME PicoFaceJV
     PROGRAM_NAME "PicoFaceJV"
-    VERSION "0.1"
     USB_PID 0x1058
     DIR ${_jv_dir}
 

--- a/instruments/PicoFaceMD/instrument.cmake
+++ b/instruments/PicoFaceMD/instrument.cmake
@@ -12,7 +12,6 @@ picoface_add_instrument(
     # ---- Identity -------------------------------------------------------
     NAME PicoFaceMD             # unique instrument ID (targets, build folders)
     PROGRAM_NAME "PicoFaceMD"   # program string shown on the display
-    VERSION "0.1"               # instrument firmware version string
     USB_PID 0x1054              # USB Product ID (must be unique per instrument!)
 
     # ---- Location -------------------------------------------------------

--- a/instruments/PicoFaceOB/instrument.cmake
+++ b/instruments/PicoFaceOB/instrument.cmake
@@ -13,7 +13,6 @@
 picoface_add_instrument(
     NAME PicoFaceOB
     PROGRAM_NAME "PicoFaceOB"
-    VERSION "0.1"
     USB_PID 0x1056
     DIR ${PICOFACE_CURRENT_INSTRUMENT_DIR}
 

--- a/instruments/PicoFaceOB/src/OB_Ui.cpp
+++ b/instruments/PicoFaceOB/src/OB_Ui.cpp
@@ -376,7 +376,12 @@ void OB_Ui::drawAbout(Display& d) const
     u8g2_DrawStr(u, 4, 14, "ABOUT");
     u8g2_DrawHLine(u, 0, 18, Display::kWidth);
     u8g2_DrawStr(u, 4, 33, kAboutName);
+    // Smaller than the name above it: the version is a git describe now, and
+    // "1.7.0-4-ga39504b" needs seventeen characters. At 8 px this line holds
+    // fifteen, and a clipped commit hash still reads like a whole one.
+    u8g2_SetFont(u, u8g2_font_6x10_tf);
     u8g2_DrawStr(u, 4, 48, kAboutVersion);
+    u8g2_SetFont(u, u8g2_font_8x13B_tf);
     u8g2_SetFont(u, u8g2_font_6x10_tf);
     // The GPL notice belongs on the instrument, not just in the repository.
     u8g2_DrawStr(u, 4, 62, "OB-Xf engine, GPL3");

--- a/instruments/PicoFaceRD/instrument.cmake
+++ b/instruments/PicoFaceRD/instrument.cmake
@@ -99,7 +99,6 @@ message(STATUS "PicoFaceRD: ${_rd_pk_out}")
 picoface_add_instrument(
     NAME PicoFaceRD
     PROGRAM_NAME "PicoFaceRD"
-    VERSION "0.1"
     USB_PID 0x1052
     DIR ${_rd_dir}
 

--- a/instruments/PicoFaceSM/instrument.cmake
+++ b/instruments/PicoFaceSM/instrument.cmake
@@ -3,7 +3,6 @@
 picoface_add_instrument(
     NAME PicoFaceSM
     PROGRAM_NAME "PicoFaceSM"
-    VERSION "0.1"
     USB_PID 0x1055
     DIR ${PICOFACE_CURRENT_INSTRUMENT_DIR}
     SOURCES

--- a/instruments/PicoFaceYC/instrument.cmake
+++ b/instruments/PicoFaceYC/instrument.cmake
@@ -17,7 +17,6 @@
 picoface_add_instrument(
     NAME PicoFaceYC
     PROGRAM_NAME "PicoFaceYC"
-    VERSION "0.1"
     USB_PID 0x1050
     DIR ${PICOFACE_CURRENT_INSTRUMENT_DIR}
 

--- a/instruments/PicoFaceYC/src/YC_Ui.cpp
+++ b/instruments/PicoFaceYC/src/YC_Ui.cpp
@@ -181,7 +181,12 @@ void YC_Ui::drawAbout(Display& d) const
     u8g2_DrawStr(u, 4, 14, "ABOUT");
     u8g2_DrawHLine(u, 0, 18, 128);
     u8g2_DrawStr(u, 4, 36, kAboutName);
+    // Smaller than the name above it: the version is a git describe now, and
+    // "1.7.0-4-ga39504b" needs seventeen characters. At 8 px this line holds
+    // fifteen, and a clipped commit hash still reads like a whole one.
+    u8g2_SetFont(u, u8g2_font_6x10_tf);
     u8g2_DrawStr(u, 4, 52, kAboutVersion);
+    u8g2_SetFont(u, u8g2_font_8x13B_tf);
     u8g2_SetFont(u, u8g2_font_6x10_tf);
     u8g2_DrawStr(u, 4, 62, "Press any button");
 }


### PR DESCRIPTION
Every instrument declared `VERSION "0.1"` in its `instrument.cmake`, and no
release ever moved it. The splash screen and the About page therefore named no
build at all — the same string has been on every image since the first one, so a
photograph in a bug report identified nothing.

## What it shows now

`git describe`, derived once in the top-level `CMakeLists.txt`. Instruments no
longer declare a version.

| Where the build is | What it shows |
|---|---|
| on a release tag | `1.7.0` |
| four commits past it | `1.7.0-4-ga39504b` |
| with uncommitted changes | `1.7.0-4-ga39504b+` |
| no `.git` at all (tarball) | `unknown` |

An explicit `VERSION` argument to `picoface_add_instrument` still wins, for
anything that ever needs its own.

## Two things it needed beyond the obvious

**CI checked out shallow and without tags.** `git describe --tags` would have had
nothing to describe against, so a release build — the one case where the number
matters most — would have shown a bare commit hash. Now `fetch-depth: 0`.

**The About page would have clipped it.** It draws in `u8g2_font_8x13B_tf` from
x=4, which holds fifteen characters; the string is seventeen. A truncated commit
hash still reads like a whole one, which is worse than showing none. That one
line is `6x10` now — the instrument name above it is unchanged. The splash was
already `6x10` and centred, so twenty-one characters fit there.

## Checked

Built `YC`, `DX`, `CP`, `OB`, `SM`, `J6`, `MD` and `RD` — all clean, and the
string `1.7.0-4-ga39504b+` is in every image. The `+` is this working tree being
dirty while I built them, which is exactly the case it exists to flag.

Also reconfigures when `HEAD` or `packed-refs` move, so the string does not go
stale in a tree that is only ever rebuilt — which is the workflow this exists to
serve.