### PR TITLE
PicoFaceJV: the velocity window gates, but only when the patch says so

### DIFF
--- a/instruments/PicoFaceJV/src/jv_engine/jv_engine.cpp
+++ b/instruments/PicoFaceJV/src/jv_engine/jv_engine.cpp
@@ -1188,17 +1188,30 @@ void Engine::noteOn(uint8_t note, uint8_t velocity) {
     soloNote_ = note;
 
     ++panAlt_;   // one step per note, so alternating tones swap sides
+    // Patch common +12 bit 7: the patch velocity switch. See the window test
+    // below -- it decides whether the per-tone velocity window applies at all.
+    const bool velSwitch = (patch_[12] & 0x80) != 0;
     for (int tone = 0; tone < 4; tone++) {
         const uint8_t* t = patch_ + JV_TONE_OFFSET + tone * JV_TONE_SIZE;
         if (!(t[0] & 0x80)) continue;                        // tone switched off
-        // Bytes +03/+04 were read as a velocity window, on the manual's word.
-        // They are not one: on the reference, forcing +03 to 127 or +04 to 30
-        // -- either of which would silence the tone under that reading --
-        // changes its output by nothing at all. What the gate did do was
-        // silence every tone of six bank-A basses below velocity 61, where
-        // they all carry +03 = 61. Measured across bank A, 70 of 1600 cells
-        // had the reference sounding and us silent, all of them at velocity
-        // 20 or 50. See tools/jv_extract/README.md.
+        // Bytes +03/+04 are a velocity window, but a conditional one: it only
+        // gates while bit 7 of the patch common byte -- the patch velocity
+        // switch -- is set. That condition is what made the window look
+        // disproven twice over. Gating unconditionally silenced six bank-A
+        // basses below velocity 61 (St Fretless, House Bass, Thumpin Bass,
+        // Pick Bass, Wonder Bass, Yowza Bass), every one of which carries
+        // +03 = 61 with the switch CLEAR, so the machine ignores the window
+        // and plays them; not gating at all sounded tones the machine keeps
+        // silent, which is audible as a rattle under A20 Marimba SW, whose
+        // third tone is windowed to 126..127 with the switch SET. Bank A
+        // splits cleanly: all ten patches whose window must be ignored have
+        // the switch clear, and all seventeen whose window must bite -- the
+        // Rhodes family, SwitchOnMute, Velo Harmnix, Slap Bass, Marimba SW --
+        // have it set. Measured on the reference: A20 at velocity 100 has no
+        // high-frequency content at all (-35.2 dB against its fundamental)
+        // and at velocity 127 it has +25.9 dB of it, the switched layer
+        // coming in exactly as the window says.
+        if (velSwitch && (velocity < t[3] || velocity > t[4])) continue;
         startVoice(voices_[allocVoice()], tone, note, velocity, glideFrom);
     }
     lastNoteOn_ = clock_;

--- a/tools/jv_extract/README.md
+++ b/tools/jv_extract/README.md
@@ -1330,6 +1330,46 @@ Until such a recording exists, leaving the reverb as it is and saying so
 plainly, as `README.md` and `Engine::Reverb` both do, beats rebuilding it around
 numbers of unknown provenance.
 
+## The velocity window, and the switch that turns it on
+
+Each tone carries a velocity window at +03/+04. The window is real, but it is
+*conditional*: it only gates while bit 7 of the patch common byte at +12 — the
+patch velocity switch — is set. Miss that condition and the bytes look wrong in
+both directions, which is exactly what happened here, twice.
+
+Gating on them unconditionally silenced six bank-A basses below velocity 61.
+St Fretless, House Bass, Thumpin Bass, Pick Bass, Wonder Bass and Yowza Bass
+all carry +03 = 61 on every tone, so under an unconditional reading they have
+nothing at all to play below that velocity, while the reference plays them.
+Across bank A that was 70 of 1600 cells sounding on the reference and silent
+here. So the gate came out.
+
+Not gating at all sounds tones the machine keeps silent. A20 Marimba SW is the
+audible case: its third tone is wave 78 "Anklungs", windowed to 126..127, and
+playing it at every velocity lays a rattle under the marimba — about 12 Hz,
+26 % of the modulation energy in the 8–16 Hz band against 1.3 % for the
+reference. It is loud, too: above 1 kHz the engine carried 50–60 dB more
+energy than the machine.
+
+The switch settles it. Measured on the reference at note 60, A20 has no
+high-frequency content at velocity 100 (−35.2 dB against its own fundamental)
+and +25.9 dB of it at velocity 127 — the windowed layer coming in exactly where
++03 says it should. And bank A splits without a single exception: of the 27
+patches carrying a window at all, the 10 whose window must be ignored have the
+switch clear, and the 17 whose window must bite have it set. The second group
+is precisely the velocity-layered material — the Rhodes family, SwitchOnMute,
+Velo Harmnix, Slap Bass, Marimba SW.
+
+With the condition in place, at note 60 and velocities 20/40/100/127 there is
+no patch in banks A and B that the machine sounds and this engine does not.
+Of the 21 patches whose window can bite, none got further from the reference
+and two moved a long way toward it: SwitchOnMute 0.325 → 0.785 and Marimba SW
+−0.008 → 0.444 in third-octave band similarity.
+
+One caveat worth keeping: the manual's own wording for bit 7 is that it
+*disables* velocity response, which is the opposite of what bank A shows. The
+reading here is the measured one.
+
 ## Credit
 
 The patch and tone field layout comes from

--- a/tools/jv_extract/jv_tone_map.h
+++ b/tools/jv_extract/jv_tone_map.h
@@ -113,23 +113,37 @@ typedef struct {
                                 //     125 Hz square wave on the playback rate,
                                 //     2.17 % per panel step. Measured -- see
                                 //     jv_calibration.h.
-    uint8_t velocityRangeLow;   // +03 DISPROVEN  the manual calls this a velocity
-                                //     window's lower bound. It is not one, or not one the
-                                //     machine gates on: forced to 127 in a patch written
-                                //     into the reference's temporary patch area -- which
-                                //     under that reading silences the tone below velocity
-                                //     127 -- its output is unchanged at every velocity.
-    uint8_t velocityRangeUp;    // +04 DISPROVEN  likewise, forced to 30 and nothing moves.
-                                //     The engine gated on these two until 26.08.2026 and
-                                //     that silenced six bank-A basses (St Fretless, House
-                                //     Bass, Thumpin Bass, Pick Bass, Wonder Bass, Yowza
-                                //     Bass) below velocity 61, where every one of their
-                                //     tones carries +03 = 61. Whatever these bytes are,
-                                //     do not gate on them.
-                                //     NOTE: the machine DOES gate somewhere -- the user
-                                //     patch "Dist Line" is silent on the reference at
-                                //     velocity 20 and sounds here, at -57 dBFS. Whatever
-                                //     does that is still unfound.
+    uint8_t velocityRangeLow;   // +03 VERIFIED  velocity window, lower bound -- but the
+                                //     window only gates while bit 7 of the patch common
+                                //     byte (+12, the patch velocity switch) is SET. That
+                                //     condition is the whole reason these two bytes read
+                                //     as disproven twice: a probe that forces +03 to 127
+                                //     in a patch whose switch is clear changes nothing,
+                                //     because the machine is not consulting the window at
+                                //     all, and gating unconditionally silenced six bank-A
+                                //     basses (St Fretless, House Bass, Thumpin Bass, Pick
+                                //     Bass, Wonder Bass, Yowza Bass) below velocity 61,
+                                //     every one of which carries +03 = 61 with the switch
+                                //     CLEAR.
+    uint8_t velocityRangeUp;    // +04 VERIFIED  upper bound, same condition.
+                                //     Bank A splits without a single exception: of the 27
+                                //     patches carrying a window at all, the 10 whose window
+                                //     must be ignored have the switch clear and the 17
+                                //     whose window must bite have it set -- the latter are
+                                //     exactly the velocity-layered ones (the Rhodes family,
+                                //     SwitchOnMute, Velo Harmnix, Slap Bass, Marimba SW).
+                                //     Measured on the reference at note 60: A20 Marimba SW,
+                                //     whose third tone is windowed to 126..127 with the
+                                //     switch set, carries no high-frequency content at all
+                                //     at velocity 100 (-35.2 dB against its own fundamental)
+                                //     and +25.9 dB of it at velocity 127 -- the switched
+                                //     layer coming in exactly where the window says. Playing
+                                //     that layer at every velocity is audible as a rattle
+                                //     under the marimba, around 12 Hz.
+                                //     NOTE: the machine gates somewhere else as well -- the
+                                //     user patch "Dist Line" is silent on the reference at
+                                //     velocity 20 and sounds here, at -57 dBFS, with no
+                                //     window in play. Whatever does that is still unfound.
     uint8_t matrixModDestAB;    // +05 VERIFIED dest A = low nibble, B = high nibble
     uint8_t matrixModDestCD;    // +06 UNVERIFIED assumed dest C/D, same packing
     uint8_t matrixModSensA;     // +07 VERIFIED signed, +-63; 64..127 disables. Pitch dest: 19.05 cents/unit
@@ -276,7 +290,13 @@ typedef struct {
     uint8_t revChorConfig;      // bits0-3 reverb type, 4-5 chorus type, 7 velocity
                                 //     reverb type 0..7 = ROOM1, ROOM2, STAGE1, STAGE2, HALL1,
                                 //     HALL2, DELAY, PAN-DLY; chorus type 0..2. Bit 7 is the
-                                //     patch velocity switch, which disables velocity response.
+                                //     patch velocity switch. VERIFIED as the enable for the
+                                //     per-tone velocity window at +03/+04: set, the window
+                                //     gates; clear, the machine ignores it and every tone
+                                //     sounds at every velocity. The engine reads it in
+                                //     noteOn(). An earlier note here had it the other way
+                                //     round, as something that "disables velocity response";
+                                //     bank A contradicts that without exception -- see +03.
     uint8_t reverbLevel;
     uint8_t reverbTime;         //     also the delay time when the type is DELAY / PAN-DLY
     uint8_t reverbFeedback;     //     only meaningful for DELAY / PAN-DLY


### PR DESCRIPTION
Michael's ear on A20 Marimba SW: *"dieses marimba hatte bei uns eine art trommel im hintergrund (so ein tack,tack,tack). im video hört man das nicht."* It is a real tone of the patch — it just is not supposed to sound at that velocity.

## What was wrong

Each tone carries a velocity window at `+03/+04`. The window is real, but it only gates while **bit 7 of the patch common byte** (`+12`, the patch velocity switch) is set. Missing that condition makes the bytes look wrong in *both* directions, and this engine has had it wrong both ways:

- **Gating unconditionally** silenced six bank-A basses below velocity 61 — St Fretless, House Bass, Thumpin Bass, Pick Bass, Wonder Bass, Yowza Bass, all carrying `+03 = 61` on every tone with the switch **clear**, so the machine ignores the window and plays them. 70 of 1600 cells sounded on the reference and were silent here. That is why the gate came out.
- **Not gating at all** sounds tones the machine keeps silent. A20 Marimba SW windows its third tone — wave 78 "Anklungs" — to `126..127` with the switch **set**. Played at every velocity it lays a rattle under the marimba: ~12 Hz, 26 % of the modulation energy in the 8–16 Hz band against 1.3 % for the reference, and 50–60 dB of excess above 1 kHz.

## Why the switch is the answer

Measured on the reference at note 60:

| A20 Marimba SW | RMS | high/low | 8–16 Hz |
|---|---|---|---|
| reference, velocity 100 | 0.00923 | −35.2 dB | 1.3 % |
| **ours, before** | 0.00759 | +18.9 dB | 25.8 % |
| **ours, after** | 0.00653 | −33.8 dB | 1.5 % |
| reference, velocity 127 | 0.02260 | +25.9 dB | 33.3 % |
| ours, after, velocity 127 | 0.01014 | +18.5 dB | 25.8 % |

The switched layer arrives exactly where `+03` says it should, on both sides.

And bank A splits without a single exception: of the 27 patches carrying a window at all, the **10 whose window must be ignored have the switch clear**, and the **17 whose window must bite have it set** — precisely the velocity-layered material (the Rhodes family, SwitchOnMute, Velo Harmnix, Slap Bass, Marimba SW).

## Regression

At note 60 and velocities 20/40/100/127 across banks A and B, **no patch sounds on the reference and is silent here**. (One case at velocity 20, B50 Log Drum at −78 dBFS, is pre-existing: its switch is clear and its window is `0..127`, so the new test is skipped entirely for it.)

Of the 21 patches whose window can bite, **none moved away** from the reference:

| | before | after |
|---|---|---|
| SwitchOnMute | 0.325 | **0.785** |
| Marimba SW | −0.008 | **0.444** |
| Slap Bass | 0.619 | 0.726 |
| SA Rhodes | 0.749 | 0.839 |
| Pop Strat | 0.608 | 0.696 |

Bank-wide median similarity is unchanged (0.910 → 0.911) — only 21 of 128 patches have a window that can bite at all.

## A caveat, and one thing the video could not decide

The owner's manual describes bit 7 as *disabling* velocity response, which is the opposite of what bank A shows. The reading here is the measured one.

The demo video cannot adjudicate this patch: its A20 segment is correctly aligned (it matches patch 20 better than any neighbour) but **the reference emulator itself only reaches 0.313 there**, against 0.92–0.98 on the surrounding patches — the demo plays A20 as a phrase, not our single note, and a marimba roll at ~10 strokes/second lands in the same 8–16 Hz band. The evidence for this change is the ROM bytes and the reference, not the recording.

🤖 Generated with [Claude Code](https://claude.com/claude-code)