### PR TITLE
PicoFaceRD: compute the velocity, stop storing four layers of it

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,12 +96,19 @@ Raspberry Pi Pico 2 and many other RP2350 boards provide:
 | PicoFaceCP | 4.22 MB | does not fit |
 | PicoFaceJV | 4.34 MB | only with `-DPICOFACEJV_4MB=ON` (3.76 MB, banks A+B) |
 | PicoFaceD5 | 0.86 MB | fits |
-| PicoFaceRD | 5.15 MB | only with `-DPICOFACERD_MODEL=MKS20` (3.01 MB) or `=MK80` (2.53 MB) |
+| PicoFaceRD | 2.56 MB | fits |
 
-The two reduced variants drop something real. The JV loses its user bank and
-the 22 samples only those patches used; the RD ships one of its two machines,
-eight patches instead of sixteen. Both are the same data played the same way --
+The JV's reduced variant drops something real: the user bank, and the 22
+samples only those patches used. Banks A and B are otherwise untouched --
 nothing is resampled or requantised.
+
+**The RD used to need one too, and no longer does.** Its packs held four
+sampled velocity layers of every note; they hold the parameter ROM's own
+corners now and the engine interpolates, which is both exact at all 128
+velocities and a fifth the size. The whole instrument went from 5.15 MB to
+2.56 MB. `-DPICOFACERD_MODEL=MKS20` or `=MK80` still builds one machine on its
+own -- eight patches, and half a ROM set is enough for it -- but nobody needs
+it to fit a board any more.
 
 **CP has no reduced variant**: it carries the Rhodes, Clavinet and E-piano
 sample sets as one indivisible whole, with no subset to drop. Anything from
@@ -169,10 +176,9 @@ repository and must never be, so a build here is the one thing CI cannot cover.
 Name a directory to build there instead and keep the result; add `--variants`
 for the reduced images too.
 
-**On a 4 MB Pico 2**, RD ships one machine instead of two:
-`-DPICOFACERD_MODEL=MKS20` (3.01 MB) or `=MK80` (2.53 MB), eight patches each,
-and only that machine's ROMs are needed. The default `BOTH` is sixteen patches
-and 5.15 MB, so it wants a 16 MB board. See
+RD also builds as a single machine — `-DPICOFACERD_MODEL=MKS20` (1.73 MB) or
+`=MK80` (1.23 MB), eight patches each, and only that machine's ROMs are needed.
+The default is both machines and 2.56 MB, which fits a 4 MB board. See
 [`instruments/PicoFaceRD/README.md`](instruments/PicoFaceRD/README.md) for the
 whole recipe and all sixteen patch offsets.
 

--- a/instruments/PicoFaceRD/README.md
+++ b/instruments/PicoFaceRD/README.md
@@ -50,10 +50,12 @@ it is that one.
 
 ### Fitting a 4 MB Pico 2
 
-PicoFaceRD normally carries both machines -- sixteen patches, 5.15 MB, and a
-16 MB board. Either machine on its own is well inside 4 MB, because the two
-halves barely share anything: the MKS-20's eight patches read two sample banks,
-the MK-80's eight read the third.
+PicoFaceRD carries both machines in 2.56 MB, which fits a 4 MB board on its
+own -- so this is a choice about how many patches to ship, not a way to make it
+fit. Either machine alone is smaller again, because the two halves barely share
+anything: the MKS-20's eight patches read two sample banks, the MK-80's eight
+read the third. A single-machine build also needs only that machine's ROMs,
+which is the reason to reach for it.
 
 ```bash
 cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
@@ -62,9 +64,9 @@ cmake -S . -B build -G Ninja -DCMAKE_BUILD_TYPE=Release \
 
 | `PICOFACERD_MODEL` | patches | image | board |
 |---|---|---|---|
-| `BOTH` (default) | 16 | 5.15 MB | 16 MB |
-| `MKS20` | 8 | 3.01 MB | fits 4 MB |
-| `MK80` | 8 | 2.53 MB | fits 4 MB |
+| `BOTH` (default) | 16 | 2.56 MB | fits 4 MB |
+| `MKS20` | 8 | 1.73 MB | fits 4 MB |
+| `MK80` | 8 | 1.23 MB | fits 4 MB |
 
 A single-machine build also only needs that machine's ROMs -- three sample
 chips and eight packs -- so half a ROM set is enough to build one.
@@ -192,10 +194,9 @@ compatible 16 MB stand-in — the Waveshare RP2350 Plus has no board file in the
 pinned SDK, and all pins used here are addressed explicitly, so the only thing
 taken from the board file is the 16 MB flash size (which matches).
 
-The 16 MB is not decoration for the default build: the image is **5.15 MB**,
-mostly sample packs, so it does not fit a 4 MB board such as a base Pico 2.
-Building one machine instead of two does fit —
-[Fitting a 4 MB Pico 2](#fitting-a-4-mb-pico-2). An oversized `.uf2` stops
+The image is **2.56 MB** and fits a 4 MB board such as a base Pico 2. It was
+5.15 MB until the packs stopped storing four velocity layers of every note and
+started storing the parameter ROM's corners instead. An oversized `.uf2` stops
 copying without saying why. See
 [How much flash an instrument needs](../../README.md#how-much-flash-an-instrument-needs).
 
@@ -254,7 +255,7 @@ plus about 44 KB of heap for the pack descriptors.
   └───────────────────────────────────────────────┘
 ```
 
