### PR TITLE
Start reading the MKS-20 firmware

### DIFF
--- a/tools/rd_extract/RD_FIRMWARE.md
+++ b/tools/rd_extract/RD_FIRMWARE.md
@@ -1,0 +1,107 @@
+# Reading the MKS-20 firmware
+
+Notes from disassembling the 8 KB program ROM, kept because the question they
+answer keeps coming back: **are the note descriptors in the ROM, so the packs
+could be built without running an emulator?**
+
+Short answer: the *inputs* are, the descriptors are not. The firmware
+interpolates them. What follows is how far that has been read.
+
+Tooling is [`rd_dasm.py`](rd_dasm.py). Its opcode table is lifted from the
+reference emulator's own dispatch table, so the mnemonics are the ones that
+emulator implements rather than a second-hand listing.
+
+```bash
+RDPIANO=~/rdpiano ./rd_make_rom.sh <romdir> /tmp/rd.blob     # also writes the program ROM
+./rd_dasm.py ~/rdpiano/librdpiano/src/mcu.cpp /tmp/program.bin sweep
+```
+
+## The memory map, from the emulator
+
+| Range | What |
+|---|---|
+| `$0000`–`$001f` | MCU registers (ports, timer) |
+| `$0020`–`$0fff` | RAM |
+| `$1000`–`$1fff` | **the sound chip** — writes go straight to it |
+| `$4000`–`$bfff` | **the parameter ROM**, banked by a latch (2 bits) |
+| `$c000`–`$ffff` | program ROM, 8 KB mirrored twice; the firmware runs in the `$e000` copy |
+
+Vectors: `RESET=$e00f`, `ICF=$e121`, **`IRQ1=$ed1a`**.
+
+## The sound chip interrupt is where the descriptors come from
+
+`IRQ1` fires when a voice part finishes an envelope segment, and the handler
+programs the next one. That is exactly the event the capture records, so this
+routine *is* the descriptor generator.
+
+```
+ed1b  ldb $1000      ; the chip says which voice and part
+ed20  andb #$f0      ;   high nibble = voice
+ed27  andb #$0f      ;   low nibble  = part
+ed2c  mul #$06       ; six bytes of state each
+ed2d  addd #$0200    ;   at $0200 + (voice*16 + part) * 6
+ed37  ldx $02,x      ; a POINTER, held in that state
+ed39  beq  ...       ;   null: the part is finished
+ed4f  addd #$0006    ; advance it by six
+ed54  std $02,x      ; and store it back
+```
+
+So each part walks a **list of six-byte entries**, one entry per envelope
+segment. That stride is why searching the parameter ROM for the captured
+`(dest, speed)` byte pairs finds nothing — wrong shape, and wrong values.
+
+## The six bytes are the corners of a bilinear interpolation
+
+```
+ed61  lda $d1        ; weight from the key
+ed65  ldb $03,x      ;   corner 3  *  d1
+ed6d  ldb $01,x      ;   corner 1  * (256-d1)
+ed70  addd $b7       ;   -> intermediate
+ed73  lda $d2        ; weight from the velocity
+ed77  ldb $02,x      ;   corner 2  *  d2
+ed7f  ldb $00,x      ;   corner 0  * (256-d2)
+ed85  ldx $d7        ; the chip register for this voice
+ed87  std $04,x      ; write the pair
+```
+
+Four corner values per entry, two weights, one 16-bit write. The captured
+`dest` and `speed` are the *interpolated* values; the ROM holds the corners.
+
+This accounts for every oddity the packs show:
+
+- **Nothing matches a byte search.** The outputs are interpolates.
+- **The velocity layers differ by a constant additive offset** (+28, +14, +3
+  between 40/80/110/127 on patch 0). A linear blend does exactly that, and the
+  chip's levels are logarithmic, so a blend is a gain.
+- **Neighbouring notes are byte-identical**, timestamps included: they land on
+  the same key weight. Only 24 distinct wave assignments across 88 keys, and
+  27 % of all 5632 captured entries are distinct.
+
+The `$d1` key weight is built at `ed43`–`ed4a` from a table indexed by the
+voice's high nibble; `$d2` comes in from the note-on path, which is not read
+yet.
+
+## What is still missing
+
+- **The note-on path**: what sets `$02,x` (the list pointer), `$d1` and `$d2`.
+  That is where the parameter ROM is actually indexed, and it is the piece that
+  turns this into a parser.
+- **Bytes 4 and 5** of each entry. The pointer advances by six and only four
+  are consumed here.
+- **Where the timestamps come from.** They are not in the ROM at all: a
+  segment's duration is however long the chip takes to ramp from the previous
+  destination to this one, which is why two notes with the same chain have the
+  same timing. `RdNewEngine` already computes that arithmetic, so the packs
+  could drop the timestamps entirely -- 3.17 MB would become roughly 0.5 MB
+  with the duplicates removed as well.
+
+Only three parameter-ROM reads in the whole firmware use a fixed address
+(`$babf`, `$bbc1`, `$babd`); everything else is indexed, so the note-on path
+has to be read to find the tables rather than grepped for.
+
+## Why this matters
+
+If the note-on path yields to the same treatment, the packs become a pure
+function of the ROM set: no emulator, no second checkout, no risk of a stale
+reference quietly producing a different-sounding instrument. That is the whole
+point of chasing it.

