### PR TITLE
The note becomes a zone, and the zone carries the pitches

### DIFF
--- a/tools/rd_extract/RD_FIRMWARE.md
+++ b/tools/rd_extract/RD_FIRMWARE.md
@@ -474,14 +474,54 @@ the packs show mean some of those zones point at the same list.
 already in A, which is why that routine reads `lda $e1` at `$e799` when reached
 the other way.
 
+## The zone entry is one index and ten pitches
+
+```
+e80b  ldx $ad        ; the zone entry, one byte in
+e80d  ldd $00,x      ; a 16-bit value
+e80f  ldx $b5
+e811  std $04,x      ;   into the part state
+e813  addd $e5       ;   plus the global tuning
+e816  std $00,x      ;   into the frame that reaches the chip
+e818  ldx $ad
+e81a  ldd $02,x      ; the next one
+e81e  std $0a,x      ;   state, stride six
+e823  std $10,x      ;   frame, stride sixteen
+e825  ldx $ad
+e827  ldd $04,x      ; and the next
+```
+
+Ten 16-bit pitch values at stride two, read from `zone + 1` — `$ad` is the zone
+entry incremented past its first byte, which is the part-block index. **One
+index byte plus ten pitches of two bytes each is twenty-one**, which is the zone
+entry's size arrived at independently for the second time.
+
+Each is stored twice: into the part state, and — with the global tuning from the
+`$e0` command added — into the frame that is handed to the chip. So the ROM
+carries an absolute pitch per part per zone; nothing is transposed from the note
+at play time, because the zone *is* the note.
+
+## Programming a note is ten parts, unrolled
+
+Note-on writes every one of the ten parts explicitly rather than looping.
+`ldx $b1` — the voice's chip base, `$1000 + voice * $100` — appears ten times in
+a row at `$e955` through `$eb05`, storing to `+$04`, `+$14`, `+$24` … `+$94`:
+chip fields 4 and 5, the envelope pair, one part every sixteen bytes. Flags and
+the envelope offset go the same way at `+$06`, `+$16`, and so on from `$e7df`.
+
+The interpolation itself is shared. `$eb16` is the interrupt's arithmetic as a
+subroutine — four corners at X, weights in `$c2` and `$c3` rather than `$d1` and
+`$d2`, the pair returned in D — and note-on calls it once per part to program
+the first segment. The interrupt then re-implements the same maths inline for
+every segment after that.
+
 ## What is still missing
 
 The envelope path is read end to end. Two things beside it are not:
 
-- **Wave address and pitch.** The captured descriptors carry a `pitch_lut`, a
-  `wave_loop` and a `wave_high` per part, and none of those come from the
-  segment lists — most likely from the six seven-byte records at `+$22` in the
-  part block, which have been located but not read.
+- **The wave address.** Chip fields 2 and 3 per part, `wave_loop` and
+  `wave_high` in the captured descriptors. Not in the zone entry and not in the
+  segment lists, so presumably in the part block; not yet found.
 
 And one thing that is not missing but worth restating, because it changes what a
 pack has to hold:

--- a/tools/rd_extract/RD_FIRMWARE.md
+++ b/tools/rd_extract/RD_FIRMWARE.md
@@ -446,13 +446,38 @@ Everything above, in the order it happens:
 Nothing in that is timing. The durations the captured packs record are the
 chip's own ramps, not the firmware's.
 
+## The note becomes a zone by subtracting fifteen and folding octaves
+
+```
+e60f  lda $9f        ; the note
+e611  suba #$0f      ; less fifteen
+e613  bcc $e619
+e615  adda #$0c      ;   under: add an octave until it is not
+e617  bcc $e615
+e619  cmpa #$62      ; over 98?
+e61b  bls $e621
+e61d  suba #$0c      ;   yes: take an octave off
+e61f  bra $e619      ;        and ask again
+e621  jsr $e79b      ; -> build $af from it
+```
+
+**Zone = note − 15, folded by octaves into 0…98.** Ninety-nine values, which is
+`$81f / 21` exactly — the zone table's own size, arrived at from the other
+direction.
+
+For the keyboard the machine actually has, 21 to 108, that is zones 6 to 93 and
+the folding never runs; it is there to catch anything outside 15…113. Eighty-
+eight keys, eighty-eight zones, one each — and the 74 distinct segment chains
+the packs show mean some of those zones point at the same list.
+
+`jsr $e79b` enters the `$af` construction one instruction in, with the zone
+already in A, which is why that routine reads `lda $e1` at `$e799` when reached
+the other way.
+
 ## What is still missing
 
 The envelope path is read end to end. Two things beside it are not:
 
-- **How the note becomes a zone index.** `$e1` reaches the zone table by way of
-  a `suba #$0f`, but the mapping from 88 keys onto 99 entries has not been
-  followed, and it is the first thing a parser would need.
 - **Wave address and pitch.** The captured descriptors carry a `pitch_lut`, a
   `wave_loop` and a `wave_high` per part, and none of those come from the
   segment lists — most likely from the six seven-byte records at `+$22` in the


### PR DESCRIPTION
Two more pieces, and the zone table's size now falls out of the data twice.

## Note to zone

```
e60f  lda $9f        ; the note
e611  suba #$0f      ; less fifteen
e615  adda #$0c      ;   under: add an octave until it is not
e619  cmpa #$62      ; over 98?
e61d  suba #$0c      ;   yes: take an octave off, ask again
e621  jsr $e79b      ; -> build $af from it
```

**Zone = note − 15, folded by octaves into 0…98.** Ninety-nine values, which is
`$81f / 21` exactly — the zone table's own size, reached from the other
direction and agreeing.

For the keyboard the machine has, 21 to 108, that is zones 6 to 93 and the
folding never runs. Eighty-eight keys, eighty-eight zones; the 74 distinct
segment chains the packs show mean some of those zones point at the same list.

## And the zone entry is one index plus ten pitches

```
e80b  ldx $ad        ; the zone entry, one byte in
e80d  ldd $00,x      ; a 16-bit value
e811  std $04,x      ;   into the part state
e813  addd $e5       ;   plus the global tuning
e816  std $00,x      ;   into the frame that reaches the chip
e81a  ldd $02,x      ; the next
e827  ldd $04,x      ; and the next
```

Ten 16-bit pitches at stride two, from `zone + 1`. **One index byte plus ten
pitches of two bytes is twenty-one** — the entry size, independently confirmed a
second time.

Each is stored twice: into the part state, and — with the global tuning from the
`$e0` command added — into the frame handed to the chip. So the ROM carries an
**absolute pitch per part per zone**. Nothing is transposed from the note at play
time, because the zone *is* the note.

## Two smaller things found on the way

- **Note-on programs all ten parts unrolled**, not in a loop: `ldx $b1` — the
  voice's chip base at `$1000 + voice * $100` — appears ten times over from
  `$e955` to `$eb05`, storing the envelope pair to `+$04`, `+$14` … `+$94`, one
  part every sixteen bytes.
- **`$eb16` is the interrupt's interpolation as a subroutine** — same four
  corners, weights in `$c2`/`$c3` instead of `$d1`/`$d2`, pair returned in D.
  Note-on calls it once per part for the first segment; the interrupt then
  re-implements the same arithmetic inline for every segment after.

## What is left

One thing: **the wave address**, chip fields 2 and 3 per part. Not in the zone
entry and not in the segment lists, so presumably in the part block — but not
yet found.

Documentation only.