### PR TITLE
A clean-clone build check for the three ROM instruments

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,12 @@ python3 tools/rd_extract/rd_make_packs.py /tmp/prog.bin /tmp/prm.bin $R \
 Python and the ROMs, nothing else -- no emulator, no toolchain beyond the one
 already building the firmware.
 
+**To check that all of this actually works from scratch**, `tools/check_clean_build.sh`
+clones into a temporary directory, copies the ROMs in from outside git, and
+builds all ten. That last part is the point: the ROM sets are not in this
+repository and must never be, so a build here is the one thing CI cannot cover.
+Add `--variants` to build the reduced images too.
+
 **On a 4 MB Pico 2**, RD ships one machine instead of two:
 `-DPICOFACERD_MODEL=MKS20` (3.01 MB) or `=MK80` (2.53 MB), eight patches each,
 and only that machine's ROMs are needed. The default `BOTH` is sixteen patches

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -353,6 +353,10 @@ These defines are deliberately not unified in the helper but set per instrument 
   hold them: the effect chip's algorithms (chorus, equalizer and the 32 reverb
   types stand on the MT-32's Boss reverb as munt documents it) and the absolute
   clock of the envelope ramps, which is calibrated against recordings.
+- `tools/check_clean_build.sh` builds the collection from a fresh clone with the
+  ROMs copied in from outside git. Three instruments need a local ROM set that
+  cannot be in the repository, so whether a stranger with the right ROMs can
+  build them is precisely what CI does not test.
 - PicoFaceRD builds from a ROM set and Python alone -- the descrambling is
   `tools/rd_extract/rd_descramble.py`, the note descriptors are computed from
   the sound CPU's own arithmetic as read out of its firmware, and no emulator

