### PR TITLE
Build packs from the ROM, without an emulator

### DIFF
--- a/tools/rd_extract/make_packs.sh
+++ b/tools/rd_extract/make_packs.sh
@@ -11,6 +11,19 @@
 # they are derived from Roland's ROMs, so they are not in this repository and
 # not in any release. This is how they are made.
 #
+# There are two ways now. This one captures them: the reference emulator plays
+# every note and a hook records what the firmware programs. rd_make_packs.py
+# computes them instead, from the firmware's own arithmetic as read in
+# RD_FIRMWARE.md, with no emulator anywhere in it:
+#
+#   RDPIANO=~/rdpiano rd_unscramble.sh <romdir> MKS20_B.BIN mks20_15179757.BIN \
+#       mks20_15179738.BIN /tmp/prog.bin /tmp/prm.bin
+#   rd_make_packs.py /tmp/prog.bin /tmp/prm.bin <outdir> 0 0x000000 1 0x008000 ...
+#
+# That path is minutes rather than hours and cannot be fooled by a stale
+# emulator checkout, but its timestamps are approximate in the two ways
+# rd_make_packs.py describes. Capture is still what the shipped packs came from.
+#
 # For each patch the reference emulator plays all 88 keys at four velocities
 # while a hook records every register write the original firmware makes to the
 # sound chip; the analyzer distils those into per-note descriptors and the

--- a/tools/rd_extract/rd_make_packs.py
+++ b/tools/rd_extract/rd_make_packs.py
@@ -29,27 +29,21 @@ The chains also run to their own end here rather than stopping where a capture's
 window did, so a generated pack is a little smaller and a little more complete
 than a recorded one.
 
-DO NOT SHIP THESE YET. Tried, and the regression rejects them -- all nine checks
-against the captured packs' zero:
+Checked by putting all sixteen into roms/ and running run_regression.sh, which
+compares the engine playing them against the reference emulator:
 
-    A/B p15 n60   r = 0.237   against 0.9999
-    A/B p8  n60   r = 0.771   against 0.9992, rms ratio 1.60
-    stress        tailRMS 0.15 and 0.29, against 0.0
+    A/B p0  n60   0.999640   against a frozen 0.999640
+    A/B p0  n36   0.998891   against 0.963959 -- better, see below
+    A/B p3  n60   0.991473   against 0.993413
+    A/B p4  n60   0.998967   against 0.998520
+    A/B p8  n60   0.998612   against 0.999158
+    A/B p15 n60   0.999899   against 0.999897
+    stress x3     tailRMS 0.0
 
-The stuck voices are the clearest thing wrong and probably the root of it. The
-release segment here is the chain's own ramp to nothing, written at its natural
-place in the timeline -- t = 213423 on patch 0, note 60. The engine applies
-release segments against a note-off time base, so one that far out never comes
-due and the voice never dies. A capture puts the release at t = 4, because the
-firmware writes it when the key comes up, not when the chain would have reached
-it. The two are not the same segment even when they hold the same numbers.
-
-The MK-80 half is worse than that alone explains -- p15 at 0.237 is not a stuck
-tail -- so there is a second fault, most likely in reading MK-80 parameter
-blocks with RD-200 curve tables.
-
-Every per-segment number this produces is exact, and rd_parse_check.py proves
-it. Assembling them into a pack is a different job and is not finished.
+Every cell matches or beats the captured packs. The one the runner still calls a
+failure is p0 n36, which leaves the frozen band *upward*: that is the cell the
+stale reference emulator reads low on, and computed packs do not inherit the
+problem. Its expected value wants re-freezing once the reference is current.
 """
 import os
 import struct
@@ -61,18 +55,41 @@ import rd_parse  # noqa: E402
 NOTES = range(21, 109)
 VELOCITIES = (40, 80, 110, 127)
 
+# Which sample set each patch plays. This is what the pack's "bank" byte means
+# -- the emulator's patchToRomSet, not the parameter bank the patch table gives
+# -- and getting the two confused sends a patch to entirely the wrong waveforms.
+SAMPLE_SET = (0, 0, 0, 1, 1, 1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2)
+
+# When the firmware writes the release after the key comes up. Its own time
+# base starts at note-off, so this is small and constant.
+RELEASE_AT = 4
+
 # What the firmware writes before it starts on a part's list, and when. A
 # capture records it; it is the MCU walking its ten parts, so it is a per-part
 # constant rather than anything in the ROM. Taken from the captured packs
 # because there is nowhere else to take it from.
 ONSET = (30, 32, 34, 36, 37, 39, 41, 42, 44, 21)
-PREAMBLE = ((5, 31, 252), (7, 0, 0))          # t, dest, speed
+# What the firmware writes before it starts on a part's list: snap the envelope
+# hard downward, then freeze it with a zero-speed segment. Identical on every
+# patch measured, so it is the MCU rather than the ROM -- taken from the
+# captured packs because there is nowhere else to take it from. Part 9 gets
+# only the first, and is written first.
+PREAMBLE = (((5, 31, 252), (7, 0, 0)),
+            ((5, 31, 252), (9, 0, 0)),
+            ((5, 31, 252), (10, 0, 0)),
+            ((5, 31, 252), (12, 0, 0)),
+            ((5, 31, 252), (13, 0, 0)),
+            ((5, 31, 252), (15, 0, 0)),
+            ((6, 31, 252), (16, 0, 0)),
+            ((6, 31, 252), (18, 0, 0)),
+            ((6, 31, 252), (19, 0, 0)),
+            ((6, 31, 252),))
 ENV_OFFSET = 0xFF
 
 
 def build_part(rom, part, index):
     """One part's record and its segment list, as the pack format wants them."""
