### PR TITLE
PicoFaceJV: the pitch offset is five cents, and the "two semitones" is withdrawn

### DIFF
--- a/tools/jv_extract/README.md
+++ b/tools/jv_extract/README.md
@@ -1457,6 +1457,56 @@ envelope off changed none of them by more than 0.02 in similarity.
 So: the residual on B63 is still unexplained, and the pitch envelope is no
 longer a candidate.
 
+## The pitch offset: five cents, and a retraction
+
+The pitch-envelope note above ended by saying the machine "runs that note about
+two semitones sharp of what the tuning bytes account for". **That is withdrawn.**
+It was inferred from how long B63 RevCymBend takes to traverse its reversed
+sample, which depends on when the note ends as much as on how fast it is played,
+and it does not survive a direct measurement of the pitch.
+
+Measured properly, both engines are given the SAME synthetic patch -- one tone,
+one wave, held at full level with every modulator neutral and both tunings at
+zero -- ours through `setPatch`, the reference by writing it into its temporary
+patch area at `nvram[0x0d70]` and resetting. The sounding pitch is then read off
+a zero-padded spectrum, searched only within a couple of semitones of the
+expected fundamental so the measurement cannot jump an octave, which is what
+made an earlier autocorrelation pass produce nonsense.
+
+| note | expected | reference | this engine |
+|---|---|---|---|
+| 48 | 130.81 | -6.0 ct | -1.3 ct |
+| 55 | 196.00 | -5.7 ct | -0.9 ct |
+| 60 | 261.63 | -6.0 ct | +1.1 ct |
+| 67 | 392.00 | -4.9 ct | +0.7 ct |
+| 72 | 523.25 | -5.4 ct | -0.1 ct |
+
+**This engine plays equal temperament to about a cent. The reference plays about
+five cents flat of it**, and the median difference is +5.0 cents with this
+engine on the sharp side. It is a constant frequency ratio, not a per-note or
+per-wave effect: waves 0, 12, 30 and 60 give +4.7, +5.3, +3.9 and +5.9 cents
+(wave 96 is a cymbal and measures nothing meaningful). It is not the pitch
+envelope -- that block moves no pitch at all, see above -- and it is not the
+reference's audio path, which runs natively at 64 kHz and divides by exactly two.
+
+**Where it comes from is not established.** The most likely reading is that it
+is the dumped unit's own stored master tune: the reference boots from
+`jv880_nvram.bin`, a 32 KB image of one real machine's battery-backed RAM with
+that machine's system settings in it. Sweeping the plausible bytes at the head
+of that image did not isolate it -- a 16-bit word at `nvram[1..2]` looked like a
+candidate at 1012 against a neutral 1024 and turned out to change nothing across
+976..1072 -- so this is a reading, not a finding.
+
+**Nothing is changed on the strength of it.** Tuning this engine five cents flat
+would match one dumped unit's saved setting rather than the instrument, and the
+nominal figure -- A = 440, equal temperament -- is what this engine already
+produces. Anyone who wants to sit with that unit can dial it: the TUNE page
+offers +-50 cents in one-cent steps.
+
+Worth knowing for every A/B measurement in this file: they all carry this five
+cents. Third-octave band similarity is insensitive to it, so none of the
+conclusions drawn from those numbers turn on it.
+
 ## Credit
 
 The patch and tone field layout comes from

--- a/tools/jv_extract/jv_tone_map.h
+++ b/tools/jv_extract/jv_tone_map.h
@@ -230,6 +230,14 @@ typedef struct {
     // pitch early in that note, and it has not been found. Removing the block
     // on the strength of the sweep alone would be a regression.
     //
+    // On "something raises the machine's pitch": a direct measurement has since
+    // put a number on the tuning difference and it is small and constant. This
+    // engine plays equal temperament to about a cent; the reference plays about
+    // FIVE cents flat of it, the same across notes 48..79 and across waves 0,
+    // 12, 30 and 60. That is nowhere near enough to account for B63's duration,
+    // so the duration argument above stands on its own and is still unexplained.
+    // See README.md, "The pitch offset: five cents, and a retraction".
+    //
     // Stakes are small either way: 68 of 539 tones set a depth, 66 of those
     // move their levels, and only 13 have a segment slow enough to hear rather
     // than a blip of a few milliseconds -- four of the thirteen being the four


### PR DESCRIPTION
**Documentation only — no engine change, deliberately.**

## The retraction first

[#85](https://github.com/Michi71/PicoVintageSynthCollection/pull/85) ended by saying the machine runs B63 "about two semitones sharp of what the tuning bytes account for". **That is withdrawn.** It was inferred from how long the patch takes to traverse its reversed sample — which depends on when the note *ends* as much as on how fast it is played — and it does not survive a direct measurement.

## What the pitch actually does

Both engines are given the **same** synthetic patch: one tone, one wave, held at full level, every modulator neutral, both tunings at zero. Ours through `setPatch`, the reference by writing it into its temporary patch area and resetting. The pitch is read off a zero-padded spectrum, searched only within a couple of semitones of the expected fundamental — an earlier autocorrelation pass jumped octaves and produced nonsense.

| note | expected | reference | this engine |
|---|---|---|---|
| 48 | 130.81 Hz | −6.0 ct | −1.3 ct |
| 55 | 196.00 Hz | −5.7 ct | −0.9 ct |
| 60 | 261.63 Hz | −6.0 ct | +1.1 ct |
| 67 | 392.00 Hz | −4.9 ct | +0.7 ct |
| 72 | 523.25 Hz | −5.4 ct | −0.1 ct |

**This engine plays equal temperament to about a cent. The reference plays about five cents flat of it.** Median difference +5.0 cents, us on the sharp side.

It is a constant frequency ratio, not per-note and not per-wave — waves 0, 12, 30 and 60 give +4.7, +5.3, +3.9 and +5.9 cents (wave 96 is a cymbal and measures nothing meaningful). It is **not** the pitch envelope, which moves no pitch at all, and **not** the reference's audio path, which runs natively at 64 kHz and divides by exactly two.

## Where it comes from — a reading, not a finding

The likeliest explanation is the dumped unit's own stored master tune: the reference boots from `jv880_nvram.bin`, a 32 KB image of one real machine's battery-backed RAM, system settings included. Sweeping the head of that image did not isolate it — a 16-bit word at `nvram[1..2]` looked like a candidate at 1012 against a neutral 1024 and turned out to change nothing across 976..1072. So this is stated as a reading and labelled as one.

## Why nothing changes

Tuning this engine five cents flat would match one dumped unit's saved setting rather than the instrument, and A = 440 in equal temperament is what this engine already produces. Anyone who wants to sit with that unit can dial it — the TUNE page already offers ±50 cents in one-cent steps.

Worth knowing for the rest of the README: every A/B measurement in it carries these five cents. Third-octave band similarity is insensitive to them, so no conclusion drawn from those numbers turns on it.

**Still open:** B63's duration. Five cents is nowhere near enough to account for it, so whatever ends that note early on the reference is not a tuning difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)