-The sound data pipeline is host-side: the sound CPU's own arithmetic, read out of its firmware in [`RD_FIRMWARE.md`](../../tools/rd_extract/RD_FIRMWARE.md) and rewritten in Python, walks each (patch, note, velocity) through the parameter ROM to per-note part descriptors (pitch, wave region, envelope segment chains); a packer emits compact `.rdp` packs that are embedded in the firmware together with losslessly repacked 4-byte sample banks. On-device, `RdNewEngine` replays those descriptors with the same envelope arithmetic as the chip.
+The sound data pipeline is host-side: the sound CPU's own arithmetic, read out of its firmware in [`RD_FIRMWARE.md`](../../tools/rd_extract/RD_FIRMWARE.md) and rewritten in Python, walks each (patch, note) through the parameter ROM to per-note part descriptors (pitch, wave region, the envelope list's corner bytes, the velocity map and curves); a packer emits compact `.rdp` packs that are embedded in the firmware together with losslessly repacked 4-byte sample banks. On-device, `RdNewEngine` replays those descriptors with the same envelope arithmetic as the chip.
 
 Details in [doc/ARCHITECTURE.md](doc/ARCHITECTURE.md). The full engineering log
 with the complete debugging history lives in [doc/RD_PORT.md](doc/RD_PORT.md).

--- a/instruments/PicoFaceRD/include/rd_engine/rd_new_engine.h
+++ b/instruments/PicoFaceRD/include/rd_engine/rd_new_engine.h
@@ -28,18 +28,27 @@ struct RdnPartDesc {
     uint16_t pitch_lut;
     uint8_t wave_loop;
     uint8_t wave_high;
-    uint8_t nseg;
-    uint8_t nrel;
-    // 6-byte packed segments in flash: u32 t (LE), u8 dest, u8 speed.
-    // The attack chain (nseg segments) is followed immediately by the release
-    // chain (nrel segments), so the release chain is segsRaw + nseg*6.
-    // The caller keeps the blob alive (flash arrays are).
-    const uint8_t* segsRaw;
+    // Which of the ten parts this is -- the note-on preamble differs per part
+    // and is the MCU's, not the ROM's.
+    uint8_t idx;
+    // The speed the firmware writes when the key comes up, from the record's
+    // seventh byte. Velocity plays no part in it.
+    uint8_t release;
+    // Two curve selectors, four bits each: low nibble for the hard layer,
+    // high nibble for the soft one. Sixteen curves, so four bits is exact.
+    uint8_t sel;
+    uint8_t ncorner;
+    // The segment list exactly as it sits in the parameter ROM: six bytes an
+    // entry, and the two layers overlap inside them -- the hard layer reads
+    // bytes 0..3, the soft one 2..5. Destination and speed are interpolated
+    // out of these at note-on, which is what makes velocity continuous rather
+    // than the four sampled layers the pack used to hold. Two bytes of tail so
+    // the soft layer can read its last entry. The caller keeps the blob alive.
+    const uint8_t* corners;
 };
 
 struct RdnEntry {
     uint8_t note;
-    uint8_t vel;
     uint8_t nparts;
     RdnPartDesc parts[10];
 };
@@ -97,9 +106,18 @@ private:
         uint8_t  pitch_hi = 0;         // (pitch_lut & 0xC000) == 0xC000, cached at noteOn
         const uint8_t* chain = nullptr; // active chain (attack or release)
         uint8_t  nch = 0;
+        const uint8_t* chain0 = nullptr; // this part's attack chain, for release
+        uint8_t  nseg0 = 0;
     };
 