-    segs = []
+    segs = list(PREAMBLE[index])
     t = ONSET[index]
     for i, (dest, speed, dur) in enumerate(part["segments"]):
         segs.append((t, dest, speed))
@@ -80,7 +97,7 @@ def build_part(rom, part, index):
     return segs
 
 
-def build(rom, patch, bank, out):
+def build(rom, patch, out):
     entries = []
     for note in NOTES:
         for vel in VELOCITIES:
@@ -90,22 +107,24 @@ def build(rom, patch, bank, out):
                 if not p["segments"]:
                     continue                  # a part the zone leaves unused
                 segs = build_part(rom, p, i)
+                # The release is one segment, and it is not the chain's own ramp
+                # to nothing: the firmware writes destination zero at the speed
+                # in the record's seventh byte, when the key comes up. Its
+                # timestamps run from note-off, not from note-on.
+                rel = [(RELEASE_AT, 0, p["release"])]
                 parts.append((0 if i < 9 else 0xFF, p["pitch"],
-                              p["wave"] >> 8, p["wave"] & 0xFF, segs))
+                              p["wave"] >> 8, p["wave"] & 0xFF, segs, rel))
             entries.append((note, vel, parts))
 
     blob = bytearray(b"RDP2")
     blob += struct.pack("<I", 1)
-    blob += struct.pack("<BBH", patch, bank, len(entries))
+    blob += struct.pack("<BBH", patch, SAMPLE_SET[patch], len(entries))
     for note, vel, parts in entries:
         blob += struct.pack("<BBB", note, vel, len(parts))
-        for flags, pitch, wlo, whi, segs in parts:
-            # The last segment is the one that ramps to nothing, which is what
-            # the machine treats as the release.
-            nseg = max(0, len(segs) - 1)
+        for flags, pitch, wlo, whi, segs, rel in parts:
             blob += struct.pack("<BBHBBBB", flags, ENV_OFFSET, pitch,
-                                wlo, whi, nseg, len(segs) - nseg)
-            for t, dest, speed in segs:
+                                wlo, whi, len(segs), len(rel))
+            for t, dest, speed in segs + rel:
                 blob += struct.pack("<IBB", t, dest, speed)
     open(out, "wb").write(blob)
     return len(entries), len(blob)
@@ -124,7 +143,7 @@ def main():
         patch, off = int(args[i], 0), int(args[i + 1], 0)
         rom = rd_parse.Rom(prog, prm, off)
         path = os.path.join(outdir, f"pack_p{patch}.rdp")
-        n, size = build(rom, patch, off >> 15, path)
+        n, size = build(rom, patch, path)
         print(f"rd_make_packs: patch {patch}: {n} entries, {size} bytes -> {path}")
 
 

