### PR TITLE
PicoFaceJV: a reverse sample has to start at `end`, and the reason is DC

### DIFF
--- a/instruments/PicoFaceJV/src/jv_engine/jv_engine.cpp
+++ b/instruments/PicoFaceJV/src/jv_engine/jv_engine.cpp
@@ -887,7 +887,13 @@ void Engine::startVoice(Voice& v, int toneIndex, uint8_t note, uint8_t vel,
     v.velocity = vel;
     v.tone = (uint8_t)toneIndex;
     v.smp = s;
-    // A reverse sample starts at the far end and walks down to `start`.
+    // A reverse sample starts at the far end and walks down to `start`. It has
+    // to be `end` and not the loop point: the decoder is a differential
+    // integrator started at zero, so a backward walk from address A puts out
+    // v(A) - v(n) and carries v(A) as DC. This sample's deltas sum to exactly
+    // zero over the body, which makes v(end) exactly 0 and v(loop) 1584 against
+    // an RMS of 3865 -- starting at the loop point measures 88-99 % DC at the
+    // output where the reference has 8-11 %. See tools/jv_extract/README.md.
     v.addr = s.reverse ? s.end : s.start;
     v.phase = 0;
     v.ref = 0;

--- a/tools/jv_extract/README.md
+++ b/tools/jv_extract/README.md
@@ -1507,6 +1507,37 @@ Worth knowing for every A/B measurement in this file: they all carry this five
 cents. Third-octave band similarity is insensitive to it, so none of the
 conclusions drawn from those numbers turn on it.
 
+## Why a reverse sample starts at `end`, and what still ends B63 early
+
+B63 RevCymBend's reference render falls away at about 2.7 s. Walking the whole
+body backwards at that patch's coarse -8 takes 3.19 s, and walking only
+`loop`..`start` takes 2.83 s -- so starting the reverse at the loop point rather
+than at `end` looked like the answer, and on two metrics it looked like a good
+one: the RMS ratio against the reference went from 0.37 to 1.11 and the
+per-window level error collapsed from -20..-26 dB to within a few dB.
+
+It is wrong, and the way it is wrong is worth keeping.
+
+The decoder is a differential integrator started at zero. Output from a
+backward walk beginning at address A is therefore `v(A) - v(n)`, so it carries a
+DC offset of exactly `v(A)`. For this sample `v(end)` is **0** -- not
+approximately, exactly -- while `v(loop)` is 1584 against a sample RMS of 3865.
+Starting at the loop point injects that as DC, and it shows: measured at the
+output, the reference carries 8-11 % DC against its own RMS and the loop-start
+build carries **88-99 %**. Most of the apparent level improvement was not signal.
+
+So `end` is the only start point that decodes without a DC step, and the ROM is
+authored for it -- the sample's deltas sum to precisely zero over the body,
+which is not an accident. The engine keeps `end`.
+
+What ends the reference early is still unknown. It is not the tuning: pitch
+measures correct to a few cents. It is not the pitch envelope, which moves no
+pitch at all. A centroid fingerprint of the sample was tried as a way to read
+the playback position straight out of the reference and does not discriminate --
+the crash's brightness barely changes across its length (5600 Hz to 5273 Hz), so
+position cannot be recovered that way. The field is narrower than it was, and
+the answer is not here yet.
+
 ## Credit
 
 The patch and tone field layout comes from


### PR DESCRIPTION
**Comment and documentation only — the code path is unchanged.** This records a hypothesis that was tested and rejected, and the reason is worth keeping next to the line.

## The hypothesis

B63 RevCymBend's reference render falls away at about 2.7 s. At that patch's coarse −8:

| | duration |
|---|---|
| whole body, `end` → `start` | 3.19 s |
| `loop` → `start` | 2.83 s |
| **reference** | **~2.7 s** |

So starting the reverse walk at the loop point looked like the answer. On two metrics it looked like a good one: the RMS ratio against the reference went from **0.37 to 1.11**, and the per-window level error collapsed from −20..−26 dB to a few dB.

## Why it is wrong

The decoder is a differential integrator started at zero. A backward walk from address A puts out `v(A) − v(n)` — so it carries **`v(A)` as DC**.

| | value |
|---|---|
| `v(end)` | **exactly 0** |
| `v(loop)` | 1584 |
| sample RMS | 3865 |

The deltas sum to precisely zero over the body, which is not an accident — the ROM is authored so that a backward walk from `end` decodes clean. Starting at `loop` injects 1584 as DC, and it measures at the output:

| | DC, 0–0.4 s | DC, 0.4–1.0 s |
|---|---|---|
| reference | 8 % | 11 % |
| ours, start at `end` | 3 % | 5 % |
| **ours, start at `loop`** | **88 %** | **99 %** |

Most of the apparent level improvement was not signal. `end` stays.

## What is still open

What ends the reference early. The field is narrower than it was:

- **Not the tuning** — pitch measures correct to a few cents ([#86](https://github.com/Michi71/PicoVintageSynthCollection/pull/86)).
- **Not the pitch envelope** — it moves no pitch at all ([#85](https://github.com/Michi71/PicoVintageSynthCollection/pull/85)).
- **Not readable from a centroid fingerprint** — tried and does not discriminate: the crash's brightness barely changes across its length (5600 Hz → 5273 Hz), so playback position cannot be recovered that way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)