### PR TITLE
PicoFaceJV: the REV samples play backwards, and forwards they roared

### DIFF
--- a/instruments/PicoFaceJV/include/jv_engine/jv_engine.h
+++ b/instruments/PicoFaceJV/include/jv_engine/jv_engine.h
@@ -40,6 +40,15 @@ struct Sample {
     // rest. Playing those as forward loops makes the sound repeat exactly once
     // per loop, which is audible as a throb at the loop rate.
     bool     bidir;
+    // Bit 2: the chip walks the address DOWN instead of up. Fifteen samples set
+    // it, 562..576, and they are exactly the fifteen belonging to the fourteen
+    // multisamples named "REV ..." -- REV Crash 1, REV SN 1..4, REV TAMB and the
+    // rest. Wave 96 "Crash 1" and wave 128 "REV Crash 1" settle what the bit
+    // does between them: they name the SAME ROM region (163489..227837 against
+    // 163488..227837) and differ only in this flag. The stored audio decays like
+    // any cymbal, from -2 dB at 0.2 s to -19 dB at 1.8 s, so nothing but reading
+    // it backwards can produce the swell the machine plays.
+    bool     reverse;
 };
 
 enum : int {

--- a/instruments/PicoFaceJV/src/jv_engine/jv_engine.cpp
+++ b/instruments/PicoFaceJV/src/jv_engine/jv_engine.cpp
@@ -668,6 +668,11 @@ bool Engine::sampleFor(int waveNumber, uint8_t note, Sample& out) const {
     // holds on the last value). An alternating loop needs at least two samples
     // to turn around in.
     out.bidir = (s[11] & 1) != 0 && out.end > out.loop + 1;
+    // Reverse plays the body once, backwards, and never reaches a loop -- so it
+    // overrides the alternating bit, which the REV records carry anyway
+    // (0x05 = both) because they were cut from the forward samples.
+    out.reverse = (s[11] & 4) != 0;
+    if (out.reverse) out.bidir = false;
     // `end` is inclusive, so it is the last address read. A cut-down build
     // zeroes the entries of the samples it dropped, which fails start < loop
     // here and leaves the tone silent rather than playing whatever now lives
@@ -685,6 +690,23 @@ int32_t Engine::decodeStep(Voice& v) const {
     uint8_t nb = w[page | ((a & 0xFFFFF) >> 5)];
     int nib = (a & 0x10) ? ((nb >> 4) & 15) : (nb & 15);
     const int32_t delta = (((int32_t)d << 11) >> ((10 - nib) & 15)) >> 1;
+
+    if (v.dir < 0 && v.smp.reverse) {
+        // Playing the body backwards. The integrator keeps ADDING while the
+        // address walks down, exactly as it does on the return leg of an
+        // alternating loop, so what comes out is the forward waveform negated
+        // and read back to front -- which is the reverse crash, the sign being
+        // inaudible.
+        v.ref += delta;
+        if (v.ref > 0x7FFFF) v.ref = 0x7FFFF;
+        if (v.ref < -0x80000) v.ref = -0x80000;
+        // `start` is the forward attack, so the swell ends there and the voice
+        // ends with it: the reference falls to digital silence rather than
+        // holding the last value or looping.
+        if (v.addr <= v.smp.start) { v.active = false; return 0; }
+        --v.addr;
+        return v.ref;
+    }
 
     if (v.dir < 0) {
         // Retracing an alternating loop. The chip does NOT undo the steps: it
@@ -865,12 +887,13 @@ void Engine::startVoice(Voice& v, int toneIndex, uint8_t note, uint8_t vel,
     v.velocity = vel;
     v.tone = (uint8_t)toneIndex;
     v.smp = s;
-    v.addr = s.start;
+    // A reverse sample starts at the far end and walks down to `start`.
+    v.addr = s.reverse ? s.end : s.start;
     v.phase = 0;
     v.ref = 0;
     v.refAtLoop = 0;
     v.loopSeen = false;
-    v.dir = 1;
+    v.dir = s.reverse ? -1 : 1;
     v.s0 = v.s1 = 0;
     v.age = ++ageCounter_;
     v.ctlPhase = 0;

--- a/tools/jv_extract/README.md
+++ b/tools/jv_extract/README.md
@@ -1370,6 +1370,51 @@ One caveat worth keeping: the manual's own wording for bit 7 is that it
 *disables* velocity response, which is the opposite of what bank A shows. The
 reading here is the measured one.
 
+## The reverse samples, and the roar they were making
+
+Bit 2 of the sample record's flag byte at +11 makes the chip walk the address
+DOWN instead of up. Fifteen samples set it -- 562 to 576 -- and they are exactly
+the fifteen belonging to the fourteen multisamples named `REV ...`: REV Steel DR,
+REV Tin Wave, REV SN 1..4, REV Kick 1, REV Cup, REV Tom, REV Cow Bell, REV TAMB,
+REV Conga, REV Maracas, REV Crash 1.
+
+Two waves settle what the bit does between them. Wave 96 `Crash 1` names sample
+543 at 163489..227837; wave 128 `REV Crash 1` names sample 576 at
+163488..227837. **The same ROM region**, one byte apart, same end address. The
+records differ in the flag alone: 0x01 against 0x05. And the stored audio decays
+like any cymbal -- decoded, it runs from -2 dB at 0.2 s to -19 dB at 1.8 s -- so
+nothing but reading it backwards can produce the swell the machine plays. The
+emulator's own address counter has the matching control bit: `if (b7)
+address_cnt2 -= ...; else += ...`, from `ram2[7] & 0x80`.
+
+Reading the flag costs one line; not reading it cost rather more than a missing
+swell. B63 RevCymBend puts all four of its tones on wave 128, and playing that
+sample forward runs off the end of the body into its alternating loop, where the
+differential integrator does not come back to where it started. Rendered for
+fifteen seconds against the reference, the machine falls to digital silence at
+second 3 and this engine went on roaring at -35 to -47 dBFS through second 13 --
+a ten-second noise burst on every note of the patch. Played backwards the body
+is traversed once and the voice ends at `start`, which is the forward attack,
+and the reference does the same: both go silent at second 3.
+
+Third-octave band similarity over six seconds: 0.539 -> 0.867. The four affected
+patches are B63 RevCymBend and User64 REVERSE MAD, which use the REV waves, and
+B13 Orch Stab 1 and User11 Orch Stab 2, which use the forward Crash 1 and are
+unchanged to the sample -- the runaway needed the reverse record's loop, not the
+alternating bit as such.
+
+**What is still wrong.** The swell is now the right shape and ends at the right
+moment, but its level is not right in the middle: at the peak this engine sits
+6.5 dB under the reference and around 0.9 s it is 27 dB under, while the two
+ends agree to about 5 dB. The sample side is exonerated -- decoded backwards it
+carries no DC (mean 7 of a 3865 RMS), never touches the clamp, and mirrors the
+forward envelope exactly (18.4 dB of swell). Windowed band similarity stays
+between 0.71 and 0.93 throughout, so the content is right and only its amplitude
+over time is not. The patch bends: coarse -8, pitch envelope depth 12 with a
+full negative deflection over T2, which changes how fast the reversed body is
+traversed and so where its swell lands. That makes the pitch envelope the first
+thing to check, and it is not checked yet -- so this is a lead, not a finding.
+
 ## Credit
 
 The patch and tone field layout comes from


### PR DESCRIPTION
B63 RevCymBend was the worst-matching patch in the bank at −19.7 dB. It turned out to hide a ten-second noise burst.

## The bit

Bit 2 of the sample flag byte at `+11` makes the chip walk the address **down** instead of up. Fifteen samples set it — 562..576 — and they are exactly the fifteen belonging to the fourteen multisamples named `REV …`: REV Steel DR, REV Tin Wave, REV SN 1..4, REV Kick 1, REV Cup, REV Tom, REV Cow Bell, REV TAMB, REV Conga, REV Maracas, REV Crash 1.

Two waves settle what it does between them:

| wave | name | sample | region | flags |
|---|---|---|---|---|
| 96 | `Crash 1` | 543 | 163489..227837 | `0x01` |
| 128 | `REV Crash 1` | 576 | 163488..227837 | `0x05` |

**The same ROM region**, one byte apart, same end address — the records differ in this flag alone. And decoded, the stored audio decays like any cymbal (−2 dB at 0.2 s to −19 dB at 1.8 s), so nothing but reading it backwards can produce the swell the machine plays. The emulator's address counter carries the matching control bit: `if (b7) address_cnt2 -= …; else += …`, from `ram2[7] & 0x80`.

## What it cost

B63 puts all four tones on wave 128. Played forward, the body runs off its end into the alternating loop, where the differential integrator does not return to where it started. Rendered fifteen seconds against the reference:

| second | reference | before | after |
|---|---|---|---|
| 2 | −46.3 | −51.0 | −50.8 |
| 3 | **−88.4** | −46.9 | **−150.5** |
| 5 | −88.4 | **−36.8** | silent |
| 9 | −88.4 | **−38.9** | silent |
| 13 | −88.4 | **−56.3** | silent |

A ten-second roar on every note of the patch, at a level above the patch's own peak. Backwards, the body is traversed once and the voice ends at `start` — the forward attack — and both engines now go silent at second 3.

Third-octave band similarity over six seconds: **0.539 → 0.867**.

## Scope

Four patches touch this material. **B63 RevCymBend** and **User64 REVERSE MAD** change; **B13 Orch Stab 1** and **User11 Orch Stab 2** use the forward `Crash 1` and are unchanged to the sample — the runaway needed the reverse record's loop, not the alternating bit as such. Nothing else in banks A and B differs by a single sample.

## Still wrong, and left open

The swell is now the right shape and ends at the right moment, but its level in the middle is not right: at the peak this engine sits 6.5 dB under the reference and around 0.9 s it is 27 dB under, while the two ends agree to about 5 dB. A two-second window therefore scores *worse* than before (0.847 → 0.747) — the reverse swell is still climbing there, where the forward crash used to be at its loudest.

The sample side is exonerated: decoded backwards it carries no DC (mean 7 against a 3865 RMS), never touches the clamp, and mirrors the forward envelope exactly (18.4 dB of swell). Windowed band similarity stays between 0.71 and 0.93 throughout, so the content is right and only its amplitude over time is not.

The patch bends — coarse −8, pitch envelope depth 12 with a full negative deflection over T2 — which changes how fast the reversed body is traversed and so where its swell lands. That makes the pitch envelope the first thing to check. It is not checked yet, so that is a lead, not a finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)