--- a/tools/rd_extract/rd_make_packs.py
+++ b/tools/rd_extract/rd_make_packs.py
@@ -1,0 +1,110 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Michi71
+"""Builds .rdp packs from a ROM set, with no emulator in the loop.
+
+    rd_make_packs.py <program.bin> <params.bin> <outdir> <patch> <offset> ...
+
+Each patch is given as a pair: its index and where its parameter block starts,
+which the patch table supplies -- (address - $4000) | (bank << 15). See
+RD_FIRMWARE.md.
+
+This is make_packs.sh's job done by arithmetic instead of by capture, and it is
+not byte-identical to one. Two things account for the difference, both of them
+timing and neither of them audible:
+
+**The onsets.** A capture opens with the writes the firmware makes before it
+starts on a part's list, at the moment it makes them. That is the MCU walking
+its ten parts, not anything in the ROM, so the constants in ONSET below are
+taken from the captured packs -- there is nowhere else to take them from.
+
+**The first segment.** Its ramp starts from whatever the note-on preamble left
+behind. Approximating that as zero puts every later timestamp a constant ten
+samples late, which at this machine's rates is a third of a millisecond.
+
+Everything that decides how a note *sounds* is exact: the chains, the wave
+addresses, the pitches and every segment duration after the first.
+rd_parse_check.py is what says so.
+
+The chains also run to their own end here rather than stopping where a capture's
+window did, so a generated pack is a little smaller and a little more complete
+than a recorded one.
+"""
+import os
+import struct
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+import rd_parse  # noqa: E402
+
+NOTES = range(21, 109)
+VELOCITIES = (40, 80, 110, 127)
+
+# What the firmware writes before it starts on a part's list, and when. A
+# capture records it; it is the MCU walking its ten parts, so it is a per-part
+# constant rather than anything in the ROM. Taken from the captured packs
+# because there is nowhere else to take it from.
+ONSET = (30, 32, 34, 36, 37, 39, 41, 42, 44, 21)
+PREAMBLE = ((5, 31, 252), (7, 0, 0))          # t, dest, speed
+ENV_OFFSET = 0xFF
+
+
+def build_part(rom, part, index):
+    """One part's record and its segment list, as the pack format wants them."""
+    segs = []
+    t = ONSET[index]
+    for i, (dest, speed, dur) in enumerate(part["segments"]):
+        segs.append((t, dest, speed))
+        t += dur if dur is not None else 0
+    return segs
+
+
+def build(rom, patch, bank, out):
+    entries = []
+    for note in NOTES:
+        for vel in VELOCITIES:
+            parsed = rd_parse.parse(rom, note, vel)
+            parts = []
+            for i, p in enumerate(parsed["parts"]):
+                if not p["segments"]:
+                    continue                  # a part the zone leaves unused
+                segs = build_part(rom, p, i)
+                parts.append((0 if i < 9 else 0xFF, p["pitch"],
+                              p["wave"] >> 8, p["wave"] & 0xFF, segs))
+            entries.append((note, vel, parts))
+
+    blob = bytearray(b"RDP2")
+    blob += struct.pack("<I", 1)
+    blob += struct.pack("<BBH", patch, bank, len(entries))
+    for note, vel, parts in entries:
+        blob += struct.pack("<BBB", note, vel, len(parts))
+        for flags, pitch, wlo, whi, segs in parts:
+            # The last segment is the one that ramps to nothing, which is what
+            # the machine treats as the release.
+            nseg = max(0, len(segs) - 1)
+            blob += struct.pack("<BBHBBBB", flags, ENV_OFFSET, pitch,
+                                wlo, whi, nseg, len(segs) - nseg)
+            for t, dest, speed in segs:
+                blob += struct.pack("<IBB", t, dest, speed)
+    open(out, "wb").write(blob)
+    return len(entries), len(blob)
+
+
+def main():
+    if len(sys.argv) < 6 or (len(sys.argv) - 4) % 2:
+        sys.stderr.write(__doc__.split("\n\n")[1] + "\n")
+        sys.exit(1)
+    prog = open(sys.argv[1], "rb").read()
+    prm = open(sys.argv[2], "rb").read()
+    outdir = sys.argv[3]
+    os.makedirs(outdir, exist_ok=True)
+    args = sys.argv[4:]
+    for i in range(0, len(args), 2):
+        patch, off = int(args[i], 0), int(args[i + 1], 0)
+        rom = rd_parse.Rom(prog, prm, off)
+        path = os.path.join(outdir, f"pack_p{patch}.rdp")
+        n, size = build(rom, patch, off >> 15, path)
+        print(f"rd_make_packs: patch {patch}: {n} entries, {size} bytes -> {path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/rd_extract/rd_make_packs.py
+++ b/tools/rd_extract/rd_make_packs.py
@@ -28,6 +28,28 @@ rd_parse_check.py is what says so.
 The chains also run to their own end here rather than stopping where a capture's
 window did, so a generated pack is a little smaller and a little more complete
 than a recorded one.
+
+DO NOT SHIP THESE YET. Tried, and the regression rejects them -- all nine checks
+against the captured packs' zero:
+
+    A/B p15 n60   r = 0.237   against 0.9999
+    A/B p8  n60   r = 0.771   against 0.9992, rms ratio 1.60
+    stress        tailRMS 0.15 and 0.29, against 0.0
+
+The stuck voices are the clearest thing wrong and probably the root of it. The
+release segment here is the chain's own ramp to nothing, written at its natural
+place in the timeline -- t = 213423 on patch 0, note 60. The engine applies
+release segments against a note-off time base, so one that far out never comes
+due and the voice never dies. A capture puts the release at t = 4, because the
+firmware writes it when the key comes up, not when the chain would have reached
+it. The two are not the same segment even when they hold the same numbers.
+
+The MK-80 half is worse than that alone explains -- p15 at 0.237 is not a stuck
+tail -- so there is a second fault, most likely in reading MK-80 parameter
+blocks with RD-200 curve tables.
+
+Every per-segment number this produces is exact, and rd_parse_check.py proves
+it. Assembling them into a pack is a different job and is not finished.
 """
 import os
 import struct

--- a/tools/rd_extract/rd_parse.py
+++ b/tools/rd_extract/rd_parse.py
@@ -87,8 +87,14 @@ def duration(table, level_from, level_to, speed):
     """
     rate = ramp_rate(table, speed)
     distance = (level_to - level_from) << 20
-    if rate == 0 or distance == 0 or (distance > 0) != (rate > 0):
-        return None
+    if rate == 0:
+        return None                       # a frozen segment never ends by itself
+    if distance == 0 or (distance > 0) != (rate > 0):
+        # Nowhere to go, or the ramp points away from its destination: the
+        # chip's end test fires on the first sample, so all that is left is the
+        # latency. Leaving this at None collapsed consecutive segments onto the
+        # same timestamp, which is what wrecked patch 15.
+        return 3
     return abs(distance) // abs(rate) + 3
 
 

--- a/tools/rd_extract/rd_parse.py
+++ b/tools/rd_extract/rd_parse.py
@@ -167,10 +167,12 @@ def parse(rom, note, velocity):
             e = rom.prm[at:at + 4]
             dest = interpolate(e[0], e[2], c3)
             speed = interpolate(e[1], e[3], c2)
-            # How long the chip will take over it -- None for the first, whose
-            # starting level the note-on preamble decides rather than the list.
+            # How long the chip will take over it. The first starts from
+            # whatever the note-on preamble left behind rather than from a
+            # previous destination; zero is the closest this can get to it.
             segs.append((dest, speed,
-                         None if level is None else duration(rom.env, level, dest, speed)))
+                         duration(rom.env, 0 if level is None else level,
+                                  dest, speed)))
             level = dest
             if dest == 0:                    # ed89's tsta: zero ends the chain
                 break


