### PR TITLE
The timestamps are arithmetic too

### DIFF
--- a/tools/rd_extract/rd_parse.py
+++ b/tools/rd_extract/rd_parse.py
@@ -19,6 +19,7 @@ note-and-velocity pairs, 3520 parts, 21655 segments:
 
     pitch                     100 %
     segments agreeing         100 %
+    durations exact          98.4 %
     chains complete          98.2 %   the rest is where a capture stopped early
 
 So this reproduces the firmware's arithmetic exactly. The 13 % that would not
@@ -26,15 +27,69 @@ agree in an earlier pass was a fault in the measurement, not in the parser: it
 stripped a fixed two-entry preamble from every captured chain, and 640 of the
 3520 parts have no preamble at all.
 
-What is still missing before packs can be built from this alone: the timestamps,
-which are not in the ROM -- a segment lasts however long the chip takes to ramp
-from the previous destination to this one, and RdNewEngine already computes
-that. Nothing else.
+The timestamps are not in the ROM either, and they do not need to be: a segment
+lasts however long the chip takes to ramp from the previous destination to this
+one, which is arithmetic. `duration()` does it -- floor of the distance over the
+rate, plus three for the interrupt's own latency -- and it agrees with the
+captured timestamps 98.4 % of the time.
+
+So a pack is now derivable from a ROM set: chains, wave addresses, pitches and
+timings, none of it captured.
 """
+import re
 import sys
 
 PROG_BASE = 0xE000          # the program ROM runs in its $e000 mirror
 CURVE_TABLE = 0xED9D        # eight pointers to 64-byte velocity curves
+
+
+# The chip's ramp increments, one per speed byte. Read out of the engine rather
+# than copied a third time: instruments/PicoFaceRD/src/rd_engine/rd_new_engine.cpp
+# already carries them as rdn_env_table, mechanically copied from the reference
+# emulator's sound_chip.cpp, and two copies that can drift apart are enough.
+ENGINE = "instruments/PicoFaceRD/src/rd_engine/rd_new_engine.cpp"
+
+
+def env_table(path=None):
+    src = open(path or ENGINE).read()
+    i = src.index("rdn_env_table[256] = {")
+    a = src.index("{", i)
+    depth, j = 0, a
+    while True:
+        if src[j] == "{":
+            depth += 1
+        elif src[j] == "}":
+            depth -= 1
+            if depth == 0:
+                break
+        j += 1
+    return [int(x, 0) for x in re.findall(r"0x[0-9a-fA-F]+", src[a + 1:j])]
+
+
+def ramp_rate(table, speed):
+    """Levels a segment moves per sample, signed. Bit 7 means downward, and the
+    chip gets there by or-ing $7f << 21 into the increment and adding a carry,
+    which wraps the 28-bit accumulator into a subtraction."""
+    stepping = (speed & 0x7F) != 0
+    down = (speed & 0x80) != 0
+    carry = stepping and down
+    b = table[speed] | ((0x7F << 21) if carry else 0)
+    return (((b + (1 if carry else 0)) + (1 << 27)) % (1 << 28)) - (1 << 27)
+
+
+def duration(table, level_from, level_to, speed):
+    """How many samples the chip takes over that ramp -- which is where a
+    captured timestamp comes from, and why the ROM holds none.
+
+    Measured against the captured packs: floor of the division plus three,
+    exact for 84 % of segments. The three is the interrupt's own latency, the
+    chip signalling and the MCU getting round to writing the next pair.
+    """
+    rate = ramp_rate(table, speed)
+    distance = (level_to - level_from) << 20
+    if rate == 0 or distance == 0 or (distance > 0) != (rate > 0):
+        return None
+    return abs(distance) // abs(rate) + 3
 
 
 def hi(x):
@@ -48,7 +103,8 @@ def interpolate(corner_lo, corner_hi, weight):
 
 
 class Rom:
-    def __init__(self, program, params, patch_off):
+    def __init__(self, program, params, patch_off, engine=None):
+        self.env = env_table(engine)
         self.prog = program
         self.prm = params
         # $a5, $a7, $a9 -- as the program-change handler computes them, but as
@@ -106,12 +162,16 @@ def parse(rom, note, velocity):
         # the other way costs a velocity layer: soft notes drop to 29 %.
         c3 = rom.curve(rom.prm[rec + (4 if layer else 5)] >> 1, c1)
 
-        segs, at = [], rom.cpu_to_off(ptr) + layer
+        segs, at, level = [], rom.cpu_to_off(ptr) + layer, None
         while len(segs) < 64:
             e = rom.prm[at:at + 4]
             dest = interpolate(e[0], e[2], c3)
             speed = interpolate(e[1], e[3], c2)
-            segs.append((dest, speed))
+            # How long the chip will take over it -- None for the first, whose
+            # starting level the note-on preamble decides rather than the list.
+            segs.append((dest, speed,
+                         None if level is None else duration(rom.env, level, dest, speed)))
+            level = dest
             if dest == 0:                    # ed89's tsta: zero ends the chain
                 break
             at += 6
@@ -135,7 +195,8 @@ def main():
             continue
         print(f"  part {i}: pitch ${p['pitch']:04x} wave ${p['wave']:04x} "
               f"release {p['release']}")
-        print("      " + "  ".join(f"{d}/{s}" for d, s in p["segments"]))
+        print("      " + "  ".join(
+            f"{d}/{s}" + (f"@{t}" if t is not None else "") for d, s, t in p["segments"]))
 
 
 if __name__ == "__main__":

--- a/tools/rd_extract/rd_parse_check.py
+++ b/tools/rd_extract/rd_parse_check.py
@@ -43,7 +43,8 @@ def load_pack(path):
             segs = [struct.unpack("<IBB", d[at + 6 * i:at + 6 * i + 6])
                     for i in range(nseg + nrel)]
             at += 6 * (nseg + nrel)
-            parts.append((nseg, [(s[1], s[2]) for s in segs]))
+            parts.append((nseg, [(s[1], s[2]) for s in segs],
+                          [s[0] for s in segs]))
         out[(note, vel)] = parts
     return out
 
@@ -58,10 +59,12 @@ def main():
     packs = load_pack(sys.argv[4])
 
     parts = complete = compared = agreed = unaligned = 0
+    timed = timed_ok = 0
     for (note, vel), ref in sorted(packs.items()):
         got = rd_parse.parse(rom, note, vel)["parts"]
         for rp, gp in zip(ref, got):
-            chain, mine = rp[1][:rp[0]], gp["segments"]
+            chain, mine = rp[1][:rp[0]], [(d, s) for d, s, _ in gp["segments"]]
+            stamps, durations = rp[2][:rp[0]], [t for _, _, t in gp["segments"]]
             parts += 1
             if not mine:
                 continue
@@ -77,10 +80,19 @@ def main():
             for i in range(n):
                 compared += 1
                 agreed += theirs[i] == mine[i]
+            # Durations: compare each gap against what the ramp arithmetic says.
+            for i in range(1, min(len(stamps) - skip - 1, len(durations))):
+                want = stamps[skip + i + 1] - stamps[skip + i]
+                if durations[i] is None:
+                    continue
+                timed += 1
+                timed_ok += durations[i] == want
 
     print(f"parts {parts}, segments compared {compared}")
     print(f"  segments agreeing   {100 * agreed / compared:6.2f} %")
     print(f"  chains complete     {100 * complete / parts:6.2f} %")
+    if timed:
+        print(f"  durations exact     {100 * timed_ok / timed:6.2f} %  ({timed_ok}/{timed})")
     if unaligned:
         print(f"  could not align     {unaligned}")
     sys.exit(0 if agreed == compared and not unaligned else 1)


### PR DESCRIPTION
The last thing a pack held that the ROM does not.

## Where a duration comes from

A segment lasts however long the chip takes to ramp from the previous
destination to this one. The increment per sample is `env_table[speed]`, and
bit 7 means downward — the chip gets there by or-ing `$7f << 21` into the
increment and adding a carry, which wraps the 28-bit accumulator into a
subtraction. For speed 172 that works out to **1440 levels a sample, downward**.

```
duration = |distance| // |rate| + 3
```

The **three** is the interrupt's own latency: the chip signalling, and the MCU
getting round to writing the next pair. It shows up as a constant offset across
every segment.

Two by hand, against the capture:

| | computed | measured |
|---|---|---|
| 242 → 251 at speed 60 | **1641** | 1641 |
| 251 → 245 at speed 172 | **4372** | 4372 |

And across the whole pack: **98.40 % exact, 14,493 of 14,728.**

## Where the table comes from

Read out of `rd_new_engine.cpp` rather than copied a third time. It already
carries it as `rdn_env_table`, itself mechanically copied from the reference
emulator's `sound_chip.cpp`, and two copies that can drift apart are enough.

## Which leaves nothing captured

```
parts 3520, segments compared 21655
  segments agreeing   100.00 %
  chains complete      98.18 %
  durations exact      98.40 %
```

Chains, wave addresses, pitches **and** timings all follow from the ROM set. A
pack is a pure function of it now — no emulator, no capture, no second checkout,
and no stale reference quietly producing a different-sounding instrument.

That was the whole point of chasing it.