+    // Where a voice's chains are built at note-on. The pack holds ROM corners
+    // now, not finished segments, so they cannot live in flash any more. The
+    // widest note in the whole bank comes to 134 segments across its ten
+    // parts; 144 leaves room without being generous.
+    static constexpr int kChainSegs = 144;
+
     struct Voice {
+        uint8_t  chainbuf[kChainSegs * 6];
         bool     active = false;
         uint8_t  note = 0;
         uint32_t age = 0;
@@ -115,7 +133,9 @@ private:
     void applyPitchFactor();        // recompute all active parts from bend*tune
     void renderVoicesBlock(unsigned parity, unsigned parityEnabled, uint32_t clockBase, int n, int32_t* out);
     static constexpr int kBlockMax = 64;
-    const RdnEntry* findEntry(uint8_t note, uint8_t vel) const;
+    const RdnEntry* findEntry(uint8_t note) const;
+    uint8_t buildChain(uint8_t* out, const RdnPartDesc& d,
+                       uint8_t layer, uint8_t c2, uint8_t c3) const;
     void startSegment(Part& p, const RdnSeg& s);
     void advanceSegments(Part& p, uint32_t tBase);
     void releaseVoice(Voice& v);
@@ -125,6 +145,8 @@ private:
     uint32_t bend_q16_ = 65536;     // pitch bend factor, Q16 (65536 = center)
     uint32_t tune_q16_ = 65536;     // master tune factor, Q16 (65536 = center)
     std::vector<RdnEntry> _entries;
+    const uint8_t* _velmap = nullptr;   // 256 bytes, parameter ROM
+    const uint8_t* _curves = nullptr;   // 16 x 64, program ROM
     const uint32_t*       _bank = nullptr;  // 4-byte packed sample bank
     uint32_t              _clock = 0;
     uint8_t               _patchId = 0;

--- a/instruments/PicoFaceRD/src/rd_engine/rd_new_engine.cpp
+++ b/instruments/PicoFaceRD/src/rd_engine/rd_new_engine.cpp
@@ -43,9 +43,10 @@ static inline uint16_t rd_le16(const uint8_t* p) {
 }
 
 bool RdNewEngine::loadPack(const uint8_t* blob, size_t len) {
-    // Header: 'RDP2' u32 version, u8 patch_id, u8 bank, u16 entry_count -> 12 bytes
-    if (!blob || len < 12) return false;
-    if (std::memcmp(blob, "RDP2", 4) != 0) return false;
+    // Header: 'RDP3' u32 version, u8 patch_id, u8 bank, u16 note_count, then
+    // the 256-byte velocity map and sixteen 64-byte curves -> 1292 bytes.
+    if (!blob || len < 12 + 256 + 16 * 64) return false;
+    if (std::memcmp(blob, "RDP3", 4) != 0) return false;
     if (rd_le32(blob + 4) != 1) return false; // version 1
 
     // Deactivate all voices before rebuilding _entries / _segStore --
@@ -72,36 +73,39 @@ bool RdNewEngine::loadPack(const uint8_t* blob, size_t len) {
     }
 
     uint16_t entry_count = (uint16_t)blob[10] | ((uint16_t)blob[11] << 8);
+    _velmap = blob + 12;
+    _curves = blob + 12 + 256;
     _entries.clear();
     _entries.reserve(entry_count);
 
     // Single pass: entries reference the segments IN PLACE in the flash blob
     // (no _segStore copy -> no heap churn, no OOM on patch switches).
-    size_t pos = 12;
+    size_t pos = 12 + 256 + 16 * 64;
     while (pos < len) {
-        if (pos + 3 > len) return false;
+        if (pos + 2 > len) return false;
         RdnEntry e;
         e.note = blob[pos++];
-        e.vel = blob[pos++];
         uint8_t part_count = blob[pos++];
         e.nparts = part_count > 10 ? 10 : part_count;
 
         for (uint8_t i = 0; i < part_count; ++i) {
-            if (pos + 8 > len) return false; // fixed 8-byte part header must fit
+            if (pos + 10 > len) return false; // fixed 10-byte part header must fit
             RdnPartDesc pd;
+            pd.idx = blob[pos++];
             pd.flags = blob[pos++];
             pd.env_offset = blob[pos++];
             pd.pitch_lut = rd_le16(blob + pos); pos += 2;
             pd.wave_loop = blob[pos++];
             pd.wave_high = blob[pos++];
+            pd.release = blob[pos++];
+            pd.sel = blob[pos++];
             uint8_t nseg = blob[pos++];
-            uint8_t nrel = blob[pos++];
-            pd.nseg = nseg;
-            pd.nrel = nrel;
-
-            if (pos + (size_t)(nseg + nrel) * 6 > len) return false;
-            pd.segsRaw = blob + pos;
-            pos += (size_t)(nseg + nrel) * 6;
+            pd.ncorner = nseg;
+            // Two bytes of tail past the last entry: the soft layer reads
+            // from offset 2, so its final four bytes run past the sixth.
+            if (pos + (size_t)nseg * 6 + 2 > len) return false;
+            pd.corners = blob + pos;
+            pos += (size_t)nseg * 6 + 2;
 
             if (i < e.nparts) e.parts[i] = pd;
         }
@@ -110,19 +114,99 @@ bool RdNewEngine::loadPack(const uint8_t* blob, size_t len) {
     return true;
 }
 
-const RdnEntry* RdNewEngine::findEntry(uint8_t note, uint8_t vel) const {
-    const RdnEntry* best = nullptr;
-    int best_diff = 256;
-    for (const auto& e : _entries) {
-        if (e.note == note) {
-            int diff = std::abs((int)e.vel - (int)vel);
-            if (diff < best_diff) {
-                best_diff = diff;
-                best = &e;
-            }
-        }
+
+// ---------------------------------------------------------------- velocity
+// The sound CPU has no velocity layers. It interpolates every segment between
+// two corner bytes in the parameter ROM, weighted by a curve it picks from the
+// velocity, and the pack now carries those corners rather than four sampled
+// results. RD_FIRMWARE.md has the chain; this is the same arithmetic.
+
+// (256-w)*lo + w*hi, truncated to 16 bits and kept as its high byte -- the
+// firmware's two muls, an add, and the psha that keeps only the high half.
+static inline uint8_t rdn_interp(uint8_t lo, uint8_t hi, uint8_t w) {
+    uint32_t v = ((256u - (uint32_t)w) * lo + (uint32_t)w * hi) & 0xFFFFu;
+    return (uint8_t)(v >> 8);
+}
+
+// Levels a segment moves per sample, signed. Bit 7 means downward, which the
+// chip reaches by or-ing $7f<<21 into the increment and adding a carry: that
+// wraps the 28-bit accumulator into a subtraction.
+static inline int32_t rdn_ramp_rate(uint8_t speed) {
+    const bool stepping = (speed & 0x7F) != 0;
+    const bool carry = stepping && (speed & 0x80) != 0;
+    uint32_t b = s_env_ram[speed] | (carry ? (0x7Fu << 21) : 0u);
+    uint32_t x = (b + (carry ? 1u : 0u) + (1u << 27)) & ((1u << 28) - 1u);
+    return (int32_t)x - (int32_t)(1u << 27);
+}
+
+// How many samples the chip takes over a ramp. The +3 is the interrupt's own
+// latency plus the MCU getting round to writing the next pair. Zero means the
+// segment never ends by itself, and the timeline does not advance over it.
+static inline uint32_t rdn_duration(uint8_t from, uint8_t to, uint8_t speed) {
+    const int32_t rate = rdn_ramp_rate(speed);
+    if (rate == 0) return 0;
+    const int32_t distance = ((int32_t)to - (int32_t)from) << 20;
+    if (distance == 0 || ((distance > 0) != (rate > 0))) return 3;
+    const uint32_t ad = (uint32_t)(distance < 0 ? -distance : distance);
+    const uint32_t ar = (uint32_t)(rate < 0 ? -rate : rate);
+    return ad / ar + 3u;
+}
+
+// What the firmware writes before it starts on a part's list: snap the
+// envelope hard downward, then freeze it. Per-part constants of the MCU, not
+// of the ROM -- part 9 gets only the first, and is written first.
+struct RdnPre { uint32_t t; uint8_t dest, speed; };
+static const RdnPre kRdnPreamble[10][2] = {
+    {{5,31,252},{7,0,0}},   {{5,31,252},{9,0,0}},   {{5,31,252},{10,0,0}},
+    {{5,31,252},{12,0,0}},  {{5,31,252},{13,0,0}},  {{5,31,252},{15,0,0}},
+    {{6,31,252},{16,0,0}},  {{6,31,252},{18,0,0}},  {{6,31,252},{19,0,0}},
+    {{6,31,252},{0,0,0}}};
+static const uint8_t kRdnPreCount[10] = {2,2,2,2,2,2,2,2,2,1};
+static const uint8_t kRdnOnset[10] = {30,32,34,36,37,39,41,42,44,21};
+static const uint32_t kRdnReleaseAt = 4;
+
+static inline void rdn_put(uint8_t* d, uint32_t t, uint8_t dest, uint8_t speed) {
+    d[0] = (uint8_t)t; d[1] = (uint8_t)(t >> 8);
+    d[2] = (uint8_t)(t >> 16); d[3] = (uint8_t)(t >> 24);
+    d[4] = dest; d[5] = speed;
+}
+
+const RdnEntry* RdNewEngine::findEntry(uint8_t note) const {
+    // One entry a note now. There is nothing left to choose between: the
+    // velocity is applied when the chain is built, not when it is looked up.
+    for (const auto& e : _entries)
+        if (e.note == note) return &e;
+    return nullptr;
+}
+
+// Builds one part's chain -- preamble, the interpolated segment list, the
+// release -- into the voice's buffer, and returns how many segments the attack
+// chain came to. This is the note-on cost the old format paid for in flash.
+uint8_t RdNewEngine::buildChain(uint8_t* out, const RdnPartDesc& d,
+                                uint8_t layer, uint8_t c2, uint8_t c3) const {
+    const uint8_t pre = kRdnPreCount[d.idx];
+    for (uint8_t i = 0; i < pre; ++i)
+        rdn_put(out + i * 6, kRdnPreamble[d.idx][i].t,
+                kRdnPreamble[d.idx][i].dest, kRdnPreamble[d.idx][i].speed);
+
+    uint8_t n = pre;
+    uint32_t t = kRdnOnset[d.idx];
+    int level = -1;                       // the preamble left it somewhere
+    for (uint8_t i = 0; i < d.ncorner && n < kChainSegs - 1; ++i) {
+        const uint8_t* g = d.corners + i * 6 + layer;
+        const uint8_t dest  = rdn_interp(g[0], g[2], c3);
+        const uint8_t speed = rdn_interp(g[1], g[3], c2);
+        rdn_put(out + n * 6, t, dest, speed);
+        ++n;
+        t += rdn_duration(level < 0 ? 0 : (uint8_t)level, dest, speed);
+        level = dest;
+        if (dest == 0) break;             // ed89's tsta: zero ends the chain
     }
-    return best;
+    // The release is not the chain's own ramp to nothing: the firmware writes
+    // destination zero at the record's own speed when the key comes up, on a
+    // time base that starts at note-off.
+    rdn_put(out + n * 6, kRdnReleaseAt, 0, d.release);
+    return n;
 }
 
 void RdNewEngine::startSegment(Part& p, const RdnSeg& s) {
@@ -271,10 +355,21 @@ void RdNewEngine::noteOn(uint8_t note, uint8_t vel) {
             releaseVoice(v);
     }
 
-    const RdnEntry* e = findEntry(note, vel);
+    const RdnEntry* e = findEntry(note);
     if (!e) return;
     Voice* v = allocVoice();
     if (!v) return;
+
+    // The velocity, the way the sound CPU takes it: a byte out of the
+    // parameter ROM's map, whose top bit picks the hard or soft layer while
+    // the rest becomes the straight weight and, shifted, an index into one of
+    // sixteen curves. Two weights come out -- the curved one moves the
+    // destinations, the straight one the speeds.
+    const uint8_t c0 = _velmap[vel & 0x7F];
+    const uint8_t layer = (c0 & 0x80) ? 2 : 0;
+    const uint8_t c2 = (uint8_t)((c0 << 1) & 0xFF);
+    const uint8_t c1 = (uint8_t)(c2 >> 2);
+    uint32_t chain_at = 0;
 
     const bool wasKilling = v->killing != 0;
     v->active = true;
@@ -311,10 +406,24 @@ void RdNewEngine::noteOn(uint8_t note, uint8_t vel) {
         p.env_b = 0;
         p.env_flags = 0;
         p.pitch_hi = ((d->pitch_lut & 0xC000) == 0xC000) ? 1 : 0;
-        p.chain = d->segsRaw;
-        p.nch = d->nseg;
+
+        // The chain is built here rather than read from flash: the pack holds
+        // the ROM's corners, and this is where the velocity is applied.
+        const uint8_t sel = layer ? (uint8_t)(d->sel & 0x0F)
+                                  : (uint8_t)(d->sel >> 4);
+        const uint8_t c3 = _curves[(size_t)(sel & 0x0F) * 64 + c1];
+        uint8_t* dst = v->chainbuf + chain_at * 6;
+        const uint32_t room = (uint32_t)kChainSegs - chain_at;
+        uint8_t built = 0;
+        if (room >= (uint32_t)d->ncorner + 4u)
+            built = buildChain(dst, *d, layer, c2, c3);
+        p.chain0 = dst;
+        p.nseg0 = built;
+        p.chain = dst;
+        p.nch = built;
+        chain_at += built + 1u;          // the release sits right behind
         p.next_t = 0xFFFFFFFFu;
-        p.dead = (d->nseg == 0 && d->nrel == 0);
+        p.dead = (built == 0);
         if (!p.dead && p.nch > 0)
             advanceSegments(p, 0);   // apply any t=0 segments, prime next_t
     }
@@ -330,12 +439,12 @@ void RdNewEngine::releaseVoice(Voice& v) {
         if (p.in_release) continue;
         p.in_release = true;
         p.seg_idx = 0;
-        const RdnPartDesc* d = &v.entry->parts[i];
-        // Release chain sits right after the attack chain in the pack blob.
-        p.chain = d->segsRaw + (size_t)d->nseg * 6;
-        p.nch = d->nrel;
+        // The release sits right behind this part's attack chain, in the
+        // voice's own buffer -- both were written at note-on.
+        p.chain = p.chain0 + (size_t)p.nseg0 * 6;
+        p.nch = 1;
         p.next_t = 0xFFFFFFFFu;
-        if (d->nrel == 0) {
+        if (p.chain0 == nullptr) {
             RdnSeg fast_rel = {0, 0, 200};
             startSegment(p, fast_rel);
         } else {

--- a/tools/rd_extract/RD_FIRMWARE.md
+++ b/tools/rd_extract/RD_FIRMWARE.md
@@ -123,17 +123,22 @@ The velocity weight is a table lookup, not arithmetic:
 
 ```
 e92b  ldb $04,x      ; curve selector out of the part block
-e92d  ldx #$ed9d     ; eight pointers, here in the program ROM
+e92d  ldx #$ed9d     ; sixteen pointers, here in the program ROM
 e930  abx
-e931  ldx $00,x      ; -> $f049, $f089, $f0c9, $f109, $f149, $f189, $f1c9, $f209
+e931  ldx $00,x      ; -> $f049, $f089 ... $f409, sixteen of them, 0x40 apart
 e933  ldb $c1        ; the velocity index
 e935  abx
 e936  ldb $00,x      ; the weight
 e93a  stb $01,x      ; -> part state byte 1, which the IRQ reads as $d2
 ```
 
-**Eight velocity curves of 64 bytes each, in the program ROM.** `$f049` is the
-straight ramp (0, 4, 8 … 252); `$f089` is bent (0, 4, 7, 10, 13 … 252).
+**Sixteen velocity curves of 64 bytes each, in the program ROM.** `$f049` is
+the straight ramp (0, 4, 8 … 252); `$f089` is bent (0, 4, 7, 10, 13 … 252). The
+pointer table runs `$f049` to `$f409` in steps of `0x40`, and index 16 is
+already something else — an earlier pass here said eight because it had only
+walked the first eight. The parts really do reach the top of the table: the
+selector bytes across a bank are 0..3 and 13..15, so a build that stores only
+eight curves loses three quarters of the ones actually in use.
 
 ## The command protocol, and where notes actually arrive
 

--- a/tools/rd_extract/README.md
+++ b/tools/rd_extract/README.md
@@ -85,6 +85,17 @@ First validation (note-by-note, vel 110): r = 0.90–0.97, RMS ratio
 
 ## v2.2: 4-byte sample banks + block doorbell
 
+- **Packs hold the ROM's corners, not finished envelopes (format RDP3).** The
+  sound CPU has no velocity layers: it interpolates every segment between two
+  corner bytes in the parameter ROM, weighted by one of sixteen curves it picks
+  from the velocity. `rd_make_packs.py` used to sample that at four velocities
+  and freeze the results, which left the level out by up to 16 dB in between --
+  correlation could not see it, being scale invariant, so it went unnoticed
+  through every A/B run. A pack now carries the corner bytes, the 256-byte
+  velocity map and the sixteen curves, and `RdNewEngine::buildChain` does the
+  interpolation at note-on. Exact at all 128 velocities, and the sixteen packs
+  went from 3.26 MB to 0.67 MB. `run_regression.sh` gained a velocity sweep,
+  which is the check whose absence let this stand.
 - The sample banks are packed into u32 (bits[13:0]=exp, [14]=exp_sign,
   [23:15]=delta, [24]=delta_sign; the widths hold across all three banks).
   Halves the dominant XIP-miss stream — two entries per 8-byte line — and 1.5 MB

--- a/tools/rd_extract/rd_make_packs.py
+++ b/tools/rd_extract/rd_make_packs.py
@@ -53,7 +53,14 @@ sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 import rd_parse  # noqa: E402
 
 NOTES = range(21, 109)
-VELOCITIES = (40, 80, 110, 127)
+# No velocity list any more. The firmware does not have velocity layers: it
+# interpolates every segment between two corner bytes in the parameter ROM,
+# weighted by a curve it picks from the velocity. Storing four sampled results
+# was an artifact of this builder, and an audible one -- between the four
+# points the level was out by up to 10.7 dB. A pack now carries the corners,
+# the velocity map and the curves, and the engine does the interpolation the
+# way the sound CPU does it. Exact at all 128 velocities, and a fifth the size.
+VELOCITIES = (40, 80, 110, 127)     # only for the verification tool now
 
 # Which sample set each patch plays. This is what the pack's "bank" byte means
 # -- the emulator's patchToRomSet, not the parameter bank the patch table gives
@@ -97,37 +104,85 @@ def build_part(rom, part, index):
     return segs
 
 
-def build(rom, patch, out):
-    entries = []
-    for note in NOTES:
-        for vel in VELOCITIES:
-            parsed = rd_parse.parse(rom, note, vel)
-            parts = []
-            for i, p in enumerate(parsed["parts"]):
-                if not p["segments"]:
-                    continue                  # a part the zone leaves unused
-                segs = build_part(rom, p, i)
-                # The release is one segment, and it is not the chain's own ramp
-                # to nothing: the firmware writes destination zero at the speed
-                # in the record's seventh byte, when the key comes up. Its
-                # timestamps run from note-off, not from note-on.
-                rel = [(RELEASE_AT, 0, p["release"])]
-                parts.append((0 if i < 9 else 0xFF, p["pitch"],
-                              p["wave"] >> 8, p["wave"] & 0xFF, segs, rel))
-            entries.append((note, vel, parts))
+def corner_chain(rom, ptr):
+    """The raw six-byte entries of a part's segment list, as they sit in the
+    parameter ROM. Six bytes cover BOTH layers: the firmware reads four bytes
+    from offset 0 for the hard layer and from offset 2 for the soft one, so the
+    two overlap inside the same entry.
 
-    blob = bytearray(b"RDP2")
+    How long the chain is depends on the velocity -- it ends where an
+    interpolated destination reaches zero, and which layer is in use decides
+    which corners are read at all. So both layers are walked and the longer one
+    kept; the engine stops at the zero it computes for its own velocity,
+    exactly as the chip does.
+
+    The stop condition has a closed form. The destination is
+    ((256-w)*lo + w*hi) >> 8, which is linear in w between 256*lo and 256*hi,
+    so it is non-zero for SOME weight exactly when max(lo, hi) > 0. No sweep
+    over the 256 weights is needed -- and walking only one layer, or only the
+    two extreme weights, silently cuts the chain short. It did."""
+    base = rom.cpu_to_off(ptr)
+    longest = 0
+    for layer in (0, 2):
+        at, n = base + layer, 0
+        while n < 64:
+            e = rom.prm[at:at + 4]
+            n += 1
+            if max(e[0], e[2]) == 0:      # zero at every weight -> chain ends
+                break
+            at += 6
+        longest = max(longest, n)
+    return bytes(rom.prm[base:base + longest * 6 + 2]), longest
+
+
+def build(rom, patch, out):
+    notes = []
+    for note in NOTES:
+        # Parsed once, at any velocity: what this needs from it -- which zone,
+        # which parts, their pitch, wave and release -- does not depend on the
+        # velocity at all. Verified across all 128.
+        parsed = rd_parse.parse(rom, note, 127)
+        zbase = rom.a7 + rd_parse.zone_of(note) * 21
+        block = rom.a9 + rom.prm[zbase] * 70
+        parts = []
+        for i, p in enumerate(parsed["parts"]):
+            if not p["segments"]:
+                continue                      # a part the zone leaves unused
+            rec = block + i * 7
+            ptr = (rom.prm[rec + 2] << 8) | rom.prm[rec + 3]
+            corners, nseg = corner_chain(rom, ptr)
+            # Which of the eight curves this part weights its destinations
+            # with. +4 is the hard layer, +5 the soft one, and the engine
+            # picks between them the same way the firmware does.
+            sel_hard = rom.prm[rec + 4] >> 1
+            sel_soft = rom.prm[rec + 5] >> 1
+            parts.append((i, 0 if i < 9 else 0xFF, p["pitch"],
+                          p["wave"] >> 8, p["wave"] & 0xFF,
+                          p["release"], sel_hard, sel_soft, nseg, corners))
+        notes.append((note, parts))
+
+    blob = bytearray(b"RDP3")
     blob += struct.pack("<I", 1)
-    blob += struct.pack("<BBH", patch, SAMPLE_SET[patch], len(entries))
-    for note, vel, parts in entries:
-        blob += struct.pack("<BBB", note, vel, len(parts))
-        for flags, pitch, wlo, whi, segs, rel in parts:
-            blob += struct.pack("<BBHBBBB", flags, ENV_OFFSET, pitch,
-                                wlo, whi, len(segs), len(rel))
-            for t, dest, speed in segs + rel:
-                blob += struct.pack("<IBB", t, dest, speed)
+    blob += struct.pack("<BBH", patch, SAMPLE_SET[patch], len(notes))
+    # The velocity map out of the parameter ROM, then the curves out of the
+    # program ROM. 1280 bytes, and they replace three quarters of the pack.
+    #
+    # SIXTEEN curves, not eight: the pointer table at $ed9d runs $f049 to
+    # $f409 in steps of 0x40, and the parts really do select from all of it --
+    # the selector bytes seen across the bank are 0..3 and 13..15. Index 16 is
+    # already something else. RD_FIRMWARE.md said eight because that pass only
+    # listed the ones it had walked.
+    blob += bytes(rom.prm[rom.a5:rom.a5 + 256])
+    for which in range(16):
+        blob += bytes(rom.curve(which, i) for i in range(64))
+    for note, parts in notes:
+        blob += struct.pack("<BB", note, len(parts))
+        for idx, flags, pitch, wlo, whi, rel, sh, ss, nseg, corners in parts:
+            blob += struct.pack("<BBBHBBBBB", idx, flags, ENV_OFFSET, pitch,
+                                wlo, whi, rel, (sh & 0x0F) | (ss << 4), nseg)
+            blob += corners
     open(out, "wb").write(blob)
-    return len(entries), len(blob)
+    return len(notes), len(blob)
 
 
 def main():

--- a/tools/rd_extract/run_regression.sh
+++ b/tools/rd_extract/run_regression.sh
@@ -197,6 +197,7 @@ build_tool rd_stress2 \
 #           period is what rounding in a phase accumulator does. The cell earns
 #           its place by being sensitive: anything that really changes the top
 #           octave will move it well beyond the 0.002 band.
+vel_cases="0:60 3:72 8:52 14:67"
 ab_cases="0:60:0.999640 0:36:0.998891 2:72:0.994845 3:60:0.991473 3:96:0.986809
           4:60:0.998967 6:48:0.999917 8:60:0.998612 10:84:0.999917 12:60:0.999669
           14:55:0.998802 15:60:0.999899"
@@ -239,6 +240,37 @@ for c in $ab_cases; do
     fi
 done
 
+
+# 4b) Velocity sweep
+# The check that was missing, and its absence cost the instrument its dynamics
+# for months. The packs used to hold four sampled velocity layers and the
+# engine picked the nearest, so between them the level was out by up to 16 dB
+# -- while the CORRELATION stayed at 0.999, because correlation is scale
+# invariant and does not care how loud a waveform is. Every cell above passed
+# throughout. Only the level ratio can see it, and only at velocities the pack
+# did not happen to store.
+#
+# So: sweep across the range, on velocities chosen to fall between the old
+# four, and hold the ratio to a band. 0.9..1.1 is about +-0.9 dB -- loose
+# enough not to trip on the harmless, far tighter than the failure it guards.
+echo "[prep] velocity sweep"
+for c in $vel_cases; do
+    patch="${c%%:*}"
+    note="${c#*:}"
+    for vel in 8 20 33 45 58 70 83 95 108 120; do
+        total=$((total+1))
+        out="$("$WORK/rd_ab_test" "$ROMS" "$ROMS" "$patch" "$note" "$vel" 2>/dev/null)"
+        last="$(printf '%s\n' "$out" | tail -n 1)"
+        rr="$(printf '%s' "$last" | sed -n 's/.* rmsRatio=\([0-9.]*\).*/\1/p')"
+        if flt "$rr" ">=" "0.9" && flt "$rr" "<=" "1.1"; then
+            printf '[ok]   vel p%-2s n%-3s v%-3s rmsRatio=%s\n' "$patch" "$note" "$vel" "$rr"
+        else
+            fails=$((fails+1))
+            printf '[FAIL] vel p%-2s n%-3s v%-3s rmsRatio=%s (want 0.9..1.1)\n' \
+                "$patch" "$note" "$vel" "${rr:-<no output>}"
+        fi
+    done
+done
 # 5) Stress tests (stuck-voice detector)
 # Cases: "instr usePedal dual"; PASS iff tailRMS < 0.001
 while IFS= read -r line; do


### PR DESCRIPTION
The sound CPU has no velocity layers. It interpolates every envelope segment
between two corner bytes in the parameter ROM, weighted by one of sixteen
curves it picks from the velocity. `RD_FIRMWARE.md` had the whole chain written
down — the pack builder ignored it and sampled the result at velocities **40,
80, 110 and 127**, and the engine picked the nearest of the four.

### What that cost

16 patches × 20 notes × 10 velocities, all ten chosen to fall between the old
four:

| | before | after |
|---|---|---|
| level error, median | 1.90 dB | **0.01 dB** |
| level error, 95th pct | 8.59 dB | 0.07 dB |
| level error, worst | 16.22 dB | 0.53 dB |
| cells past 1 dB | 2110 / 3200 | **0** |
| correlation, median | 0.9990 | 1.0000 |

On a piano the dynamic response *is* the expressive axis. This is very likely
what anyone comparing the two would hear first.

### Why every A/B run missed it

**Correlation is scale invariant.** A waveform at the wrong level still
correlates at 0.999, and all twelve frozen cells sit on velocity 110 — one the
pack happened to store, where it was exact. The measurement was blind to the
one thing that was wrong.

### What changed

Packs (format `RDP3`) carry the corner bytes, the 256-byte velocity map and the
sixteen curves. `RdNewEngine::buildChain` interpolates at note-on — the same
two muls and a shift the firmware does — and computes each segment's duration
as before. Everything downstream of the chain is untouched.

### Two things fell out of it

- **Packs: 3.26 MB → 0.67 MB.** The chain was being stored four times. The
  whole instrument is now **2.56 MB instead of 5.15**, and fits a 4 MB board
  with both machines aboard — the reduced variants stay as a choice, not a
  necessity.
- **The curve table has sixteen entries, not eight.** Parts select up to index
  15; `RD_FIRMWARE.md` said eight because that pass had walked only the first
  half. A build storing eight loses three quarters of the ones in use.

### Verified

- A Python reconstruction rebuilds the old per-velocity chains out of a v3
  pack: **5632 of 5632 entries byte-identical**, all sixteen patches.
- The twelve frozen A/B cells: **unchanged to six decimals**.
- `run_regression.sh` gained the velocity sweep whose absence let this stand —
  level ratio held to 0.9..1.1 at ten velocities between the old four. Against
  the old packs it fires on 7 of 10 and 8 of 10 cells. `REGRESSION PASS (55
  checks)`.

RAM grows by ~30 kB: the chains are built into a per-voice buffer, since the
pack no longer holds finished segments to point at.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