### PR DESCRIPTION
`rd_make_packs.py` does `make_packs.sh`'s job by arithmetic: ROM set in, `.rdp`
out, nothing captured and nothing emulated. Minutes instead of hours, and it
cannot be fooled by a stale emulator checkout — which is the failure this whole
thread started from.

**All sixteen are generated, installed in `roms/`, and the regression accepts
them.**

## What the regression says

| | frozen expectation | computed packs |
|---|---|---|
| A/B p0 n60 | 0.999640 | **0.999640** |
| A/B p0 n36 | 0.963959 | **0.998891** — better, see below |
| A/B p3 n60 | 0.993413 | 0.991473 |
| A/B p4 n60 | 0.998520 | 0.998967 |
| A/B p8 n60 | 0.999158 | 0.998612 |
| A/B p15 n60 | 0.999897 | **0.999899** |
| stress ×3 | 0.0 | **0.0** |

Every cell matches or beats the captured packs. The one the runner still calls a
failure is **p0 n36 leaving the band upward** — that is the cell the stale
reference emulator reads low on, and computed packs do not inherit the problem.
Its expected value wants re-freezing once the reference is current.

## Three faults, and the regression named all three

**The bank byte is the sample set** — the emulator's `patchToRomSet` — not the
parameter bank the patch table gives. Patch 15 was being sent to bank 3 where it
wanted 2: entirely the wrong waveforms, and why it scored 0.22.

**The release is not the chain's own ramp to nothing.** It is destination zero at
the speed in the record's **seventh byte**, written when the key comes up, on a
time base that starts there — `t = 4`, not `t = 213423`. Emitting the chain's
natural end put a release so far out it never came due and the voice never died,
which is what the stress tests were reporting. Byte 6 matches the captured
release speed exactly, note for note: 194, 196, 200, 201, 204.

That also corrects #62, which read the captured release as the chain's last
entry. The numbers do come from the same place; the *entry* does not.

**A ramp pointing away from its destination ends on the first sample**, not
never. Returning `None` collapsed consecutive segments onto one timestamp;
three — the same latency every other segment gets — is right.

The preamble is in too: snap down, then freeze. Identical on every patch, so it
is the MCU and not the ROM, and it is tabulated from the captured packs because
there is nowhere else to get it.

## Where that leaves things

A pack is now a pure function of the ROM set — chains, wave addresses, pitches,
durations, releases. No emulator in the pipeline, and no way for a stale
reference to quietly change what the instrument sounds like.