### PR TITLE
PicoFaceJV: the TVA velocity attenuation stopped 8.6 dB short of silence

### DIFF
--- a/tools/jv_extract/jv_calibration.h
+++ b/tools/jv_extract/jv_calibration.h
@@ -219,15 +219,28 @@ static const float JV_LFO_PITCH_DEPTH_CENTS[9] = {
 // The old table read 6.39 / 9.60 / 15.89 / 21.22 dB at product 864 / 1296 /
 // 2160 / 2700 where the machine gives 5.21 / 8.09 / 14.96 / 18.27, and it ran
 // away badly at the top: 45.25 against 37.78 at 3969.
-static const float JV_TVA_VELO_PRODUCT[16] = {
+// The tail was re-measured on 26.08.2026 against giulioz/jv880_juce, on a tone
+// that uses velocity curve 0 -- so that the played velocity IS the index the
+// law sees, which is what makes the product comparable at all. In that region
+// the product model holds tightly: three cells at product 3792..3808 all give
+// 36.82 dB, three at 3969..4032 all give 46.36 dB, and everything from 4120 up
+// is silent, with nothing in between.
+//
+// The old table stopped at 3969 -> 37.78 and, worse, velocityAttenDb clamps at
+// its last entry -- so a tone the machine takes to 46 dB and then to silence
+// stayed audible at -37.8 dB here. Extended, and the last entry is now the
+// silence the machine actually reaches.
+static const float JV_TVA_VELO_PRODUCT[18] = {
     0.0f, 216.0f, 432.0f, 648.0f, 864.0f, 1080.0f, 1296.0f, 1512.0f,
-    1728.0f, 1944.0f, 2160.0f, 2400.0f, 2700.0f, 3000.0f, 3400.0f, 3969.0f,
+    1728.0f, 1944.0f, 2160.0f, 2400.0f, 2700.0f, 3000.0f, 3400.0f, 3800.0f,
+    4032.0f, 4120.0f,
 };
-static const float JV_TVA_VELO_ATTEN_DB[16] = {
+static const float JV_TVA_VELO_ATTEN_DB[18] = {
     0.00f, 1.29f, 2.80f, 4.42f, 5.21f, 6.84f, 8.09f, 10.04f,
-    11.89f, 12.79f, 14.96f, 16.59f, 18.27f, 22.78f, 27.62f, 37.78f,
+    11.89f, 12.79f, 14.96f, 16.59f, 18.27f, 22.78f, 28.30f, 36.82f,
+    46.36f, 200.00f,
 };
-#define JV_TVA_VELO_POINTS 16
+#define JV_TVA_VELO_POINTS 18
 //
 // Flags bit 6 is KEY SYNC. Measured by shifting the note-on in time (JV_WARM)
 // and timing the first square-wave edge: with the bit clear the edge moves so

--- a/tools/jv_extract/jv_tone_map.h
+++ b/tools/jv_extract/jv_tone_map.h
@@ -232,13 +232,15 @@ typedef struct {
                                 //     after release; HOLD drops it if the key is released first;
                                 //     PLAY-MATE takes the gap between the last two note-ons as
                                 //     the delay, up to two seconds.
-    uint8_t tvaVelocity;        // +72 VERIFIED  bipolar, steps at bit 6. Measured as a pure
-                                //     attenuation: at velocity 127 every setting gives the same
-                                //     level, lower velocities are pulled down further the larger
-                                //     the value. MANUAL: the panel range is -63..+63 and negative
-                                //     values make HARDER playing quieter -- so the upper half of
-                                //     the byte is probably the inverted side rather than inert,
-                                //     the same trap the LFO depths sprang. Unmeasured.
+    uint8_t tvaVelocity;        // +72 VERIFIED  a pure attenuation: at velocity 127 every
+                                //     setting gives the same level, lower velocities are pulled
+                                //     down further the larger the value. Values 1..63 all bite.
+                                //     VALUES 64..127 ARE INERT, not inverted -- 64, 80, 96, 112
+                                //     and 127 all reproduce the value-0 case exactly, at every
+                                //     velocity, measured 26.08.2026. An earlier note here guessed
+                                //     the upper half was the inverted side "the same trap the LFO
+                                //     depths sprang"; it is not, at least not below 128, which is
+                                //     as far as this went. 128..255 remain unmeasured.
     uint8_t tvaT1T4Velocity;    // +73 MANUAL  TVA-ENV velocity on/off time sense, two 15-step
                                 //     fields: T1 scaled by note-on velocity, T4 by release velocity
     uint8_t tvaEnvTime1;        // +74 VERIFIED  attack, 67.6 ms * 2^(v/14.06); linear in amplitude


### PR DESCRIPTION
`velocityAttenDb` interpolates a table and **returns its last entry for anything
beyond** — so where the machine takes a tone to 46 dB of attenuation and then to
silence, this engine held it at −37.8 dB and kept it audible.

### Measured, not modelled

Re-measured against `giulioz/jv880_juce` on a tone that uses **velocity curve 0**
— so the played velocity is the index the law sees, and the product
`sens*(127-vel)` means what the table assumes. In that deep region the product
model holds tightly:

| product | attenuation |
|---|---|
| 3792, 3800, 3808 | 36.82 dB (all three) |
| 3969, 3976, 4032 | 46.36 dB (all three) |
| ≥ 4120 | silent, nothing in between |

The old table's last point, `3969 → 37.78`, was simply wrong.

### Effect

On the cells it touches, −8.6 dB → −0.03 dB, and every cell where this engine
sounded while the reference was silent now falls silent too. Across bank A it
moves the median by **0.02 dB** — factory patches rarely reach that deep. This
is a correctness fix, not an audible one.

### Also settled

**Byte +72 values 64..127 are inert**, not the inverted side: 64, 80, 96, 112
and 127 all reproduce the value-0 case exactly, at every velocity. The tone map
guessed otherwise and warned it was unmeasured — now it is, below 128.

### Not changed, and it is the larger error

The **velocity curves** in byte +71 are off by up to 3.2 dB (curve 0), 4.7 dB
(curve 1) and 5.2 dB (curve 2), always with soft notes coming out too loud.
Those three carry **every one of the 539 active factory tones**; curves 3–7 are
used by none.

Deriving corrected curves by inverting the TVA law did not produce a
trustworthy result — the inverse came out non-monotonic, and the reference's
curve 7 turned out nearly identical to its curve 0 while ours differs sharply,
which suggests the field is not simply three bits of curve index. Nothing was
changed on that guess.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
