### PR TITLE
Say what a full build actually needs, and test that it works

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,38 @@ version used to read `0.1` in every build ever made, which identified nothing.
 
 A tarball without `.git` builds fine and shows `unknown`.
 
+### The three that need ROMs
+
+`PicoFaceRD`, `PicoFaceJV` and `PicoFaceD5` play the original machines' own
+data, which is not distributable. Each looks in its own `roms/` directory —
+`instruments/<name>/roms/`, gitignored — and removes itself from the build with
+a note if what it needs is not there. Nothing else is affected.
+
+| | what goes in `roms/` | |
+|---|---|---|
+| **PicoFaceD5** | two PCM ROMs and a program EPROM | identified by CRC32, so **names do not matter** |
+| | | plus optional `*.syx` bulk dumps for the patch banks |
+| **PicoFaceJV** | `jv880_rom2.bin`, `jv880_waverom1.bin`, `jv880_waverom2.bin` | exact names, 256 KB + 2 MB + 2 MB |
+| **PicoFaceRD** | `mks20_15179736.BIN` … `41.BIN`, `MK80_IC5.bin`, `MK80_IC6.bin`, `MK80_IC7.bin` | exact names, 128 KB each |
+| | `pack_p0.rdp` … `pack_p15.rdp` | **built, not found** — see below |
+
+**The RD needs two things nobody else does.** Its sixteen `.rdp` packs are note
+descriptors derived from those ROMs, and they have to be made once:
+
+```bash
+git clone https://github.com/Michi71/rdpiano ~/rdpiano
+tools/rd_extract/rd_unscramble.sh instruments/PicoFaceRD/roms \
+    RD200_B.bin mks20_15179757.BIN mks20_15179738.BIN /tmp/prog.bin /tmp/prm.bin
+python3 tools/rd_extract/rd_make_packs.py /tmp/prog.bin /tmp/prm.bin \
+    instruments/PicoFaceRD/roms 0 0x000000 1 0x008000 …
+```
+
+That checkout is also what the build itself needs, once, to descramble the
+sample ROMs — set `RDPIANO` when configuring. Neither it nor anything from it
+is in this repository; see
+[`instruments/PicoFaceRD/README.md`](instruments/PicoFaceRD/README.md) for the
+whole recipe and the patch offsets.
+
 Building a single instrument:
 
 ```bash

--- a/instruments/PicoFaceD5/README.md
+++ b/instruments/PicoFaceD5/README.md
@@ -15,11 +15,16 @@ and everybody else's build stays green.
 Put the D-50's ROM images in `roms/` (gitignored). Files are identified by
 content, so their names do not matter:
 
-| Image | Size | Purpose |
-|---|---|---|
-| PCM ROM A (IC30) | 256 KB | lower half of the sample data |
-| PCM ROM B (IC29) | 256 KB | upper half |
-| program EPROM (IC22) | 64 KB | the PCM names |
+| Image | Size | CRC32 | Purpose |
+|---|---|---|---|
+| PCM ROM A (IC30) | 256 KB | `1461C0FB` | lower half of the sample data |
+| PCM ROM B (IC29) | 256 KB | `E50599BF` | upper half |
+| PCM combined (late boards) | 512 KB | `E2AED2D9` | A and B in one chip, accepted in place of the pair |
+| program EPROM (IC22) | 64 KB | any known version | the PCM names |
+
+The EPROM versions the converter recognises are v1.04, v1.10, v2.10, v2.20,
+v2.21, v2.22 and v1.06; an unknown 64 KB image carrying the name table is
+accepted with a warning. `tools/d5_extract/d5_rom.py` holds the checksums.
 
 512 KB dumps that contain a 256 KB chip twice are folded automatically, and a
 combined 512 KB image of both chips is accepted in place of the pair. The

--- a/instruments/PicoFaceRD/README.md
+++ b/instruments/PicoFaceRD/README.md
@@ -18,10 +18,26 @@ distributable, and nothing derived from it is in this repository either.
 
 | File | Size | What it is |
 |---|---|---|
-| `mks20_15179736/37/38.BIN` | 128 KB each | MKS-20 sample chips, first set |
-| `mks20_15179739/40/41.BIN` | 128 KB each | MKS-20 sample chips, second set |
-| `MK80_IC5/IC6/IC7.bin` | 128 KB each | MK-80 sample chips |
-| `pack_p0.rdp` … `pack_p15.rdp` | ~3.2 MB total | the note descriptors, one file per patch |
+| `mks20_15179736.BIN`, `mks20_15179737.BIN`, `mks20_15179738.BIN` | 128 KB each | MKS-20 sample chips, first set |
+| `mks20_15179739.BIN`, `mks20_15179740.BIN`, `mks20_15179741.BIN` | 128 KB each | MKS-20 sample chips, second set |
+| `MK80_IC5.bin`, `MK80_IC6.bin`, `MK80_IC7.bin` | 128 KB each | MK-80 sample chips |
+| `pack_p0.rdp` … `pack_p15.rdp` | ~3.3 MB total | the note descriptors, one file per patch |
+
+Three more are needed to *make* the packs, though not to build once they exist:
+
+| File | Size | What it is |
+|---|---|---|
+| `mks20_15179757.BIN` | 128 KB | MKS-20 parameter ROM |
+| `MK80_IC18.bin` | 128 KB | MK-80 parameter ROM |
+| `RD200_B.bin` | 8 KB | sound-CPU firmware |
+
+All names are as the preserved dumps carry them. **`RD200_B.bin` and not one of
+the MKS-20's own** — the parser follows that firmware's arithmetic, and looks
+for its velocity curves at `$ed9d`, where the MKS-20's ROMs keep theirs
+somewhere else. It makes no audible difference which is used: the two sets of
+curves differ by at most 2 in 252, and building patch 0 both ways gives 25,539
+segments and not one different. But the parser has one address compiled in, and
+it is that one.
 
 The nine ROMs become a 1.81 MB blob at configure time: three packed sample banks
 and the chip's two arithmetic tables, which is all the engine reads. Building it
@@ -40,8 +56,35 @@ need nothing but Python.
 
 ### Where the packs come from
 
-They are capture output, and they are the one input here that cannot be
-downloaded from anywhere. Making them:
+They are the one input here that cannot be downloaded from anywhere. There are
+two ways to make them, and the first is the one that made the packs this
+instrument ships with.
+
+**Computed, from the ROMs.** The firmware's own arithmetic, rewritten from the
+disassembly in [`tools/rd_extract/RD_FIRMWARE.md`](../../tools/rd_extract/RD_FIRMWARE.md).
+Minutes, and no emulator runs:
+
+```bash
+git clone https://github.com/Michi71/rdpiano ~/rdpiano
+R=instruments/PicoFaceRD/roms
+RDPIANO=~/rdpiano tools/rd_extract/rd_unscramble.sh $R \
+    RD200_B.bin mks20_15179757.BIN mks20_15179738.BIN /tmp/prog.bin /tmp/mks.bin
+RDPIANO=~/rdpiano tools/rd_extract/rd_unscramble.sh $R \
+    RD200_B.bin MK80_IC18.bin MK80_IC5.bin /tmp/x.bin /tmp/mk80.bin
+python3 tools/rd_extract/rd_make_packs.py /tmp/prog.bin /tmp/mks.bin $R \
+    0 0x000000 1 0x008000 2 0x010000 3 0x018000 \
+    4 0x003c20 5 0x00ab50 6 0x014260 7 0x01bef0
+python3 tools/rd_extract/rd_make_packs.py /tmp/prog.bin /tmp/mk80.bin $R \
+    8 0x000020 9 0x008000 10 0x010000 11 0x018000 \
+    12 0x002c00 13 0x00b1f0 14 0x012910 15 0x0199f0
+```
+
+Those sixteen offsets are the patch tables, read out of the ROMs themselves --
+the MKS-20 keeps its in its sound-CPU ROM at `$e82b`, the MK-80 at the head of
+its parameter ROM. `RD_FIRMWARE.md` says how.
+
+**Captured, by playing every note.** The older way, and how the packs were first
+made. Hours rather than minutes, and it needs a second checkout:
 
 ```bash
 git clone https://github.com/Michi71/librdpiano ~/librdpiano

