### PR TITLE
Bytes four and five are a coarse velocity split

### DIFF
--- a/tools/rd_extract/RD_FIRMWARE.md
+++ b/tools/rd_extract/RD_FIRMWARE.md
@@ -306,10 +306,47 @@ the emulator's hard-coded tables fall out of this one:
 All eight, both columns. `patchToOffset` and `patchToRomSet` are the same table
 read twice, and it is in the ROM.
 
+## Bytes four and five: a coarse velocity split
+
+The interrupt reads `$00,x` to `$03,x` and advances by six, so two bytes of each
+entry looked unused. They are not — the *pointer* is what moves.
+
+Note-on, having fetched the list pointer out of the parameter block:
+
+```
+e940  ldd $02,x      ; the list pointer
+e942  bne $e94b      ; zero means this part is unused
+e94b  ldx $b5
+e94d  addd $c4       ; <-- offset the whole list
+e94f  std $02,x      ; and that is what the interrupt walks
+e952  jsr $eb16      ; program the first segment
+```
+
+and `$c4` was set from **bit 7 of the velocity weight**:
+
+```
+e7be  ldx #$0000
+e7c1  ldb $c0        ; $a5[velocity]
+e7c3  bpl $e7c7      ; bit 7 clear -> $c4 = 0
+e7c5  inx
+e7c6  inx            ; bit 7 set   -> $c4 = 2
+e7c7  stx $c4
+```
+
+So **each entry carries six corner values, and bit 7 picks which four apply**:
+bytes 0-3 or bytes 2-5. A coarse two-layer velocity split sitting on top of the
+fine interpolation, and it persists for the whole chain because the offset is
+applied once, to the starting pointer, while the stride stays six.
+
+The two roles do not collide. `$c1` is `(($c0 << 1) & $ff) >> 2`, and the `aslb`
+discards bit 7 — so the curve index is built from bits 0-6 and bit 7 alone
+chooses the layer. One byte out of `$a5`, two jobs, no overlap.
+
+That also means `$a5` is not just a velocity curve: it is a velocity **map**,
+one byte a step, carrying a layer bit and a within-layer position.
+
 ## What is still missing
 
-- **Bytes 4 and 5** of each segment entry. The pointer advances by six and the
-  interrupt consumes four.
 - **The key weight** at `$0040 + voice`. It is written by the `$80`/`$a0`
   handler, not by note-on, and the reference emulator never sends those
   commands — so how they are driven on real hardware is open.

--- a/tools/rd_extract/RD_FIRMWARE.md
+++ b/tools/rd_extract/RD_FIRMWARE.md
@@ -249,13 +249,65 @@ which is, byte for byte, the MK-80 half of the `patchToOffset` table the
 reference emulator carries hard-coded. That table was derived from this
 structure; it can be read from the ROM instead.
 
