### PR TITLE
PicoFaceJV: two reasons notes did not sound at all

### DIFF
--- a/instruments/PicoFaceJV/src/jv_engine/jv_engine.cpp
+++ b/instruments/PicoFaceJV/src/jv_engine/jv_engine.cpp
@@ -1146,7 +1146,14 @@ void Engine::noteOn(uint8_t note, uint8_t velocity) {
     for (int tone = 0; tone < 4; tone++) {
         const uint8_t* t = patch_ + JV_TONE_OFFSET + tone * JV_TONE_SIZE;
         if (!(t[0] & 0x80)) continue;                        // tone switched off
-        if (velocity < t[3] || velocity > t[4]) continue;    // velocity window
+        // Bytes +03/+04 were read as a velocity window, on the manual's word.
+        // They are not one: on the reference, forcing +03 to 127 or +04 to 30
+        // -- either of which would silence the tone under that reading --
+        // changes its output by nothing at all. What the gate did do was
+        // silence every tone of six bank-A basses below velocity 61, where
+        // they all carry +03 = 61. Measured across bank A, 70 of 1600 cells
+        // had the reference sounding and us silent, all of them at velocity
+        // 20 or 50. See tools/jv_extract/README.md.
         startVoice(voices_[allocVoice()], tone, note, velocity, glideFrom);
     }
     lastNoteOn_ = clock_;

--- a/instruments/PicoFaceJV/src/jv_engine/jv_engine.cpp
+++ b/instruments/PicoFaceJV/src/jv_engine/jv_engine.cpp
@@ -625,6 +625,28 @@ bool Engine::sampleFor(int waveNumber, uint8_t note, Sample& out) const {
     uint16_t si = be16(idx + zone * 2);
     if (si == 0xFFFF || si >= JV_SAMPLE_COUNT) return false;
 
+    // A zone list can end in a terminator rather than a zone. One sample -- a
+    // twenty-frame body looping over a single frame, which can sustain
+    // nothing -- appears in nine multisamples and is the last occupied zone in
+    // every one of them. All nine are the basses. Reading it as a playable
+    // zone left eight bank-A patches silent above note 84 while the reference
+    // played on, in tune, from the zone below: measured on St Fretless, the
+    // reference tracks 276, 311, 369, 440, 522 Hz at notes 85 to 96 where this
+    // engine produced nothing at all.
+    //
+    // It is recognised rather than hardcoded by number: of 577 samples it is
+    // the only one that both loops over a single frame and is shorter than a
+    // quarter-second's worth of anything -- the other 41 single-frame loops
+    // are one-shots of 298 frames and up, and every other short sample has a
+    // real loop. Fall back to the zone below, which is what the machine plays.
+    for (int guard = 0; guard < 16 && zone > 0; ++guard) {
+        const uint8_t* c = rom_.rom2 + JV_SAMPLE_TABLE + (size_t)si * JV_SAMPLE_STRIDE;
+        const uint32_t cs = be24(c), cl = be24(c + 3), ce = be24(c + 6);
+        if (!(cl == ce && ce - cs < 64)) break;      // a real zone, keep it
+        si = be16(idx + --zone * 2);
+        if (si == 0xFFFF || si >= JV_SAMPLE_COUNT) return false;
+    }
+
     const uint8_t* s = rom_.rom2 + JV_SAMPLE_TABLE + (size_t)si * JV_SAMPLE_STRIDE;
     out.start = be24(s);
     out.loop = be24(s + 3);

--- a/tools/jv_extract/jv_tone_map.h
+++ b/tools/jv_extract/jv_tone_map.h
@@ -94,8 +94,23 @@ typedef struct {
                                 //     125 Hz square wave on the playback rate,
                                 //     2.17 % per panel step. Measured -- see
                                 //     jv_calibration.h.
-    uint8_t velocityRangeLow;   // +03 MANUAL  velocity window, lower bound 0..127
-    uint8_t velocityRangeUp;    // +04 MANUAL  velocity window, upper bound 0..127
+    uint8_t velocityRangeLow;   // +03 DISPROVEN  the manual calls this a velocity
+                                //     window's lower bound. It is not one, or not one the
+                                //     machine gates on: forced to 127 in a patch written
+                                //     into the reference's temporary patch area -- which
+                                //     under that reading silences the tone below velocity
+                                //     127 -- its output is unchanged at every velocity.
+    uint8_t velocityRangeUp;    // +04 DISPROVEN  likewise, forced to 30 and nothing moves.
+                                //     The engine gated on these two until 26.08.2026 and
+                                //     that silenced six bank-A basses (St Fretless, House
+                                //     Bass, Thumpin Bass, Pick Bass, Wonder Bass, Yowza
+                                //     Bass) below velocity 61, where every one of their
+                                //     tones carries +03 = 61. Whatever these bytes are,
+                                //     do not gate on them.
+                                //     NOTE: the machine DOES gate somewhere -- the user
+                                //     patch "Dist Line" is silent on the reference at
+                                //     velocity 20 and sounds here, at -57 dBFS. Whatever
+                                //     does that is still unfound.
     uint8_t matrixModDestAB;    // +05 VERIFIED dest A = low nibble, B = high nibble
     uint8_t matrixModDestCD;    // +06 UNVERIFIED assumed dest C/D, same packing
     uint8_t matrixModSensA;     // +07 VERIFIED signed, +-63; 64..127 disables. Pitch dest: 19.05 cents/unit

--- a/tools/jv_extract/jv_tone_map.h
+++ b/tools/jv_extract/jv_tone_map.h
@@ -49,6 +49,15 @@
 //   +0 start(24), +3 loop(24), +6 end(24), +11 flag, +12 rootKey,
 //   +13 tune(16be), +17 level
 //   `end` is INCLUSIVE: a loop spans end-loop+1 samples.
+//   A ZONE LIST CAN END IN A TERMINATOR, not a zone. Sample 149 -- a 20-frame
+//   body looping over a single frame, so it can sustain nothing -- appears in
+//   nine multisamples (waves 18-25 and 29, the basses) and is the last
+//   occupied zone in every one. It is not playable and the machine does not
+//   play it: measured on St Fretless, the reference tracks 276/311/369/440/522
+//   Hz at notes 85..96, which is the zone BELOW, transposed. Read as a zone it
+//   silenced eight bank-A patches above note 84. Of 577 samples it is the only
+//   one that both loops over a single frame and runs under 64 frames, so it is
+//   recognised by that rather than by its number.
 //   rootKey is exact semitones; tune is 0.1 cent per unit, neutral at 1024.
 //   The machine itself sits 9.4 cents below equal temperament.
 //   All four established by patching rom2 and measuring -- see README.md.


### PR DESCRIPTION
Two separate faults, both found by sweeping our engine against
`giulioz/jv880_juce` (driven through the `JV880Synth` wrapper from `jv880pi`),
and both the same shape: **notes that produced nothing.**

## 1. Gating on two bytes that are not a velocity window

**Six bank-A basses were silent below velocity 61** — at −150 dB, on every
note: St Fretless, House Bass, Thumpin Bass, Pick Bass, Wonder Bass, Yowza
Bass.

`noteOn` skipped a tone whose velocity fell outside bytes `+03`/`+04`, which
`jv_tone_map.h` documents as a velocity window **on the manual's word** —
marked `MANUAL`, meaning taken from the book rather than measured. All six carry
`+03 = 61` in every enabled tone.

Measured rather than argued: a patch with `+03` forced to **127** — which under
that reading silences the tone below velocity 127 — written into the reference's
temporary patch area leaves its output **unchanged at every velocity**. Same for
`+04` forced to 30. (The ROMs cannot be edited to test this; the emulator
SHA1-checks them.)

## 2. A zone list can end in a terminator, not a zone

**Eight bass patches were silent above note 84**, where the reference plays at
up to **−18.6 dBFS**.

Their multisamples end in sample 149: a twenty-frame body looping over a single
frame, which can sustain nothing. It appears in nine multisamples — waves 18–25
and 29, all basses — and in every one it is the **last occupied zone**.
`sampleFor` read it as a zone; the voice played twenty frames and held.

The machine plays the zone below. On St Fretless the reference tracks
276/311/369/440/522 Hz at notes 85–96 where we produced nothing; with the
fallback we track the same within 8 cents.

Recognised rather than hardcoded: of 577 samples it is the only one that both
loops over a single frame **and** runs under 64 frames.

## Result

Dense grid — 18,432 cells, 192 patches, six notes, sixteen velocities:

| | before | after |
|---|---|---|
| reference sounds, we are silent | 136 | **2** |
| …of those, above −60 dBFS | **109** | **0** |
| loudest missing note | −18.6 dBFS | — |

On the earlier 1600-cell grid the scatter at low velocity also halves — 5.51 dB
against 10.14 at velocity 20 — bringing it in line with the 4.9 dB the high
velocities already had.

## What this does not fix

Ordinary level agreement: median **2.79 dB** across all three banks, 47 of 64
bank-A patches within 3 dB. Separate question; this PR is about notes that did
not sound.

## One loose end, recorded not smoothed

The machine gates somewhere: user patch `Dist Line` is silent on the reference
at velocity 20 and sounds here at −57 dBFS. Not these bytes. Noted in
`jv_tone_map.h`.

## A note on process

I argued against running the dense sweep — the loose end it was chasing sat at
−57 dBFS and looked not worth the time. It found fault 2, at −18.6 dBFS, which
the coarse grid had missed purely because it sampled notes 36/48/60/72/84 and
this needed note 90.

The harness is local; it depends on a checkout that is not in this repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
