### PR TITLE
Measure the RD regression against the reference, not an adaptation

### DIFF
--- a/instruments/PicoFaceRD/README.md
+++ b/instruments/PicoFaceRD/README.md
@@ -269,7 +269,7 @@ section 8.
 Everything is verified host-first on the Mac/Linux side before it touches the device:
 
 ```sh
-RDPIANO=~/rdpiano RDPIANO_REF=~/librdpiano tools/rd_extract/run_regression.sh
+RDPIANO=~/rdpiano tools/rd_extract/run_regression.sh
 ```
 
 builds the sample banks and the packs from `roms/` exactly as the firmware
@@ -279,9 +279,11 @@ expected correlations, and runs stuck-voice stress tests (chord hammering with
 sustain pedal, single- and dual-thread). `REGRESSION PASS/FAIL` with an exit
 code.
 
-Two checkouts, because they are two different things: `RDPIANO` is the upstream
-emulator, whose firmware execution is what the capture watches; `RDPIANO_REF`
-is the adapted one with the model tables
+`RDPIANO` is [giulioz/rdpiano](https://github.com/giulioz/rdpiano) in its
+**original state** -- the A/B test measures against that and refuses an adapted
+copy, because an adaptation can carry per-patch tone shaping the original does
+not have, and then the test measures the adaptation. The capture path is the
+one that wants `RDPIANO_REF`, the adapted one with the model tables
 compiled in, which is what the A/B test compares against. The extraction and
 analysis toolchain is documented in
 [tools/rd_extract/README.md](../../tools/rd_extract/README.md).

--- a/tools/rd_extract/README.md
+++ b/tools/rd_extract/README.md
@@ -14,8 +14,14 @@ shorthand for the instrument directory.
 | | what | why |
 |---|---|---|
 | `$I/roms/` | nine sample ROMs, sixteen `.rdp` packs | Roland's, and data derived from it |
-| `RDPIANO` | a checkout of [Michi71/rdpiano](https://github.com/Michi71/rdpiano) | the firmware execution the *capture* watches |
-| `RDPIANO_REF` | a checkout of [Michi71/librdpiano](https://github.com/Michi71/librdpiano) | the adapted emulator the A/B test measures against |
+| `RDPIANO` | a checkout of [giulioz/rdpiano](https://github.com/giulioz/rdpiano), **original** | the reference the A/B test measures against |
+| `RDPIANO_REF` | a checkout of [Michi71/librdpiano](https://github.com/Michi71/librdpiano) | the adapted emulator the *capture* drives |
+
+**The A/B reference must be the original, not an adaptation of it.** An adapted
+copy can carry a hand-written per-patch voicing table -- gain, brightness,
+saturation, noise, ten partials each -- live in its output path and absent from
+the original; measuring against that measures the adaptation.
+`run_regression.sh` refuses a checkout whose `sound_chip.cpp` has one.
 
 Only `make_packs.sh` (the capture path) and `run_regression.sh` (the A/B test)
 want those two. `check_variants.sh`, which proves the 4 MB single-machine
@@ -198,7 +204,7 @@ lever is real; the measurement to derive it from is not this one.
 
 ## Regression runner (one command)
 
-    RDPIANO=~/rdpiano RDPIANO_REF=~/librdpiano tools/rd_extract/run_regression.sh
+    RDPIANO=~/rdpiano tools/rd_extract/run_regression.sh
 
 Builds the sample banks and the packs from `$I/roms/` exactly as the firmware
 build does — so the test covers exactly what ships — then `rd_ab_test` and

--- a/tools/rd_extract/rd_ab_test.cpp
+++ b/tools/rd_extract/rd_ab_test.cpp
@@ -1,16 +1,43 @@
 // SPDX-License-Identifier: GPL-3.0-or-later
 // SPDX-FileCopyrightText: 2026 Michi71
 
-// rd_ab_test.cpp -- A/B comparison: RdNewEngine vs Mcu reference emulator
+// rd_ab_test.cpp -- A/B comparison: RdNewEngine against the reference emulator.
+//
+//   rd_ab_test <romdir> <packdir> <patch> <note> <vel> [wav-prefix]
+//
+// The reference is giulioz/rdpiano in its original state. That used to be an
+// adapted copy of it, and the difference is not cosmetic: the adaptation grew
+// a hand-written per-patch voicing table (gain, brightness, saturation, noise)
+// that the original does not have and that is live in its output path. A
+// regression measured against it would be measuring the adaptation.
+//
+// The original takes ROM images rather than compiled-in tables and has no
+// loadPatch, so patch selection is done the way its firmware does it: mount
+// the patch's parameter block with loadSounds, then hand the sound CPU the
+// panel bytes 0x31 0x30. The three tables below are the mapping, and they are
+// the same ones rd_make_packs.py uses.
 #include "rd_new_engine.h"
 #include "mcu.h"
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
 #include <vector>
+#include <string>
 #include <cmath>
 #include <cstdint>
 #include <algorithm>
+
+static const u8 SET[16]     = {0,0,0,1,1,1,1,1,2,2,2,2,2,2,2,2};
+static const int RATE[16]   = {20000,20000,20000,32000,32000,20000,20000,32000,
+                               20000,20000,20000,32000,20000,20000,32000,20000};
+static const size_t OFF[16] = {
+    0x000000,0x008000,0x010000,0x018000,0x003c20,0x00ab50,0x014260,0x01bef0,
+    0x000020,0x008000,0x010000,0x018000,0x002c00,0x00b1f0,0x012910,0x0199f0};
+static const char* SAMPLES[3][3] = {
+    {"mks20_15179738.BIN","mks20_15179737.BIN","mks20_15179736.BIN"},
+    {"mks20_15179741.BIN","mks20_15179740.BIN","mks20_15179739.BIN"},
+    {"MK80_IC5.bin","MK80_IC6.bin","MK80_IC7.bin"}};
+static const char* PARAMS[3] = {"mks20_15179757.BIN","mks20_15179757.BIN","MK80_IC18.bin"};
 
 static void w16(FILE* f, uint16_t v) { fwrite(&v, 2, 1, f); }
 static void w32(FILE* f, uint32_t v) { fwrite(&v, 4, 1, f); }
@@ -19,84 +46,83 @@ static void writeWav(const char* path, const std::vector<int32_t>& buf, uint32_t
     FILE* f = fopen(path, "wb");
     if (!f) { fprintf(stderr, "Cannot write %s\n", path); return; }
     uint32_t dataSize = (uint32_t)(buf.size() * 2);
-    fwrite("RIFF", 1, 4, f);
-    w32(f, 36 + dataSize);
-    fwrite("WAVE", 1, 4, f);
-    fwrite("fmt ", 1, 4, f);
-    w32(f, 16);
-    w16(f, 1);
-    w16(f, 1);
-    w32(f, rate);
-    w32(f, rate * 2);
-    w16(f, 2);
-    w16(f, 16);
-    fwrite("data", 1, 4, f);
-    w32(f, dataSize);
+    fwrite("RIFF", 1, 4, f); w32(f, 36 + dataSize); fwrite("WAVE", 1, 4, f);
+    fwrite("fmt ", 1, 4, f); w32(f, 16); w16(f, 1); w16(f, 1);
+    w32(f, rate); w32(f, rate * 2); w16(f, 2); w16(f, 16);
+    fwrite("data", 1, 4, f); w32(f, dataSize);
     for (int32_t s : buf) {
-        float v = (float)s * (1.0f / 131072.0f);
-        float c = 0.9f;
-        v = c * std::tanh(v / c);   // softclip (applied identically to both files)
-        int16_t out = (int16_t)(v * 32767.0f);
-        w16(f, (uint16_t)out);
+        int32_t v = s; if (v > 32767) v = 32767; if (v < -32768) v = -32768;
+        w16(f, (uint16_t)(int16_t)v);
     }
     fclose(f);
 }
 
+static std::vector<u8> slurp(const std::string& path, size_t want) {
+    FILE* f = fopen(path.c_str(), "rb");
+    if (!f) { fprintf(stderr, "rd_ab_test: cannot open %s\n", path.c_str()); exit(2); }
+    std::vector<u8> v(want);
+    size_t n = fread(v.data(), 1, want, f);
+    fclose(f);
+    if (n != want) { fprintf(stderr, "rd_ab_test: %s is short\n", path.c_str()); exit(2); }
+    return v;
+}
+
 int main(int argc, char** argv) {
-    if (argc < 2) {
-        fprintf(stderr, "Usage: %s pack.rdp patch [note=60] [vel=110] [prefix=ab]\n", argv[0]);
+    if (argc < 6) {
+        fprintf(stderr, "usage: %s <romdir> <packdir> <patch> <note> <vel> "
+                        "[wav-prefix]\n", argv[0]);
         return 1;
     }
-    const char* packPath = argv[1];
-    int patch    = argc > 2 ? std::atoi(argv[2]) : 0;
-    int note     = argc > 3 ? std::atoi(argv[3]) : 60;
-    int vel      = argc > 4 ? std::atoi(argv[4]) : 110;
-    const char* prefix = argc > 5 ? argv[5] : "ab";
+    std::string romdir = argv[1], packdir = argv[2];
+    int patch = atoi(argv[3]), note = atoi(argv[4]), vel = atoi(argv[5]);
+    const char* prefix = argc > 6 ? argv[6] : nullptr;
+    if (patch < 0 || patch > 15) { fprintf(stderr, "patch out of range\n"); return 1; }
 
-    FILE* pf = fopen(packPath, "rb");
-    if (!pf) { fprintf(stderr, "Cannot open pack: %s\n", packPath); return 1; }
-    fseek(pf, 0, SEEK_END);
-    long sz = ftell(pf);
-    fseek(pf, 0, SEEK_SET);
-    std::vector<uint8_t> pack((size_t)sz);
-    size_t rd = fread(pack.data(), 1, (size_t)sz, pf);
+    const u8 set = SET[patch];
+    auto ic5 = slurp(romdir + "/" + SAMPLES[set][0], 0x20000);
+    auto ic6 = slurp(romdir + "/" + SAMPLES[set][1], 0x20000);
+    auto ic7 = slurp(romdir + "/" + SAMPLES[set][2], 0x20000);
+    auto prm = slurp(romdir + "/" + std::string(PARAMS[set]), 0x20000);
+    auto prg = slurp(romdir + "/RD200_B.bin", 0x2000);
+
+    char pp[512];
+    snprintf(pp, sizeof(pp), "%s/pack_p%d.rdp", packdir.c_str(), patch);
+    FILE* pf = fopen(pp, "rb");
+    if (!pf) { fprintf(stderr, "rd_ab_test: cannot open %s\n", pp); return 2; }
+    fseek(pf, 0, SEEK_END); long psz = ftell(pf); fseek(pf, 0, SEEK_SET);
+    std::vector<uint8_t> pack((size_t)psz);
+    if ((long)fread(pack.data(), 1, (size_t)psz, pf) != psz) { fclose(pf); return 2; }
     fclose(pf);
-    if ((long)rd != sz) { fprintf(stderr, "Short read on pack\n"); return 1; }
 
     RdNewEngine eng;
     if (!eng.loadPack(pack.data(), pack.size())) {
-        fprintf(stderr, "loadPack failed\n");
-        return 1;
-    }
+        fprintf(stderr, "loadPack failed\n"); return 1; }
 
-    Mcu mcu(0);
+    Mcu mcu(ic5.data(), ic6.data(), ic7.data(), prg.data(), prm.data());
     mcu.reset();
-    mcu.commands_queue.push(0x30);
-    mcu.commands_queue.push(0xE0);
-    mcu.commands_queue.push(0x00);
-    mcu.commands_queue.push(0x00);
-    for (int i = 0; i < 1024; i++) mcu.get_next_sample();
-    mcu.loadPatch(patch);
-    uint32_t rate = (uint32_t)mcu.getCurrentSampleRate();
+    mcu.commands_queue.push(0x30); mcu.commands_queue.push(0xE0);
+    mcu.commands_queue.push(0x00); mcu.commands_queue.push(0x00);
+    const bool r32 = RATE[patch] == 32000;
+    for (int i = 0; i < 1024; i++) mcu.generate_next_sample(r32);
+    mcu.loadSounds(ic5.data(), ic6.data(), ic7.data(), prm.data(), OFF[patch]);
+    mcu.commands_queue.push(0x31); mcu.commands_queue.push(0x30);
+    const uint32_t rate = (uint32_t)RATE[patch];
 
-    // Fresh-boot quirk: the firmware kills high FIRST notes after ~70 samples.
+    // Fresh-boot quirk: the firmware kills a high FIRST note after ~70 samples.
     // A quiet primer note settles the allocator; its tail is negligible at vel 1.
     mcu.sendMidiCmd(0x90, 60, 1);
-    for (size_t i = 0; i < (size_t)(0.05 * rate); ++i) mcu.get_next_sample();
+    for (size_t i = 0; i < (size_t)(0.05 * rate); ++i) mcu.generate_next_sample(r32);
     mcu.sendMidiCmd(0x80, 60, 0);
-    for (size_t i = 0; i < (size_t)(1.0 * rate); ++i) mcu.get_next_sample();
+    for (size_t i = 0; i < (size_t)(1.0 * rate); ++i) mcu.generate_next_sample(r32);
 
-    size_t onSamples  = (size_t)(2.0 * rate);
-    size_t offSamples = (size_t)(1.5 * rate);
-
+    const size_t onSamples = (size_t)(2.0 * rate), offSamples = (size_t)(1.5 * rate);
     std::vector<int32_t> bufRef, bufNew;
-    bufRef.reserve(onSamples + offSamples);
-    bufNew.reserve(onSamples + offSamples);
+    bufRef.reserve(onSamples + offSamples); bufNew.reserve(onSamples + offSamples);
 
-    mcu.sendMidiCmd(0x90, note, vel);
-    for (size_t i = 0; i < onSamples; i++) bufRef.push_back(mcu.get_next_sample());
-    mcu.sendMidiCmd(0x80, note, 0);
-    for (size_t i = 0; i < offSamples; i++) bufRef.push_back(mcu.get_next_sample());
+    mcu.sendMidiCmd(0x90, (u8)note, (u8)vel);
+    for (size_t i = 0; i < onSamples; i++) bufRef.push_back(mcu.generate_next_sample(r32));
+    mcu.sendMidiCmd(0x80, (u8)note, 0);
+    for (size_t i = 0; i < offSamples; i++) bufRef.push_back(mcu.generate_next_sample(r32));
 
     eng.noteOn((uint8_t)note, (uint8_t)vel);
     for (size_t i = 0; i < onSamples; i++) bufNew.push_back(eng.renderSample());
@@ -107,50 +133,38 @@ int main(int argc, char** argv) {
     // samples of shift flip r at high frequencies).
     size_t start = (size_t)(0.1 * rate);
     size_t L = (size_t)(1.5 * rate);
-    if (start + L > std::min(bufRef.size(), bufNew.size())) {
+    if (start + L > std::min(bufRef.size(), bufNew.size()))
         L = std::min(bufRef.size(), bufNew.size()) - start;
-    }
 
-    double bestR = -2.0;
-    long bestLag = 0;
+    double bestR = -2.0; long bestLag = 0;
     for (long lag = -300; lag <= 300; ++lag) {
-        double sAB = 0.0, sAA = 0.0, sBB = 0.0;
+        double sAB = 0, sAA = 0, sBB = 0;
         for (size_t i = start; i < start + L; i += 2) {
             long j = (long)i + lag;
             if (j < 0 || (size_t)j >= bufNew.size()) continue;
-            double a = bufRef[i];
-            double b = bufNew[(size_t)j];
-            sAB += a * b;
-            sAA += a * a;
-            sBB += b * b;
+            double a = bufRef[i], b = bufNew[(size_t)j];
+            sAB += a * b; sAA += a * a; sBB += b * b;
         }
-        if (sAA > 0.0 && sBB > 0.0) {
+        if (sAA > 0 && sBB > 0) {
             double r = sAB / std::sqrt(sAA * sBB);
-            if (r > bestR) {
-                bestR = r;
-                bestLag = lag;
-            }
+            if (r > bestR) { bestR = r; bestLag = lag; }
         }
     }
-
-    double sumSqRef = 0.0, sumSqNew = 0.0;
+    double sumSqRef = 0, sumSqNew = 0;
     for (size_t i = start; i < start + L; ++i) {
         sumSqRef += (double)bufRef[i] * bufRef[i];
         sumSqNew += (double)bufNew[i] * bufNew[i];
     }
-    double rmsRef = std::sqrt(sumSqRef / L);
-    double rmsNew = std::sqrt(sumSqNew / L);
-    double rmsRatio = (rmsRef > 0.0) ? (rmsNew / rmsRef) : 0.0;
+    double rmsRef = std::sqrt(sumSqRef / L), rmsNew = std::sqrt(sumSqNew / L);
 
     printf("bestLag=%ld r=%.6f rmsRef=%.1f rmsNew=%.1f rmsRatio=%.4f activeVoices=%d\n",
-           bestLag, bestR, rmsRef, rmsNew, rmsRatio, eng.activeVoices());
+           bestLag, bestR, rmsRef, rmsNew, rmsRef > 0 ? rmsNew / rmsRef : 0.0,
+           eng.activeVoices());
 
-
-    char path[512];
-    snprintf(path, sizeof(path), "%s_ref.wav", prefix);
-    writeWav(path, bufRef, rate);
-    snprintf(path, sizeof(path), "%s_new.wav", prefix);
-    writeWav(path, bufNew, rate);
-
+    if (prefix) {
+        char path[512];
+        snprintf(path, sizeof(path), "%s_ref.wav", prefix); writeWav(path, bufRef, rate);
+        snprintf(path, sizeof(path), "%s_new.wav", prefix); writeWav(path, bufNew, rate);
+    }
     return 0;
 }

--- a/tools/rd_extract/run_regression.sh
+++ b/tools/rd_extract/run_regression.sh
@@ -6,19 +6,26 @@
 # Builds two host tools, runs an A/B matrix against the reference emulator,
 # runs stuck-voice stress tests, and aggregates a final PASS/FAIL summary.
 #
-# Usage: RDPIANO=/path/to/librdpiano ./run_regression.sh
+# Usage: RDPIANO=/path/to/rdpiano ./run_regression.sh
 #
 # Two things it needs that are deliberately not in this repository:
 #
-#   RDPIANO       the upstream emulator, whose SoundChip takes three ROM images
-#                 -- https://github.com/Michi71/rdpiano. The descrambling lives
-#                 there, so this is what builds the sample banks.
-#   RDPIANO_REF   the adapted emulator with the model tables compiled in --
-#                 https://github.com/Michi71/librdpiano. This is what the A/B
-#                 test compares the engine against. Defaults to RDPIANO if that
-#                 checkout happens to carry the tables too.
-#   roms/     instruments/PicoFaceRD/roms/, holding the nine sample ROMs and
-#             the sixteen .rdp packs. Same directory the firmware builds from.
+#   RDPIANO   a checkout of https://github.com/giulioz/rdpiano -- the reference
+#             emulator, in its original state. This is what the A/B test
+#             compares the engine against.
+#   roms/     instruments/PicoFaceRD/roms/, holding the nine sample ROMs, the
+#             two parameter ROMs, RD200_B.bin and the sixteen .rdp packs.
+#
+# The reference used to be an adapted copy of that emulator, and the difference
+# turned out not to be cosmetic: the adaptation carries a hand-written
+# per-patch voicing table -- gain, brightness, saturation, noise, ten partials
+# each -- which is live in its output path and which the original does not
+# have. Measuring against it was measuring the adaptation. Switched 2026-08-26,
+# and the expectations below were re-frozen with it.
+#
+# The adapted copy is still what make_packs.sh drives for the capture path;
+# that one wants its loadPatch and its compiled-in tables, and no sound of its
+# comes out of it.
 #
 # The packs used to be dumped back out of a generated source file in the
 # instrument tree. They are input now, not output, so that step is gone.
@@ -42,12 +49,14 @@ WORK="$REPO/build_host"
 ROMS="$R/roms"
 mkdir -p "$WORK"
 
+# Deliberately NOT falling back to RDPIANO_REF: that names the adapted copy,
+# and silently measuring against it is the mistake this switch removes.
 if [ -z "${RDPIANO:-}" ]; then
-    echo "run_regression: set RDPIANO to a checkout of the upstream emulator" >&2
-    echo "    git clone https://github.com/Michi71/rdpiano" >&2
+    echo "run_regression: set RDPIANO to a checkout of the reference emulator" >&2
+    echo "    git clone https://github.com/giulioz/rdpiano" >&2
     exit 1
 fi
-REF="${RDPIANO_REF:-$RDPIANO}"
+REF="$RDPIANO"
 RD=""
 for cand in "$REF/rdpiano" "$REF/librdpiano" "$REF"; do
     if [ -f "$cand/src/mcu.cpp" ] && [ -f "$cand/include/mcu.h" ]; then RD="$cand"; break; fi
@@ -56,10 +65,20 @@ if [ -z "$RD" ]; then
     echo "run_regression: no src/mcu.cpp under $REF" >&2
     exit 1
 fi
-if [ ! -f "$RD/src/mks20a_tables.cpp" ]; then
-    echo "run_regression: $RD has no model tables, so the A/B test has nothing" >&2
-    echo "    to compare against. Set RDPIANO_REF to a checkout that has them:" >&2
-    echo "    git clone https://github.com/Michi71/librdpiano" >&2
+# Two checks that the checkout really is the reference and not an adaptation
+# of it. The first is the API the A/B test is written against; the second is
+# the reason this matters at all.
+if ! grep -q 'generate_next_sample' "$RD/include/mcu.h"; then
+    echo "run_regression: $RD is not the reference emulator -- its Mcu has no" >&2
+    echo "    generate_next_sample. An adapted copy will not do here:" >&2
+    echo "    git clone https://github.com/giulioz/rdpiano" >&2
+    exit 1
+fi
+if grep -q 'g_voicingTable' "$RD/src/sound_chip.cpp"; then
+    echo "run_regression: $RD carries a per-patch voicing table in its sound" >&2
+    echo "    path, so it is an adapted copy, not the reference. Measuring" >&2
+    echo "    against it would measure the adaptation. Use the original:" >&2
+    echo "    git clone https://github.com/giulioz/rdpiano" >&2
     exit 1
 fi
 if [ ! -f "$ROMS/pack_p0.rdp" ]; then
@@ -68,10 +87,10 @@ if [ ! -f "$ROMS/pack_p0.rdp" ]; then
 fi
 
 # The sample banks the engine reads, built from the ROMs exactly as the
-# firmware build does it. Only the banks -- the emulator computes the two
-# lookup tables itself, and linking both would define them twice.
+# firmware build does it. The two lookup tables come along this time: the
+# reference computes its own privately, so nothing collides.
 echo "[prep] sample banks"
-RDPIANO="$RDPIANO" "$HERE/rd_make_rom.sh" "$ROMS" "$WORK/rd_rom.blob" >/dev/null || {
+python3 "$HERE/rd_make_rom.py" "$ROMS" "$WORK/rd_rom.blob" >/dev/null || {
     echo "[FAIL] rd_make_rom"; exit 1; }
 echo "[prep] descriptor packs"
 python3 "$HERE/rd_embed_packs.py" "$ROMS" "$WORK" >/dev/null || {
@@ -108,21 +127,20 @@ build_tool() {
 }
 
 # 2) Build tools
-# Both trees carry a rom_tables.h and they declare different things: the
-# emulator's names its decoded arrays, the engine's names the packed banks. The
-# A/B test includes headers from both, so it gets a third that is the union,
-# ahead of either on the include path.
+# The engine's rom_tables.h names the packed sample banks and the chip's two
+# lookup tables. The reference emulator has no header of that name -- it
+# computes those two itself in its SoundChip constructor -- so the shim just
+# carries the engine's declarations, ahead of anything else on the path.
 mkdir -p "$WORK/shim"
-cp "$RD/include/rom_tables.h" "$WORK/shim/ref_rom_tables.h"
 cat > "$WORK/shim/rom_tables.h" <<'SHIM'
-/* Generated by run_regression.sh -- the union of the two rom_tables.h, for the
-   one translation unit that includes headers from both trees. */
+/* Generated by run_regression.sh. */
 #pragma once
 #include <cstdint>
-#include "ref_rom_tables.h"
 extern const uint32_t rd_samples_pk4_a[0x20000];
 extern const uint32_t rd_samples_pk4_b[0x20000];
 extern const uint32_t rd_samples_pk4_m[0x20000];
+extern const uint16_t rd_phase_exp_table[131072];
+extern const uint16_t rd_samples_exp_table[32768];
 SHIM
 
 # The emulator and its model tables come from the checkout; the sample banks
@@ -135,12 +153,9 @@ build_tool rd_ab_test \
     "$HERE/rd_ab_test.cpp" \
     "$RD/src/mcu.cpp" \
     "$RD/src/sound_chip.cpp" \
-    "$RD/src/mks20a_tables.cpp" \
-    "$RD/src/mks20b_tables.cpp" \
-    "$RD/src/mk80_tables.cpp" \
-    "$RD/src/program_tables.cpp" \
     "$R/src/rd_engine/rd_new_engine.cpp" \
-    "$WORK/rd_rom_blob.S"
+    "$WORK/rd_rom_blob.S" \
+    "$WORK/rd_rom_tables.S"
 
 build_tool rd_stress2 \
     clang++ -O2 -w -std=c++17 -I "$R/include" -I "$R/include/rd_engine" -I "$R/effects" \
@@ -157,27 +172,34 @@ build_tool rd_stress2 \
 # 3) The packs are input now: they live beside the ROMs and both the firmware
 # build and this harness read the same files. Nothing to dump.
 
-# 4) A/B matrix vs reference emulator
+# 4) A/B matrix vs the reference emulator
 # Cases: patch:note:expected_r (vel always 110)
-# Re-frozen 2026-08-25, because the packs stopped being captured and started
-# being computed (tools/rd_extract/rd_make_packs.py). The comparison is the
-# same one -- the engine against the reference emulator -- but its input is
-# derived from the ROM set now, so the numbers move a little and the old ones
-# would be measuring the wrong thing.
 #
-# What moved, against the values frozen 2026-07-20:
+# Re-run 2026-08-26 against giulioz/rdpiano in its original state, after the
+# reference was switched away from an adapted copy of it (see the header).
+# Every one of the six values frozen on 2026-08-25 came back IDENTICAL to six
+# decimals -- so those numbers were never measuring the adaptation, and the
+# switch confirms them rather than moving them. What it removes is the risk
+# that a later run picks up a checkout somebody has since modified.
 #
-#   0:36   0.963959 -> 0.998891   the one that was far out, now in line with
-#                                 the rest. Nothing was fixed to achieve it:
-#                                 that cell was low because a captured pack
-#                                 holds only what fitted in its window, and a
-#                                 computed one holds the whole chain.
-#   3:60   0.993413 -> 0.991473   the only one that dropped, and by 0.002.
-#                                 Unexplained; small enough to sit inside the
-#                                 band the runner already allows, and noted
-#                                 here rather than smoothed over.
-#   the rest                      within 0.0006 either way.
-ab_cases="0:60:0.999640 0:36:0.998891 3:60:0.991473 4:60:0.998967 8:60:0.998612 15:60:0.999899"
+# Six cells added at the same time, to cover more than middle C on four patches:
+#
+#   2:72    a second MKS-20 piano, an octave up
+#   6:48    E-Piano 1 low
+#   10:84   MK-80 Blend high
+#   12:60   MK-80 A. Piano 1, the one patch whose held-phase minimum is highest
+#   14:55   MK-80 Clavi, 32 kHz
+#   3:96    the hard one, and deliberately so. Harpsichord in the top octave is
+#           where waveform correlation falls apart -- 0.9868 here, and lower
+#           still further up. It is not a timbre difference: pitch matches to
+#           0.0 cents, level to 0.4 %, and the third-octave spectrum to 0.11 dB.
+#           What differs is the phase of the partials, which at ~12 samples per
+#           period is what rounding in a phase accumulator does. The cell earns
+#           its place by being sensitive: anything that really changes the top
+#           octave will move it well beyond the 0.002 band.
+ab_cases="0:60:0.999640 0:36:0.998891 2:72:0.994845 3:60:0.991473 3:96:0.986809
+          4:60:0.998967 6:48:0.999917 8:60:0.998612 10:84:0.999917 12:60:0.999669
+          14:55:0.998802 15:60:0.999899"
 
 for c in $ab_cases; do
     patch="${c%%:*}"
@@ -186,7 +208,7 @@ for c in $ab_cases; do
     exp="${rest#*:}"
 
     total=$((total+1))
-    out="$("$WORK/rd_ab_test" "$ROMS/pack_p${patch}.rdp" "$patch" "$note" 110 "$WORK/ab_p${patch}n${note}" 2>/dev/null)"
+    out="$("$WORK/rd_ab_test" "$ROMS" "$ROMS" "$patch" "$note" 110 "$WORK/ab_p${patch}n${note}" 2>/dev/null)"
     last="$(printf '%s\n' "$out" | tail -n 1)"
     r="$(printf '%s' "$last" | sed -n 's/.* r=\([0-9.]*\).*/\1/p')"
     rmsRatio="$(printf '%s' "$last" | sed -n 's/.* rmsRatio=\([0-9.]*\).*/\1/p')"


### PR DESCRIPTION
Two things, one of which I broke.

### The runner was dead

[#73](https://github.com/Michi71/PicoVintageSynthCollection/pull/73) deleted
`rd_make_rom.sh` and left `run_regression.sh` calling it — so the regression has
not run since, and that PR's own body said the A/B test was fine. It calls
`rd_make_rom.py` now. The same PR made the upstream emulator unnecessary for
building the sample banks, so that requirement is gone too.

### The A/B reference was an adapted copy

`RDPIANO_REF` pointed at a fork whose `sound_chip.cpp` has grown a hand-written
`g_voicingTable[16][10]` — gain, brightness, saturation and noise, per patch and
per partial. **782 lines against the original's 426**, live in the output path
(`applyVoicingDefaults` at line 349, values read back in `update`), and absent
from `giulioz/rdpiano` entirely. A regression aimed at that measures the
adaptation.

`rd_ab_test.cpp` is rewritten against the original's API: ROM images instead of
compiled-in tables, no `loadPatch`, and patch selection the way its firmware
does it — mount the parameter block with `loadSounds`, then hand the sound CPU
the panel bytes `0x31 0x30`. The mapping tables are the ones `rd_make_packs.py`
already uses.

The runner now **refuses** a checkout whose `sound_chip.cpp` carries a voicing
table, and no longer falls back to `RDPIANO_REF` — falling back silently is
exactly the failure being removed.

```
run_regression: .../librdpiano carries a per-patch voicing table in its sound
    path, so it is an adapted copy, not the reference.
```

### The frozen numbers did not move

All six came back **identical to six decimals** against the original. So they
were never measuring the adaptation — that fork was modified after they were
frozen. The switch confirms them and closes the door on a later run quietly
picking up a modified checkout.

### Six cells added

Twelve now instead of six. `3:96` is there on purpose: the harpsichord top
octave, r=0.9868, the hardest cell in the instrument. It is **not** a timbre
difference — pitch matches to 0.0 cents, level to 0.4 %, third-octave spectrum
to 0.11 dB. What differs is partial phase, which at ~12 samples per period is
what rounding in a phase accumulator does. It earns its place by being
sensitive: anything that really changes the top octave moves it well past the
0.002 band.

`REGRESSION PASS (15 checks)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