--- a/tools/rd_extract/RD_FIRMWARE.md
+++ b/tools/rd_extract/RD_FIRMWARE.md
@@ -809,6 +809,51 @@ Only three parameter-ROM reads in the whole firmware use a fixed address
 (`$babf`, `$bbc1`, `$babd`); everything else is indexed, which is why all of
 this had to be read rather than grepped for.
 
+## Is the MKS-20's firmware the same?
+
+Everything above was read out of the RD-200's, because that is what the
+reference emulator runs -- while playing MKS-20 data. Which raises a fair
+question: does a real MKS-20 read its own parameter ROM the same way?
+
+**Where it counts, yes.** The layout constants are byte-identical in all three
+sound-CPU ROMs -- `#$15` for the 21-byte zone entry, `#$46` for the 70-byte part
+block, `addd #$0100` and `addd #$081f` for the two bases. So is the
+interpolation: the same four corners at the same offsets, the same two weights,
+the same order, and the same layer rule.
+
+Three things do differ, and none of them reaches the sound.
+
+**The RAM.** The RD-200 packs its per-part state as `$0200 + (voice*10 + part)*6`
+-- the multiply-by-`$a0`-and-take-the-high-byte trick. The MKS-20 indexes flat
+by the chip's raw id, `$0200 + id*6`, which is sixteen slots a voice where ten
+are used. Ninety-six bytes a voice against sixty; the RD-200 is the tighter,
+later arrangement, and it saves 576 bytes across sixteen voices. The velocity
+weights sit at `$0055` there rather than `$0040`.
+
+**Where the layer offset is applied.** The MKS-20 adds it to X inside the
+interrupt, every time; the RD-200 adds it once to the stored pointer at note-on.
+Same result.
+
+**The command set.** The MKS-20's dispatch table has no program change, no note
+off and no sustain -- its main CPU does that work. It selects patches with `$40`
+and keeps its patch table in its own program ROM rather than at the head of the
+parameter ROM.
+
+## The velocity curves differ, and it does not matter
+
+The eight curves are not byte-identical. Curve 0, the straight ramp, is; the
+other seven differ by **at most 2 out of 252**, mean 0.05 to 0.42, and every
+endpoint agrees. The two MKS-20 ROMs agree with each other exactly, so it is the
+RD-200 that was retuned.
+
+Whether that reaches a pack is a question with an answer rather than an opinion:
+building patch 0 both ways and comparing gives **25,539 segments, not one
+different**. A weight off by two moves an interpolated corner by a fraction of a
+level, and the high byte the chip is handed does not notice.
+
+So the packs this repository builds are what an MKS-20 would play, and the one
+real difference between the firmwares is invisible at the output.
+
 ## Why this matters
 
 The packs can become a pure function of the ROM set: no emulator, no second