--- a/tools/check_clean_build.sh
+++ b/tools/check_clean_build.sh
@@ -1,0 +1,148 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: MIT
+# SPDX-FileCopyrightText: 2026 Michi71
+#
+# Builds the whole collection from a fresh clone, the way somebody who just
+# found the repository would.
+#
+#     tools/check_clean_build.sh [--local] [--variants] [--keep]
+#
+# The point is the ROMs. Three instruments need a local ROM set, and those sets
+# are not in the repository and must never be -- so the one thing a build here
+# never exercises is whether a stranger with the right ROMs can actually build
+# them. Everything else is covered by CI; this is not.
+#
+# So: clone into a temporary directory, copy the ROMs in from outside git, and
+# build. If the instructions have drifted, this is what says so -- when it was
+# first run against the RD's documented recipe it found three real faults,
+# including a ROM the instructions named that was not in roms/ at all.
+#
+#   --local     clone from this checkout instead of GitHub (no network; tests
+#               what is committed here, including branches not yet pushed)
+#   --variants  also build the reduced images: PICOFACEJV_4MB=ON and
+#               PICOFACERD_MODEL=MK80. Roughly doubles the time.
+#   --keep      leave the temporary tree behind for poking at
+#
+# Where the ROMs come from:
+#
+#   PICOFACE_ROMS=/path   a directory holding PicoFaceD5/, PicoFaceJV/ and
+#                         PicoFaceRD/ subdirectories of ROM files
+#   unset                 this checkout's own instruments/*/roms
+#
+# An instrument whose ROMs are absent is reported as skipped, not as a failure:
+# that is the designed behaviour, and it is worth confirming too.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$HERE/.." && pwd)"
+URL="https://github.com/Michi71/PicoVintageSynthCollection"
+ROM_INSTRUMENTS=(PicoFaceD5 PicoFaceJV PicoFaceRD)
+
+local_clone=0; variants=0; keep=0
+for arg in "$@"; do
+    case "$arg" in
+        --local)    local_clone=1 ;;
+        --variants) variants=1 ;;
+        --keep)     keep=1 ;;
+        -h|--help)  sed -n '3,40p' "$0" | sed 's/^# \{0,1\}//'; exit 0 ;;
+        *) echo "check_clean_build: unknown option $arg" >&2; exit 2 ;;
+    esac
+done
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/picoface-clean.XXXXXX")"
+cleanup () {
+    if [ "$keep" -eq 1 ]; then echo "tree kept at $WORK"
+    else rm -rf "$WORK"; fi
+}
+trap cleanup EXIT
+TREE="$WORK/PicoVintageSynthCollection"
+
+say () { printf '\n== %s\n' "$*"; }
+
+# ---------------------------------------------------------------- fresh clone
+if [ "$local_clone" -eq 1 ]; then
+    say "cloning from this checkout"
+    git clone --quiet "$REPO" "$TREE" || exit 1
+    # A local clone starts on whatever HEAD pointed at; make that explicit.
+    branch="$(git -C "$REPO" rev-parse --abbrev-ref HEAD)"
+    git -C "$TREE" checkout --quiet "$branch" 2>/dev/null || true
+    echo "   branch $branch, commit $(git -C "$TREE" rev-parse --short HEAD)"
+else
+    say "cloning $URL"
+    git clone --quiet "$URL" "$TREE" || exit 1
+    echo "   commit $(git -C "$TREE" rev-parse --short HEAD)"
+fi
+
+say "submodules"
+git -C "$TREE" submodule update --init --recursive --quiet || exit 1
+git -C "$TREE" submodule status --recursive | awk '{printf "   %s %s\n", substr($1,1,7), $2}'
+
+# ------------------------------------------------------------------- the ROMs
+say "ROM sets"
+src_root="${PICOFACE_ROMS:-}"
+for inst in "${ROM_INSTRUMENTS[@]}"; do
+    if [ -n "$src_root" ]; then src="$src_root/$inst"
+    else src="$REPO/instruments/$inst/roms"; fi
+    dst="$TREE/instruments/$inst/roms"
+    if [ -d "$src" ] && [ -n "$(ls -A "$src" 2>/dev/null)" ]; then
+        mkdir -p "$dst"
+        # -f follows symlinks, so a ROM directory kept as links into another
+        # checkout works as well as one holding the files -- which is how at
+        # least one of these is actually kept. Directories and dangling links
+        # are skipped rather than erroring.
+        for f in "$src"/*; do
+            [ -f "$f" ] || continue
+            cp -L "$f" "$dst/"
+        done
+        printf '   %-12s %2d files from %s\n' "$inst" "$(ls -1 "$dst" 2>/dev/null | wc -l | tr -d ' ')" "$src"
+    else
+        printf '   %-12s none (expected at %s) -- will be skipped\n' "$inst" "$src"
+    fi
+done
+
+# -------------------------------------------------------------------- the build
+build_one () {          # $1 = label, $2.. = extra -D flags
+    local label="$1"; shift
+    local dir="$WORK/build-$label"
+    say "configure + build: $label"
+    if ! cmake -S "$TREE" -B "$dir" -G Ninja -DCMAKE_BUILD_TYPE=Release "$@" \
+            > "$WORK/$label.configure.log" 2>&1; then
+        echo "   CONFIGURE FAILED -- $WORK/$label.configure.log"
+        tail -15 "$WORK/$label.configure.log" | sed 's/^/     /'
+        return 1
+    fi
+    grep -E 'PicoFace[A-Za-z0-9]+: skipped' "$WORK/$label.configure.log" | sed 's/^-- /   /'
+    if ! cmake --build "$dir" > "$WORK/$label.build.log" 2>&1; then
+        echo "   BUILD FAILED -- $WORK/$label.build.log"
+        grep -iE '\berror\b' "$WORK/$label.build.log" | head -10 | sed 's/^/     /'
+        return 1
+    fi
+    for uf2 in "$dir"/*.uf2; do
+        [ -e "$uf2" ] || continue
+        local n; n="$(basename "$uf2" .uf2)"
+        local bytes; bytes="$(wc -c < "$dir/$n.bin" 2>/dev/null || echo 0)"
+        local fits="fits 4 MB"
+        [ "$bytes" -ge 4194304 ] && fits="needs a bigger board"
+        printf '   %-13s %9d bytes  %s\n' "$n" "$bytes" "$fits"
+    done
+    return 0
+}
+
+rc=0
+build_one full || rc=1
+if [ "$variants" -eq 1 ]; then
+    build_one jv4mb -DPICOFACE_INSTRUMENTS_FILTER=PicoFaceJV -DPICOFACEJV_4MB=ON || rc=1
+    build_one rdmk80 -DPICOFACE_INSTRUMENTS_FILTER=PicoFaceRD -DPICOFACERD_MODEL=MK80 || rc=1
+fi
+
+# ------------------------------------------------------------------- the verdict
+say "result"
+built="$(ls -1 "$WORK/build-full"/*.uf2 2>/dev/null | wc -l | tr -d ' ')"
+echo "   $built of 10 instruments built"
+if [ "$rc" -eq 0 ] && [ "$built" -gt 0 ]; then
+    echo "CLEAN BUILD PASS"
+else
+    echo "CLEAN BUILD FAIL"
+    rc=1
+fi
+exit $rc


### PR DESCRIPTION
CI builds seven of the ten instruments. The other three need a local ROM set
that is not in this repository and must never be — so **the one thing no build
here exercises is whether somebody who has the right ROMs can build them from a
clone.**

That gap is not hypothetical. It is where the RD's documented recipe quietly
rotted until [#72](https://github.com/Michi71/PicoVintageSynthCollection/pull/72)
actually ran it: it named a ROM that was not in `roms/` at all, did not use
`python3` the way the rest of the repository does, and named the wrong file as
the program ROM — which dies with an `IndexError` deep inside the parser rather
than saying anything a reader could act on.

```bash
tools/check_clean_build.sh            # clone from GitHub, build all ten
tools/check_clean_build.sh --local    # clone from this checkout instead
tools/check_clean_build.sh --variants # plus the two reduced images
```

The ROMs come from `PICOFACE_ROMS` (a directory with `PicoFaceD5/`,
`PicoFaceJV/`, `PicoFaceRD/` subdirectories), or from this checkout's own
`instruments/*/roms` if that is unset. **Nothing ever puts a ROM into git** —
they are copied into the temporary tree, which is removed unless `--keep`.

An instrument whose ROMs are absent is reported as skipped rather than failing:
that is the designed behaviour, and worth confirming too.

### One bug in the first draft, worth recording

The JV's `roms/` here is **symlinks into another checkout**, not files. `find
-maxdepth 1 -type f` does not follow links, so the first run reported
`PicoFaceJV 0 files` and the build skipped it. Reported as-is that would have
read like a missing ROM set. It copies with `[ -f "$f" ]` now, which follows
links, and skips directories and dangling links instead of erroring.

### Verified

10 of 10 from a GitHub clone and from a local one, plus `PICOFACEJV_4MB=ON`
(3.95 MB) and `PICOFACERD_MODEL=MK80` (2.65 MB). The sizes it reports match the
flash table in the README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
