### PR TITLE
A first parser, and what it does not yet get right

### DIFF
--- a/tools/rd_extract/rd_parse.py
+++ b/tools/rd_extract/rd_parse.py
@@ -1,0 +1,141 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Michi71
+"""Derives a note's envelope chains from a ROM set, without running anything.
+
+    rd_parse.py <program.bin> <params.bin> <patch-offset> <note> <velocity>
+
+This is the firmware's own arithmetic, rewritten from the disassembly in
+RD_FIRMWARE.md rather than observed. Feed it the descrambled ROMs that
+rd_unscramble.sh writes and it produces, per part, the wave address and the
+chain of (destination, speed) pairs the firmware would program into the sound
+chip -- which is what a .rdp pack holds, minus the timestamps the chip
+generates.
+
+The patch offset is where that patch's parameter block starts, as the patch
+table gives it: (address - $4000) | (bank << 15).
+
+STATE: this is a first version and it is not finished. Measured against the
+sixteen captured packs, patch 0, all 352 (note, velocity) pairs:
+
+    speeds exact   88.9 %      the straight interpolation and the corner
+                               layout are right
+    destinations   33.6 %      the curve-weighted one is not
+    chain lengths  mostly wrong
+
+The destinations are systematically one low where they are close, and solving
+for the weight that would make them exact puts it at 224..231 where this
+computes 220. That pins the fault to the velocity path: $a5[113] and $a5[114]
+hold the byte that would give 228 -- and 228 is the value at which both weights
+agree, since curve[228 >> 2] is 228 on the straight curve. So one step between
+the MIDI velocity and the index into $a5 is still missing, and the chain
+framing follows from the same place.
+
+Enough is right that the structure in RD_FIRMWARE.md is not in doubt; not
+enough to build packs with.
+"""
+import sys
+
+PROG_BASE = 0xE000          # the program ROM runs in its $e000 mirror
+CURVE_TABLE = 0xED9D        # eight pointers to 64-byte velocity curves
+
+
+def hi(x):
+    """The high byte of a 16-bit accumulator, which is what psha keeps."""
+    return (x >> 8) & 0xFF
+
+
+def interpolate(corner_lo, corner_hi, weight):
+    """(256 - w) * lo + w * hi, as the firmware does it: two muls and an add."""
+    return hi(((256 - weight) * corner_lo + weight * corner_hi) & 0xFFFF)
+
+
+class Rom:
+    def __init__(self, program, params, patch_off):
+        self.prog = program
+        self.prm = params
+        # $a5, $a7, $a9 -- as the program-change handler computes them, but as
+        # offsets into the parameter ROM rather than CPU addresses.
+        self.a5 = patch_off
+        self.a7 = patch_off + 0x100
+        self.a9 = self.a7 + 0x81F
+        self.bank = patch_off >> 15
+
+    def cpu_to_off(self, addr):
+        """A 16-bit CPU address in the $4000 window, in this patch's bank."""
+        return (addr - 0x4000) | (self.bank << 15)
+
+    def curve(self, which, index):
+        base = (self.prog[CURVE_TABLE - PROG_BASE + 2 * which] << 8) \
+             | self.prog[CURVE_TABLE - PROG_BASE + 2 * which + 1]
+        return self.prog[base - PROG_BASE + index]
+
+
+def zone_of(note):
+    """zone = note - 15, folded by octaves into 0..98."""
+    z = note - 0x0F
+    while z < 0:
+        z += 12
+    while z > 0x62:
+        z -= 12
+    return z
+
+
+def parse(rom, note, velocity):
+    # The velocity map: one byte, two jobs.
+    c0 = rom.prm[rom.a5 + velocity]
+    layer = 2 if (c0 & 0x80) else 0          # $c4
+    c2 = (c0 << 1) & 0xFF                    # the straight weight
+    c1 = c2 >> 2                             # the curve index
+
+    zone = zone_of(note)
+    zbase = rom.a7 + zone * 21
+    block = rom.a9 + rom.prm[zbase] * 70
+
+    parts = []
+    for p in range(10):
+        rec = block + p * 7
+        wave = (rom.prm[rec] << 8) | rom.prm[rec + 1]
+        ptr = (rom.prm[rec + 2] << 8) | rom.prm[rec + 3]
+        pitch = (rom.prm[zbase + 1 + p * 2] << 8) | rom.prm[zbase + 2 + p * 2]
+        release = rom.prm[rec + 6]
+        if ptr == 0:
+            parts.append({"pitch": pitch, "wave": wave, "release": release,
+                          "segments": []})
+            continue
+        # +4 or +5 by the same layer bit that offsets the list.
+        c3 = rom.curve(rom.prm[rec + 4 + (1 if layer else 0)] >> 1, c1)
+
+        segs, at = [], rom.cpu_to_off(ptr) + layer
+        while len(segs) < 64:
+            e = rom.prm[at:at + 4]
+            dest = interpolate(e[0], e[2], c3)
+            speed = interpolate(e[1], e[3], c2)
+            segs.append((dest, speed))
+            if dest == 0:                    # ed89's tsta: zero ends the chain
+                break
+            at += 6
+        parts.append({"pitch": pitch, "wave": wave, "release": release,
+                      "segments": segs})
+    return {"zone": zone, "block": block, "weight": c0, "layer": layer // 2,
+            "curve_index": c1, "parts": parts}
+
+
+def main():
+    if len(sys.argv) != 6:
+        sys.stderr.write(__doc__.split("\n\n")[1] + "\n")
+        sys.exit(1)
+    rom = Rom(open(sys.argv[1], "rb").read(), open(sys.argv[2], "rb").read(),
+              int(sys.argv[3], 0))
+    r = parse(rom, int(sys.argv[4], 0), int(sys.argv[5], 0))
+    print(f"zone {r['zone']}  block ${r['block']:06x}  weight ${r['weight']:02x}"
+          f"  layer {r['layer']}  curve index {r['curve_index']}")
+    for i, p in enumerate(r["parts"]):
+        if not p["segments"]:
+            continue
+        print(f"  part {i}: pitch ${p['pitch']:04x} wave ${p['wave']:04x} "
+              f"release {p['release']}")
+        print("      " + "  ".join(f"{d}/{s}" for d, s in p["segments"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/rd_extract/rd_unscramble.cpp
+++ b/tools/rd_extract/rd_unscramble.cpp
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Michi71
+//
+// rd_unscramble -- writes out a ROM set's program and parameter ROMs with the
+// address and data lines put back in order, which is what reading the firmware
+// needs. Same arrangement as rd_make_rom: it links against a hooked copy of a
+// reference-emulator checkout, because that is where the descrambling lives,
+// and nothing of that emulator is in this repository.
+//
+// The sample ROMs are not written here -- rd_make_rom is for those.
+
+#include "mcu.h"
+#include <cstdio>
+#include <cstdlib>
+#include <string>
+
+static void read_rom(const std::string& dir, const char* name, u8* buf, size_t len)
+{
+    const std::string path = dir + "/" + name;
+    FILE* f = fopen(path.c_str(), "rb");
+    if (!f) { fprintf(stderr, "rd_unscramble: cannot open %s\n", path.c_str()); exit(2); }
+    const size_t got = fread(buf, 1, len, f);
+    fclose(f);
+    if (got != len) {
+        fprintf(stderr, "rd_unscramble: %s is %zu bytes, expected %zu\n",
+                path.c_str(), got, len);
+        exit(2);
+    }
+}
+
+static void write_out(const char* path, const void* p, size_t n)
+{
+    FILE* f = fopen(path, "wb");
+    if (!f) { fprintf(stderr, "rd_unscramble: cannot write %s\n", path); exit(2); }
+    fwrite(p, 1, n, f);
+    fclose(f);
+}
+
+int main(int argc, char** argv)
+{
+    if (argc != 7) {
+        fprintf(stderr,
+            "usage: rd_unscramble <romdir> <progrom> <paramsrom> <ic5> "
+            "<out-program.bin> <out-params.bin>\n");
+        return 1;
+    }
+    const std::string dir = argv[1];
+    static u8 prog[0x2000], prm[0x20000], ic[0x20000];
+    read_rom(dir, argv[2], prog, sizeof prog);
+    read_rom(dir, argv[3], prm,  sizeof prm);
+    // The Mcu wants three sample images to construct its sound chip. Only the
+    // descrambling is wanted here, so one image serves for all three.
+    read_rom(dir, argv[4], ic, sizeof ic);
+
+    Mcu* m = new Mcu(ic, ic, ic, prog, prm);
+    m->loadSounds(ic, ic, ic, prm, 0);
+    write_out(argv[5], m->program_rom,    0x2000);
+    write_out(argv[6], m->params_rom_tmp, 0x20000);
+    printf("rd_unscramble: %s -> %s, %s -> %s\n", argv[2], argv[5], argv[3], argv[6]);
+    return 0;
+}

--- a/tools/rd_extract/rd_unscramble.sh
+++ b/tools/rd_extract/rd_unscramble.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Michi71
+#
+#   RDPIANO=/path/to/rdpiano rd_unscramble.sh <romdir> <progrom> <paramsrom> \
+#                                             <ic5> <out-program> <out-params>
+#
+# Descrambles a program and parameter ROM pair for reading. See
+# tools/rd_extract/RD_FIRMWARE.md, and rd_make_rom.sh for the same arrangement
+# applied to the sample ROMs.
+
+set -euo pipefail
+if [ $# -ne 6 ]; then
+    echo "usage: RDPIANO=... $0 <romdir> <progrom> <paramsrom> <ic5> <out-program> <out-params>" >&2
+    exit 1
+fi
+if [ -z "${RDPIANO:-}" ]; then
+    echo "$0: set RDPIANO to a checkout of the upstream emulator" >&2
+    echo "    git clone https://github.com/Michi71/rdpiano" >&2
+    exit 1
+fi
+for cand in "$RDPIANO/librdpiano" "$RDPIANO/rdpiano" "$RDPIANO"; do
+    if [ -f "$cand/src/mcu.cpp" ] && [ -f "$cand/include/mcu.h" ]; then upstream=$cand; break; fi
+done
+if [ -z "${upstream:-}" ]; then echo "$0: no src/mcu.cpp under $RDPIANO" >&2; exit 1; fi
+if ! grep -q 'SoundChip(const u8 \*' "$upstream/include/sound_chip.h"; then
+    echo "$0: $upstream is the adapted emulator; this needs the upstream one." >&2
+    exit 1
+fi
+
+here=$(cd "$(dirname "$0")" && pwd)
+work=$(mktemp -d); trap 'rm -rf "$work"' EXIT
+mkdir -p "$work/include" "$work/src"
+sed 's/^private:/public:/' "$upstream/include/mcu.h" > "$work/include/mcu.h"
+cp "$upstream/include/"{sound_chip.h,mame_utils.h,mcu_ops.h} "$work/include/"
+cp "$upstream/src/"{mcu.cpp,sound_chip.cpp} "$work/src/"
+
+c++ -O2 -w -std=c++17 -I "$work/include" -o "$work/rd_unscramble" \
+    "$here/rd_unscramble.cpp" "$work"/src/*.cpp
+"$work/rd_unscramble" "$@"


### PR DESCRIPTION
The parser, started. **It is not finished, and the file says so at the top.**

## Two tools

- **`rd_unscramble`** writes a ROM set's program and parameter ROMs with the
  address and data lines put back — what reading them needs. Same arrangement as
  `rd_make_rom`: hooked copy of a checkout, nothing vendored.
- **`rd_parse.py`** walks the structure from `RD_FIRMWARE.md` and produces, per
  part, the wave address and the chain of (destination, speed) pairs the
  firmware would program. No emulator involved — this is the firmware's
  arithmetic rewritten, not observed.

```
zone 45  block $000c67  weight $ee  layer 1  curve index 55
  part 0: pitch $6c01 wave $1000 release 200
      241/123  250/60  244/172  224/176  205/171  197/152  153/164  137/149  0/150
```

## Measured against the captured packs

Patch 0, all 352 note-and-velocity pairs, 2096 segments compared:

| | |
|---|---|
| speeds exact | **88.9 %** |
| destinations exact | 33.6 % |
| chain lengths | mostly wrong |

So **the straight interpolation and the corner layout are right** — that is what
88.9 % of speeds landing exactly means — and the curve-weighted one is not.

## Where the fault is, precisely

The destinations that are close are **one low**. Solving for the weight that
would make them exact puts it at **224…231**, where this computes **220**.

That pins it to the velocity path. `$a5[113]` and `$a5[114]` hold `$f2`, which
doubles to **228** — and 228 is exactly where both weights agree, since
`curve[228 >> 2]` is 228 on the straight curve. So **one step between the MIDI
velocity and the index into `$a5` is still missing**, and the chain framing
almost certainly follows from the same place.

Neither of the two indexing paths I read gives it: raw velocity 110 lands on
`$a5[110]` = 238 → 220, and the `(velocity × 247) >> 8` + `$80` path lands on
`$a5[234]` = 206 → 156. The needed index is 113 or 114.

## What this settles anyway

Enough is right that **the structure in `RD_FIRMWARE.md` is not in doubt** — the
zone arithmetic, the part-block layout, the six-byte entries and the two
interpolations all had to be correct for nine speeds in ten to land exactly.

Not enough to build packs with.