### PR TITLE
PicoFaceJV: the pitch envelope does not explain B63, and no byte in it moves the pitch

### DIFF
--- a/tools/jv_extract/README.md
+++ b/tools/jv_extract/README.md
@@ -1415,6 +1415,48 @@ full negative deflection over T2, which changes how fast the reversed body is
 traversed and so where its swell lands. That makes the pitch envelope the first
 thing to check, and it is not checked yet -- so this is a lead, not a finding.
 
+## The pitch envelope, and a lead that did not survive
+
+B63 RevCymBend was left with a residual: the right swell, ending at the right
+moment, but 6.5 dB under the reference at its peak and 27 dB under in the
+middle. The patch bends -- coarse -8, depth 12, a full negative deflection over
+T2 -- so the pitch envelope was named as the first thing to check, on the
+reasoning that a wrong pitch traverses a reversed sample at the wrong speed.
+It was checked. It is not the cause.
+
+**The sweep.** Every one of the 84 tone bytes was written into the reference's
+temporary patch area at 0 and 127, on a synthetic single-tone patch held
+forever, with a pitch envelope armed at maximum depth and a T2 long enough to
+glide audibly within the measured second. Four bytes move the sounding pitch:
++37 and +38, the two tunings; +39, whose low nibble is the random pitch and at
+15 draws over +-1200 cents; and +01, which is simply a different wave. Nothing
+in +40..+51 moves it at all. The harness is sound -- +67 sweeps the level
+cleanly from silence to 0.086 RMS across the same range, and +37 tracks the
+keyboard in exact semitones (value 8 gives +8, 16 gives +16, 24 gives +24).
+
+A factory patch says the same. B23 GlassVoices gives its third tone depth 250
+with a 400 ms segment, and the reference holds a flat 262.5 Hz through the
+note -- as does this engine.
+
+**Why it is not acted on.** One measurement pulls the other way. This engine's
+pitch envelope puts an octave on B63 at note-on and glides it down, and with
+that in place the note ends at 2.8 s, which is exactly when the reference ends;
+switched off, the ending moves out to 3.6 s and third-octave band similarity
+falls from 0.867 to 0.841. Coarse -8 alone predicts 3.19 s, so the machine is
+running that note about two semitones sharp of what the tuning bytes account
+for, and where that comes from is unknown. Deleting the block on the strength
+of the sweep would trade a modelled sweep for a wrong duration.
+
+**Stakes.** 68 of 539 tones set a depth and 66 of those move their levels, but
+only 13 have a segment slow enough to hear as a sweep rather than a blip of a
+few milliseconds -- and four of the thirteen are the four tones of B63. The
+others are User29 Glasswaves, User49 UTAKATA, User56 Glass Pad, User62 Arctic
+Winds, User63 DistanceCall, B23 GlassVoices and B59 JP-8 Pad. Switching the
+envelope off changed none of them by more than 0.02 in similarity.
+
+So: the residual on B63 is still unexplained, and the pitch envelope is no
+longer a candidate.
+
 ## Credit
 
 The patch and tone field layout comes from

