### PR TITLE
PicoFaceJV: take the velocity curves from the ROM instead of a fitted formula

### DIFF
--- a/instruments/PicoFaceJV/include/jv_engine/jv_engine.h
+++ b/instruments/PicoFaceJV/include/jv_engine/jv_engine.h
@@ -310,6 +310,7 @@ private:
         return patch_ && (patch_[24] & JV_PORTA_MODE_LEGATO_BIT);
     }
     bool sampleFor(int waveNumber, uint8_t note, Sample& out) const;
+    int  velocityIndex(int curve, uint8_t vel) const;
     int32_t decodeStep(Voice& v) const;
     void updateFilterCoeffs(Voice& v);
     void updateModulation(Voice& v, uint32_t clock);

--- a/instruments/PicoFaceJV/src/jv_engine/jv_engine.cpp
+++ b/instruments/PicoFaceJV/src/jv_engine/jv_engine.cpp
@@ -614,6 +614,15 @@ void Engine::setPatch(const uint8_t* patch362) {
     reverb_.reset();
 }
 
+// The velocity curve tables, straight out of the machine's own ROM.
+int Engine::velocityIndex(int curve, uint8_t vel) const {
+    if (!rom_.rom2 || rom_.rom2Len < JV_VELO_CURVE_BASE + 7 * 128)
+        return vel;                       // no ROM to read: leave velocity alone
+    if (curve < 0 || curve > 6) curve = 0;   // 7 is not a curve; the table ends
+    const uint8_t b = rom_.rom2[JV_VELO_CURVE_BASE + curve * 128 + (vel & 0x7F)];
+    return 127 - (int)(b >> 1);
+}
+
 bool Engine::sampleFor(int waveNumber, uint8_t note, Sample& out) const {
     if (waveNumber < 0 || waveNumber >= JV_MULTI_COUNT) return false;
     const uint8_t* ms = rom_.rom2 + JV_MULTI_TABLE + (size_t)waveNumber * JV_MULTI_STRIDE;
@@ -918,10 +927,24 @@ void Engine::startVoice(Voice& v, int toneIndex, uint8_t note, uint8_t vel,
     // multiplying by it wrongly attenuated 233 of the 577 samples.
     float lvl = patchLevelToLinear(patch_[21]) * levelToLinear(t[67]) * analogLevel;
 
-    // Velocity: the curve warps velocity first, then the sensitivity law acts
-    // on the warped value. Curve 1 (stored 0) is the straight line the whole
-    // velocity calibration was measured on, so it stays an exact identity.
-    const int velA = (int)(jv_velocity_curve(t[71] & 7, vel) + 0.5f);
+    // Velocity: the curve comes out of the ROM, not out of a fitted formula.
+    // The machine holds seven of them at rom2:0x5390, 128 bytes each, indexed
+    // by the raw MIDI velocity and selected by the low three bits of +71 --
+    // located by logging which addresses the firmware actually reads during a
+    // note-on. What they hold is not a warped velocity but a FALLING
+    // attenuation index: curve 0 is exactly 254 - 2*velocity.
+    //
+    // The sensitivity law downstream is a function of sens * (127 - velA), and
+    // curve 0 gives 254 - 2*vel = 2*(127 - vel) -- so the index the law wants
+    // is simply half the table byte. That also settles why curve 0 always
+    // looked right: the law was calibrated on it.
+    //
+    // Proven independent of how the byte arose: eight pairs of (curve,
+    // velocity) that land on the same byte from different curves all produce
+    // the same level, within 0.28 dB. So the attenuation is a function of the
+    // byte alone, and feeding it through the existing law fits all seven
+    // curves to 0.65 dB median, 2.2 dB worst -- against 6.7 to 20.9 dB before.
+    const int velA = velocityIndex(t[71] & 7, vel);
     {
         // Signed, magnitude up to 63; the ROM byte is two's complement where
         // the SysEx view adds 64. Positive makes soft notes quieter, negative

--- a/tools/jv_extract/jv_tone_map.h
+++ b/tools/jv_extract/jv_tone_map.h
@@ -61,6 +61,16 @@
 //   rootKey is exact semitones; tune is 0.1 cent per unit, neutral at 1024.
 //   The machine itself sits 9.4 cents below equal temperament.
 //   All four established by patching rom2 and measuring -- see README.md.
+// The seven velocity curves, 128 bytes each, indexed by raw MIDI velocity and
+// selected by the low three bits of tone byte +71. Found by logging the ROM
+// addresses the firmware reads during a note-on: PC 0x0062CC reads
+// 0x5390 + curve*128 + velocity. The byte is a FALLING attenuation index, not
+// a warped velocity -- curve 0 is exactly 254 - 2*velocity, and the level law
+// downstream wants half of it. Index 7 is not a curve; the table ends at 6.
+// Factory patches use only 0, 1 and 2: 371, 153 and 15 of 539 active tones.
+#define JV_VELO_CURVE_BASE 0x5390
+#define JV_VELO_CURVE_COUNT 7
+
 #define JV_MULTI_TABLE   0x0004
 #define JV_MULTI_COUNT   129
 #define JV_MULTI_STRIDE  60


### PR DESCRIPTION
The machine holds **seven velocity curves at `rom2:0x5390`**, 128 bytes each,
indexed by the raw MIDI velocity and selected by the low three bits of tone byte
`+71`.

Found by logging which ROM addresses the firmware actually reads during a
note-on — `PC 0x0062CC` reads `0x5390 + curve*128 + velocity`, confirmed at
velocities 10, 40 and 100 and across curve values.

### What the tables actually hold

Not a warped velocity but a **falling attenuation index**. Curve 0 is exactly
`254 − 2·velocity`, and the sensitivity law downstream is a function of
`sens × (127 − velA)` — so the index it wants is **half the byte**. That is also
why curve 0 always looked right here: the law was calibrated on it, and half of
`254 − 2v` is `127 − v` exactly.

| Curve | vel 1 | 32 | 64 | 96 | 127 | |
|---|---|---|---|---|---|---|
| 0 | 252 | 190 | 126 | 62 | 0 | exactly `254 − 2v` |
| 1 | 254 | 233 | 194 | 123 | 0 | |
| 2 | 255 | 252 | 240 | 191 | 0 | |
| 3–6 | | | | | | increasingly hard |
| 7 | — | | | | | not a curve; the table ends at 6 |

### Why a table lookup is legitimate here

Because the attenuation depends on the **byte alone**, not on how it arose:
eight pairs of (curve, velocity) that reach the same byte from different curves
all produce the same level, **within 0.28 dB**.

### Result

Offline against the reference, all seven curves now fit to **0.65 dB median,
2.2 dB worst** — against 6.7 to 20.9 dB for the fitted formula. End to end the
isolated curve error narrows from 2.0–5.2 dB to 2.2–3.9 dB and stops depending
on which curve.

### It does not move the factory banks

**Bank A: 2.43 dB before, 2.43 dB after.** 371 of 539 active tones use curve 0,
already an exact identity; 153 more use curve 1, where the old formula was
close. This is a correctness change — guesswork replaced by the machine's own
data — not an audible one, and it should not be sold as one.

### The more interesting result

The ~2.4 dB that remains is **not** the velocity curve. Ruled out so far, each
by measurement: tone count, patch level, tone level, the sample level byte, dry
send, analog feel, the TVA velocity law, the velocity curves, and measurement
noise — the reference reproduces bit-exactly across runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