+## There are three sound-CPU firmwares, and this was the RD-200's
+
+`RD200_B.bin`, `mks20_cpub_1.0.bin` and `MKS20_B.BIN` are three different 8 KB
+ROMs. Everything above was read out of the first, which is also the one the
+reference emulator loads -- its own `read_byte` says so: *"HACK: only works with
+the RD200 ROM"*. It plays MKS-20 sample and parameter ROMs with RD-200 firmware.
+
+All three boot at `$e00f` and all three dispatch the same way, only from
+different addresses:
+
+| ROM | ICF | IRQ1 | dispatch table |
+|---|---|---|---|
+| `RD200_B.bin` | `$e121` | `$ed1a` | `$e16e` |
+| `MKS20_B.BIN` | `$e120` | `$e78b` | `$e164` |
+| `mks20_cpub_1.0.bin` | `$e0dd` | `$e748` | `$e121` |
+
+**The MKS-20's command set is smaller.** Its table has no `$30` (program
+change), no `$b0` (note off) and no `$50` (sustain) -- those entries are zero.
+Its main CPU does more of the work.
+
+## Which is why its patch table is somewhere else entirely
+
+The MKS-20 selects patches with `$40`, not `$30`, and its table is in **its own
+program ROM** at `$e82b` rather than at the head of the parameter ROM:
+
+```
+00 40 00  01 40 00  02 40 00  07 40 00  04 7c 20  05 6b 50  06 82 60  07 7e f0
+```
+
+Same three-byte shape, one twist -- the handler splits the first byte:
+
+```
+e19e  lda $00,x      ; the bank byte
+e1a2  anda #$03      ; only the low two bits reach the latch
+e1a4  ldb $3b
+e1a6  andb #$04      ; and bit 2 comes from elsewhere
+e1a9  sta $e000
+e1ac  ldd $01,x      ; the address, as before
+```
+
+So **bits 0-1 are the parameter bank and bit 2 is the sample set**, and both of
+the emulator's hard-coded tables fall out of this one:
+
+| Patch | byte | offset from bits 0-1 | set from bit 2 | emulator |
+|---|---|---|---|---|
+| 0 | `$00` | `0x000000` | 0 | `0x000000` / 0 |
+| 1 | `$01` | `0x008000` | 0 | `0x008000` / 0 |
+| 2 | `$02` | `0x010000` | 0 | `0x010000` / 0 |
+| 3 | `$07` | `0x018000` | 1 | `0x018000` / 1 |
+| 4 | `$04` | `0x003c20` | 1 | `0x003c20` / 1 |
+| 5 | `$05` | `0x00ab50` | 1 | `0x00ab50` / 1 |
+| 6 | `$06` | `0x014260` | 1 | `0x014260` / 1 |
+| 7 | `$07` | `0x01bef0` | 1 | `0x01bef0` / 1 |
+
+All eight, both columns. `patchToOffset` and `patchToRomSet` are the same table
+read twice, and it is in the ROM.
+
 ## What is still missing
 
-- **The MKS-20's equivalent header.** The same search does not find it in
-  `mks20_15179757.BIN`, the parameter ROM the emulator uses for both MKS-20
-  sample sets. Either it lives in another chip, or the MKS-20's main CPU
-  supplies the offsets by a different route. Its `patchToOffset` half is
-  therefore still only known from the emulator.
 - **Bytes 4 and 5** of each segment entry. The pointer advances by six and the
   interrupt consumes four.
 - **The key weight** at `$0040 + voice`. It is written by the `$80`/`$a0`


### PR DESCRIPTION
> Stacked on #52 — this branch came off it, so its commit shows here too. Merge
> #52 first and this shrinks to the one below.

The second of the two remaining unknowns. The interrupt reads four bytes of each
six-byte segment entry and advances by six, which left two looking unused.

**They are not unused. It is the pointer that moves.**

## Where it happens

Note-on, having fetched the list pointer out of the parameter block:

```
e940  ldd $02,x      ; the list pointer
e942  bne $e94b      ; zero means this part is unused
e94b  ldx $b5
e94d  addd $c4       ; <-- offset the whole list
e94f  std $02,x      ; and that is what the interrupt walks
e952  jsr $eb16      ; program the first segment
```

and `$c4` comes from **bit 7 of the velocity weight**:

```
e7c1  ldb $c0        ; $a5[velocity]
e7c3  bpl $e7c7      ; bit 7 clear -> $c4 = 0
e7c5  inx
e7c6  inx            ; bit 7 set   -> $c4 = 2
e7c7  stx $c4
```

## What it means

**Each entry carries six corner values, and bit 7 picks which four apply** —
bytes 0-3, or bytes 2-5. A coarse two-layer velocity split sitting on top of the
fine interpolation.

It holds for the whole chain, because the offset is applied once to the
*starting* pointer while the stride stays six. Every segment in that part's
envelope reads from the same layer.

## And the two roles do not collide

`$c1` is `(($c0 << 1) & $ff) >> 2`, and the `aslb` throws bit 7 away. So the
curve index is built from **bits 0-6** and **bit 7 alone** chooses the layer. One
byte out of `$a5`, two jobs, no overlap — which is why the earlier fit could
find a consistent weight sequence at all.

That also settles what `$a5` is. Not a velocity curve: a velocity **map**, one
byte a step, carrying a layer bit and a position within that layer.

## One left

Only the key weight at `$0040 + voice` now, written by the `$80`/`$a0` handler
that the reference emulator never sends.

Documentation only.