--- a/tools/rd_extract/rd_dasm.py
+++ b/tools/rd_extract/rd_dasm.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Michi71
+"""HD6301 disassembler for the MKS-20 / MK-80 program ROM.
+
+    rd_dasm.py <mcu.cpp> <program.bin> [sweep | <addr> [count]]
+
+`sweep` follows the interrupt vectors by recursive descent and prints only
+bytes actually reached as instructions, with gaps marked. Give an address
+instead for a plain linear run from there.
+
+Get the program ROM out of a ROM set with rd_make_rom; the reference
+emulator's mcu.cpp supplies the opcode table.
+
+The opcode table is lifted from the reference emulator's own dispatch table
+(Mcu::hd63701_insn), so the mnemonics and addressing modes are the ones that
+emulator implements rather than a second-hand listing.
+
+The ROM is 8 KB mirrored into 0xC000-0xFFFF; the firmware runs in the 0xE000
+copy, which is where the vectors point.
+"""
+import re, sys
+
+BRANCH = {'bcc','bcs','beq','bge','bgt','bhi','ble','bls','blt','bmi','bne',
+          'bpl','bra','brn','bvc','bvs','bsr'}
+IMM16  = {0x8c,0x8e,0x83,0xc3,0xcc,0xce}          # cpx lds subd addd ldd ldx
+BITOP  = {'aim','oim','eim','tim'}                 # 6301: immediate + operand
+
+def load_ops(path):
+    s = open(path).read()
+    i = s.index('hd63701_insn[0x100]')
+    body = s[s.index('{', i)+1 : s.index('};', i)]
+    return re.findall(r'&Mcu::(\w+)', body)
+
+def decode(ops, rom, off, base):
+    op = rom[off]
+    name = ops[op]
+    m = re.search(r'_(im|di|ix|ex)$', name)
+    mode = m.group(1) if m else None
+    mn = re.sub(r'_(im|di|ix|ex)$', '', name)
+    pc = base + off
+
+    if mn in BITOP:                       # aim #$xx,<dir> / aim #$xx,off,x
+        imm, opnd = rom[off+1], rom[off+2]
+        txt = f"{mn} #${imm:02x},${opnd:02x}" + (",x" if mode=='ix' else "")
+        return 3, txt, None
+    if mn in BRANCH:
+        rel = rom[off+1]
+        tgt = (pc + 2 + (rel - 256 if rel > 127 else rel)) & 0xffff
+        return 2, f"{mn} ${tgt:04x}", tgt
+    if mode is None:
+        return 1, mn, None
+    if mode == 'im':
+        if op in IMM16:
+            v = (rom[off+1] << 8) | rom[off+2]
+            return 3, f"{mn} #${v:04x}", None
+        return 2, f"{mn} #${rom[off+1]:02x}", None
+    if mode == 'di':
+        return 2, f"{mn} ${rom[off+1]:02x}", None
+    if mode == 'ix':
+        return 2, f"{mn} ${rom[off+1]:02x},x", None
+    v = (rom[off+1] << 8) | rom[off+2]
+    return 3, f"{mn} ${v:04x}", (v if mn in ('jmp','jsr') else None)
+
+TERMINAL = {'rts','rti','jmp','bra','swi','wai','slp'}
+
+def sweep(ops, rom, base, seeds):
+    """Recursive descent: only bytes actually reached as instructions."""
+    code, targets, todo = {}, set(), list(seeds)
+    while todo:
+        pc = todo.pop()
+        while True:
+            off = pc - base
+            if not (0 <= off < len(rom)) or off in code:
+                break
+            n, txt, tgt = decode(ops, rom, off, base)
+            code[off] = (n, txt)
+            mn = txt.split()[0]
+            if tgt is not None:
+                targets.add(tgt)
+                if mn in ('jsr','bsr') or mn.startswith('b'):
+                    todo.append(tgt)
+            if mn in TERMINAL:
+                break
+            pc += n
+    return code, targets
+
+def main():
+    ops = load_ops(sys.argv[1])
+    rom = open(sys.argv[2], 'rb').read()
+    base = 0xE000
+    if len(sys.argv) > 3 and sys.argv[3] == 'sweep':
+        names = ['SCI','TOF','OCF','ICF','IRQ1','SWI','NMI','RESET']
+        seeds, vec = [], {}
+        for i, nm in enumerate(names):
+            o = 0x1ff0 + i*2
+            v = (rom[o] << 8) | rom[o+1]
+            vec[v] = nm
+            if 0xe000 <= v <= 0xffff: seeds.append(v)
+        code, targets = sweep(ops, rom, base, seeds)
+        print(f"; vectors: " + ", ".join(f"{n}=${a:04x}" for a,n in vec.items()))
+        print(f"; {len(code)} instructions, {sum(n for n,_ in code.values())} of {len(rom)} bytes reached")
+        prev = None
+        for off in sorted(code):
+            n, txt = code[off]
+            a = base + off
+            if prev is not None and off != prev:
+                print(f"; ---- gap {prev+base:04x}..{a-1:04x} ({off-prev} bytes) ----")
+            lbl = " <--" if a in targets else ""
+            raw = " ".join(f"{b:02x}" for b in rom[off:off+n])
+            print(f"{a:04x}  {raw:<9}  {txt}{lbl}")
+            prev = off + n
+        return
+    start = int(sys.argv[3], 0) if len(sys.argv) > 3 else None
+    count = int(sys.argv[4], 0) if len(sys.argv) > 4 else 64
+
+    if start is None:                     # follow the reset vector
+        start = (rom[0x1ffe] << 8) | rom[0x1fff]
+        print(f"; reset vector -> ${start:04x}")
+    off = start - base
+    for _ in range(count):
+        if not (0 <= off < len(rom)): break
+        n, txt, tgt = decode(ops, rom, off, base)
+        raw = " ".join(f"{b:02x}" for b in rom[off:off+n])
+        print(f"{base+off:04x}  {raw:<9}  {txt}")
+        off += n
+
+main()