--- a/tools/rd_extract/rd_parse.py
+++ b/tools/rd_extract/rd_parse.py
@@ -127,7 +127,15 @@ class Rom:
     def curve(self, which, index):
         base = (self.prog[CURVE_TABLE - PROG_BASE + 2 * which] << 8) \
              | self.prog[CURVE_TABLE - PROG_BASE + 2 * which + 1]
-        return self.prog[base - PROG_BASE + index]
+        off = base - PROG_BASE + index
+        if not (0 <= off < len(self.prog)):
+            raise SystemExit(
+                f"rd_parse: no velocity curve at ${base:04x}. CURVE_TABLE is "
+                f"${CURVE_TABLE:04x}, which is where the RD-200's firmware "
+                f"keeps it -- the MKS-20's own sound-CPU ROMs put it elsewhere "
+                f"(${0xe80b:04x} and ${0x7c8 + 0xe000:04x}). Pass RD200_B.bin "
+                f"as the program ROM.")
+        return self.prog[off]
 
 
 def zone_of(note):


### PR DESCRIPTION
> Stacked on #71 — this branch came off it, so its commit shows here too.

The three instruments that need ROMs said so, but not usefully enough for
someone who **has** the files and wants to know which ones.

## What changed

**The root README** gains a table of what goes in each `roms/` directory: exact
names for the JV and the RD, *identified by CRC32, names do not matter* for the
D-50, and the RD's extra step of building its packs before it can build at all.

**The D-50's table** gains the reference CRC32s — `1461C0FB`, `E50599BF`,
`E2AED2D9` — so a dump can be checked rather than hoped about, plus the seven
EPROM versions the converter knows.

**The RD's file list** stops using slash shorthand (`mks20_15179736/37/38.BIN`)
and names all twelve files, and its pack recipe gains the **computed path** —
which is where the shipped packs came from and which the README did not mention
at all, offering only the capture that takes hours.

## Then I ran the recipe as written

Which was worth doing, because it did not work:

- **Three of the twelve ROMs were not in `roms/` at all.** The first command
  failed on a missing file, and the file list had never mentioned them.
- **The snippet called the tools directly** where this repository invokes Python
  tools with `python3` everywhere else.
- **It named `MKS20_B.BIN` as the program ROM**, which dies with an `IndexError`:
  the parser looks for velocity curves at `$ed9d`, and that is the *RD-200's*
  address. The MKS-20's own ROMs keep theirs at `$e80b`. `rd_parse` now says
  that in words instead of crashing.

That last one is worth keeping in mind: it makes **no audible difference** which
firmware's curves are used — #71 measured 25,539 segments and not one different
— but the parser has one address compiled in, and it is the RD-200's.

## And then it worked

```
16 von 16 bytegleich mit den ausgelieferten
```

The documented commands reproduce all sixteen shipped packs **byte for byte**.