--- a/tools/jv_extract/jv_tone_map.h
+++ b/tools/jv_extract/jv_tone_map.h
@@ -210,8 +210,31 @@ typedef struct {
     uint8_t tvpEnvTime3;        // +48 VERIFIED acts on pitch
     uint8_t tvpEnvLevel3;       // +49 MANUAL  bipolar
     uint8_t tvpEnvTime4;        // +50 MANUAL  release segment of the pitch envelope
-    uint8_t tvpEnvLevel4;       // +51 MANUAL  bipolar. The whole pitch envelope is unimplemented:
-                                //     the engine reads none of +40..+51.
+    uint8_t tvpEnvLevel4;       // +51 MANUAL  bipolar.
+    // ------------------------------------------------------------------
+    // A byte-by-byte sweep of the whole 84-byte tone record against the
+    // reference, with a pitch envelope armed at maximum depth and a segment
+    // long enough to glide for a second, found NO byte in +40..+51 that moves
+    // the sounding pitch. Of all 84, only +37 and +38 (the two tunings), +39's
+    // low nibble (random pitch, which at 15 draws over +-1200 cents) and +01
+    // (a different wave) do. A factory patch bears it out: B23 GlassVoices
+    // gives its third tone depth 250 with a 400 ms segment, and the reference
+    // holds a flat 262.5 Hz through the whole note, exactly as this engine
+    // does.
+    //
+    // That is a negative result and it is left standing rather than acted on,
+    // because one measurement pulls the other way: this engine's own pitch
+    // envelope makes B63 RevCymBend end at 2.8 s, which is when the reference
+    // ends, and switching it off pushes the ending out to 3.6 s and the band
+    // similarity down from 0.867 to 0.841. So something raises the machine's
+    // pitch early in that note, and it has not been found. Removing the block
+    // on the strength of the sweep alone would be a regression.
+    //
+    // Stakes are small either way: 68 of 539 tones set a depth, 66 of those
+    // move their levels, and only 13 have a segment slow enough to hear rather
+    // than a blip of a few milliseconds -- four of the thirteen being the four
+    // tones of B63 itself.
+    // ------------------------------------------------------------------
     uint8_t tvfCutoff;          // +52 VERIFIED cutoff, 431 Hz * 2^(v/17.93); needs +55 != OFF
     uint8_t tvfResonance;       // +53 VERIFIED resonance: level and brightness rise together
     uint8_t tvfTimeKFKeyfollow; // +54 PARTIAL reacts; period-2 alternation confirms it is packed


### PR DESCRIPTION
**Documentation only — no engine change, deliberately.** This closes the lead I flagged in [#84](https://github.com/Michi71/PicoVintageSynthCollection/pull/84).

## The question

B63 RevCymBend was left with a residual after the reverse-sample fix: the right swell, ending at the right moment, but 6.5 dB under the reference at its peak and 27 dB under in the middle. The patch bends — coarse −8, depth 12, a full negative deflection over T2 — so the pitch envelope was the obvious suspect: a wrong pitch traverses a reversed sample at the wrong speed.

## What the reference says

Every one of the 84 tone bytes was written into the reference's temporary patch area at 0 and 127, on a synthetic single-tone patch held forever, with a pitch envelope armed at maximum depth and a segment long enough to glide within the measured second.

Four bytes move the sounding pitch:

| byte | what it is |
|---|---|
| +37 | coarse tune — exact semitones (8 → +8, 16 → +16, 24 → +24) |
| +38 | fine tune |
| +39 | low nibble is random pitch; at 15 it draws over ±1200 cents |
| +01 | a different wave |

**Nothing in +40..+51 moves it at all.** The harness is sound — +67 sweeps the level cleanly from silence to 0.086 RMS across the same range.

A factory patch agrees: **B23 GlassVoices** gives its third tone depth 250 with a 400 ms segment, and the reference holds a flat 262.5 Hz through the note — exactly as this engine does.

## Why nothing is removed

One measurement pulls the other way, and it is worth stating rather than burying. This engine's pitch envelope puts an octave on B63 at note-on and glides it down. With that in place:

| | ending | similarity |
|---|---|---|
| reference | 2.8 s | — |
| ours, pitch envelope on | **2.8 s** | **0.867** |
| ours, pitch envelope off | 3.6 s | 0.841 |

Coarse −8 alone predicts 3.19 s, so the machine runs that note about two semitones sharp of what the tuning bytes account for, and I do not know why. Deleting the block on the strength of the sweep would trade a modelled sweep for a wrong duration.

## Stakes

68 of 539 tones set a depth and 66 move their levels, but only **13** have a segment slow enough to hear as a sweep rather than a blip of a few milliseconds — and **four of the thirteen are the four tones of B63**. The others are User29 Glasswaves, User49 UTAKATA, User56 Glass Pad, User62 Arctic Winds, User63 DistanceCall, B23 GlassVoices, B59 JP-8 Pad. Switching the envelope off moved none of them by more than 0.02.

The residual on B63 remains unexplained. The pitch envelope is no longer a candidate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)