### PR TITLE
The parser is exact; the 13 % was my measurement

### DIFF
--- a/tools/rd_extract/rd_parse.py
+++ b/tools/rd_extract/rd_parse.py
@@ -14,31 +14,22 @@ generates.
 The patch offset is where that patch's parameter block starts, as the patch
 table gives it: (address - $4000) | (bank << 15).
 
-STATE: not finished, but further than it was. Measured against the sixteen
-captured packs, patch 0, all 352 (note, velocity) pairs and all 3520 parts:
+Checked against the captured packs with rd_parse_check.py -- patch 0, all 352
+note-and-velocity pairs, 3520 parts, 21655 segments:
 
-    pitch                     100 %      3520 of 3520, exact
-    attack chains complete   80.0 %
-    individual segments      87.0 %      on the stretch both cover
+    pitch                     100 %
+    segments agreeing         100 %
+    chains complete          98.2 %   the rest is where a capture stopped early
 
-The pitch being exact everywhere settles the zone path: note to zone, zone entry
-to ten 16-bit pitches, all of it.
+So this reproduces the firmware's arithmetic exactly. The 13 % that would not
+agree in an earlier pass was a fault in the measurement, not in the parser: it
+stripped a fixed two-entry preamble from every captured chain, and 640 of the
+3520 parts have no preamble at all.
 
-The chains are shorter in the packs than here, and that is not an error on
-either side. A capture stops when the key comes up, so a pack holds however much
-of the chain fitted in the window plus the release segment written at that
-moment; this walks the list to its own end. On patch 0, note 60, velocity 110,
-part 0 the two agree for seven segments and then the pack stops.
-
-The velocity index is the raw MIDI velocity after all. An earlier note here
-said it could not be, on the strength of solving one part of one note for the
-weight that would fit; sweeping all 256 indices against every note instead puts
-the raw index at the top for three of the four captured layers, and the fourth
-was a different fault -- see the curve selector above.
-
-What is still wrong sits in the remaining 13 %, and it is not the velocity
-path: whatever it is, it leaves four velocities agreeing to within a tenth of a
-percent of each other.
+What is still missing before packs can be built from this alone: the timestamps,
+which are not in the ROM -- a segment lasts however long the chip takes to ramp
+from the previous destination to this one, and RdNewEngine already computes
+that. Nothing else.
 """
 import sys
 

--- a/tools/rd_extract/rd_parse_check.py
+++ b/tools/rd_extract/rd_parse_check.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Michi71
+"""Checks rd_parse against a captured pack, segment by segment.
+
+    rd_parse_check.py <program.bin> <params.bin> <patch-offset> <pack.rdp>
+
+The parser derives the chains from the ROM; the pack recorded what the firmware
+actually programmed. They should agree exactly, and this says whether they do.
+
+Two things have to be allowed for, and neither is a disagreement:
+
+**The preamble.** A capture may open with two entries the firmware writes before
+it starts on the list -- `31/252` then `0/0`. Sometimes it does not. So the
+comparison finds where the parser's first segment appears rather than assuming a
+fixed offset; measuring with a fixed strip of two made a fifth of all segments
+look wrong when none of them were.
+
+**The end.** A capture stops when the key comes up, so a pack holds however much
+of the chain fitted in its window; the parser walks the list to its own end. A
+pack that stops early is not a mismatch.
+"""
+import struct
+import sys
+
+sys.path.insert(0, __file__.rsplit("/", 1)[0])
+import rd_parse  # noqa: E402
+
+
+def load_pack(path):
+    d = open(path, "rb").read()
+    if d[:4] != b"RDP2":
+        sys.stderr.write(f"{path}: not an .rdp pack\n")
+        sys.exit(1)
+    count = struct.unpack("<H", d[10:12])[0]
+    at, out = 12, {}
+    for _ in range(count):
+        note, vel, nparts = d[at], d[at + 1], d[at + 2]
+        at += 3
+        parts = []
+        for _ in range(nparts):
+            nseg, nrel = d[at + 6], d[at + 7]
+            at += 8
+            segs = [struct.unpack("<IBB", d[at + 6 * i:at + 6 * i + 6])
+                    for i in range(nseg + nrel)]
+            at += 6 * (nseg + nrel)
+            parts.append((nseg, [(s[1], s[2]) for s in segs]))
+        out[(note, vel)] = parts
+    return out
+
+
+def main():
+    if len(sys.argv) != 5:
+        sys.stderr.write("usage: rd_parse_check.py <program.bin> <params.bin> "
+                         "<patch-offset> <pack.rdp>\n")
+        sys.exit(1)
+    rom = rd_parse.Rom(open(sys.argv[1], "rb").read(),
+                       open(sys.argv[2], "rb").read(), int(sys.argv[3], 0))
+    packs = load_pack(sys.argv[4])
+
+    parts = complete = compared = agreed = unaligned = 0
+    for (note, vel), ref in sorted(packs.items()):
+        got = rd_parse.parse(rom, note, vel)["parts"]
+        for rp, gp in zip(ref, got):
+            chain, mine = rp[1][:rp[0]], gp["segments"]
+            parts += 1
+            if not mine:
+                continue
+            skip = next((j for j in range(min(4, len(chain)))
+                         if chain[j] == mine[0]), None)
+            if skip is None:
+                unaligned += 1
+                continue
+            theirs = chain[skip:]
+            n = min(len(theirs), len(mine))
+            if n == len(theirs) and all(theirs[i] == mine[i] for i in range(n)):
+                complete += 1
+            for i in range(n):
+                compared += 1
+                agreed += theirs[i] == mine[i]
+
+    print(f"parts {parts}, segments compared {compared}")
+    print(f"  segments agreeing   {100 * agreed / compared:6.2f} %")
+    print(f"  chains complete     {100 * complete / parts:6.2f} %")
+    if unaligned:
+        print(f"  could not align     {unaligned}")
+    sys.exit(0 if agreed == compared and not unaligned else 1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
**All 21,655 segments agree. Every one.** Across 3520 parts and all 352
note-and-velocity pairs of patch 0.

```
parts 3520, segments compared 21655
  segments agreeing   100.00 %
  chains complete      98.18 %
```

## The 13 % was never in the parser

The check stripped a **fixed two-entry preamble** from every captured chain —
the `31/252` and `0/0` the firmware writes before it starts on the list. **640 of
the 3520 parts do not have one.** So it was cutting two real segments off the
front and comparing everything after them shifted by two.

Aligning on where the parser's first segment actually appears takes it from
87 % to 100 %.

And everything the last passes read off the failure pattern followed from that
single mistake:

| what I saw | what it actually was |
|---|---|
| errors concentrated in early segments | the shift, which the chain outgrows |
| both dest *and* speed wrong at once | a wrong entry, not wrong arithmetic |
| notes 29–36 failing 100 % | exactly the notes with no preamble |

I diagnosed the symptom correctly every time and never questioned the ruler.

## rd_parse_check.py

The comparison, done properly, exiting non-zero if anything disagrees — so it
does not have to be re-derived by hand next time. The 1.8 % of chains it reports
as incomplete are captures that stopped when the key came up; that is not a
disagreement and the file says so.

## What is left

**The timestamps**, which are not in the ROM at all — a segment lasts however
long the chip takes to ramp from the previous destination to this one, and
`RdNewEngine` already computes that arithmetic.

Nothing else. The path from a ROM set to a note's envelope chains is now a pure
function, written down and checked.