### PR DESCRIPTION
Answering "can we get the descriptors out of the ROM directly, and stop
depending on anyone's repository?"

**Not as they stand — but their inputs are in there, and the shape is now
known.** This is the first pass, kept in the repository rather than in a
scratchpad that gets emptied.

## The tool

[`rd_dasm.py`](tools/rd_extract/rd_dasm.py), an HD6301 disassembler whose
opcode table is lifted from the reference emulator's own dispatch table — so
the mnemonics are the ones that emulator implements, not a second-hand listing.
`sweep` follows the interrupt vectors by recursive descent.

## What it found

Vectors: `RESET=$e00f`, `ICF=$e121`, **`IRQ1=$ed1a`**.

`IRQ1` fires when a voice part finishes an envelope segment and the handler
programs the next one — so that routine **is** the descriptor generator, and it
reads clean:

```
ed1b  ldb $1000      ; the chip says which voice and part
ed2c  mul #$06       ; six bytes of state each
ed2d  addd #$0200    ;   at $0200 + (voice*16 + part) * 6
ed37  ldx $02,x      ; a POINTER held in that state
ed4f  addd #$0006    ; advance by six
ed54  std $02,x      ; store back
```

Each part walks a **list of six-byte entries**, one per envelope segment. Then:

```
ed61  lda $d1        ; weight from the key
ed65  ldb $03,x      ;   corner 3 *  d1
ed6d  ldb $01,x      ;   corner 1 * (256-d1)
ed73  lda $d2        ; weight from the velocity
ed77  ldb $02,x      ;   corner 2 *  d2
ed7f  ldb $00,x      ;   corner 0 * (256-d2)
ed87  std $04,x      ; write the pair to the chip
```

**Four corner values, two weights, one write.** The captured `dest` and `speed`
are the interpolated values; the ROM holds the corners.

## It explains everything the packs were doing

- **No byte search matches** — I looked for the captured pairs in the parameter
  ROM and found nothing, not even the bare `dest` sequence. Of course: those are
  interpolates, and the stride is six.
- **Velocity layers differ by a constant additive offset** (+28, +14, +3 across
  40/80/110/127 on patch 0, the same for every segment). A linear blend does
  exactly that, and the chip's levels are logarithmic, so a blend is a gain.
- **Neighbouring notes are byte-identical**, timestamps included — same key
  weight bucket. Only 24 distinct wave assignments across 88 keys, and just
  **27 %** of all 5632 captured entries are distinct.

## What is missing

The **note-on path**: what sets the list pointer and the two weights. That is
where the parameter ROM is actually indexed, and it is the piece that turns
this into a parser. Only three reads in the whole firmware use a fixed
parameter-ROM address, so it has to be read rather than grepped for.

Also unread: bytes 4 and 5 of each entry.

## A side finding worth having anyway

**The timestamps are not in the ROM and do not need to be in the packs.** A
segment's duration is however long the chip takes to ramp from the previous
destination to this one — which is why two notes with the same chain have
identical timing — and `RdNewEngine` already computes that arithmetic. Dropping
them and the duplicates would take the packs from **3.17 MB to roughly 0.5 MB**,
independently of whether the parser ever gets written.

Documentation only, plus one tool. Nothing in the build changes.