### PR TITLE
PicoFaceJV: a fall to silence covers 32.6 dB, not 40

### DIFF
--- a/instruments/PicoFaceJV/src/jv_engine/jv_engine.cpp
+++ b/instruments/PicoFaceJV/src/jv_engine/jv_engine.cpp
@@ -29,6 +29,27 @@ float lookup(const float* tbl, int n, int v) {
 float envRiseSeconds(int v) { return lookup(JV_ENV_RISE_S, JV_ENV_RISE_N, v); }
 float envFallSeconds(int v) { return lookup(JV_ENV_FALL_S, JV_ENV_FALL_N, v); }
 
+// How far a segment falling to silence travels over one fall time. The fall
+// table itself is measured; this is the depth that rides on it, and it is 32.6
+// dB, not the 40 that stood here before.
+//
+// Measured against the reference on a synthetic patch -- one tone, one looping
+// wave, held at full level with every modulator neutral -- by timing a 12 dB
+// drop after the body has run out and only the envelope is still working. At 40
+// the engine reached that point in 0.81..0.85 of the reference's time across
+// stage-2 times 70..110, and its release in 0.74..0.79. Sweeping the figure
+// crosses unity between 32 and 34 (34 gives 0.96, 32 gives 1.02); 32.6 lands
+// the decay at 0.99..1.03 and the release at 0.95..0.97, the remaining release
+// gap being the 0.1 s offset the measurement window starts with.
+//
+// Both stages ride on this: stage 2 whenever its level is zero, which is how
+// most percussive patches are built, and every release to silence. The rise
+// side is untouched and stays exact -- at stage-1 time 70 the engine tracks the
+// reference within 1 % at every point of the ramp.
+#ifndef JV_FALL_TO_SILENCE_DB
+#define JV_FALL_TO_SILENCE_DB 32.6f
+#endif
+
 // A TVA envelope target, on its own measured curve rather than the tone-level
 // one -- the two are up to 9.4 dB apart.
 float envLevelToLinear(int v) {
@@ -203,8 +224,9 @@ float Engine::Env::tick() {
         } else if (target > 1e-6f && level > 1e-6f) {
             decay = powf(target / level, 1.0f / remaining); // linear in dB, to target
         } else {
-            // Falling to silence: the calibration is a 40 dB drop per fall time.
-            decay = powf(10.0f, -40.0f / (20.0f * remaining));
+            // Falling to silence: a fixed dB drop per fall time. Overridable at
+            // compile time so the figure can be swept without editing here.
+            decay = powf(10.0f, -JV_FALL_TO_SILENCE_DB / (20.0f * remaining));
         }
         segmentValid = true;
     }

--- a/tools/jv_extract/README.md
+++ b/tools/jv_extract/README.md
@@ -1507,6 +1507,48 @@ Worth knowing for every A/B measurement in this file: they all carry this five
 cents. Third-octave band similarity is insensitive to it, so none of the
 conclusions drawn from those numbers turn on it.
 
+## The fall to silence was 40 dB and should be 32.6
+
+A57 Slap Bass sat 1.8 dB over the reference and would not come closer. Tracked
+across the keyboard, the error turned out not to be a level at all: the attack
+matched to within a decibel at every note, and everything after it drifted. At
+note 40 -- the root of the zone, so no pitch shift at all -- the two agreed at
+the transient and were 2.5 dB apart by 1.3 s. That is a decay rate.
+
+The samples in that patch loop, so once the body has run out the level is
+whatever the envelope says, and the envelope is all this patch has: T1 = 0 to
+full, then T2 = 82 down to zero. Measured there, the reference decays at
+-11.3 dB/s and this engine at -13.8.
+
+Put on a synthetic patch -- one tone, one looping wave, held at full level with
+every modulator neutral -- and timed by a 12 dB drop taken after the body runs
+out, the error is a clean constant. Across stage-2 times 70 to 110 the engine
+reached that point in **0.81 to 0.85** of the reference's time, and its release
+in 0.74 to 0.79. Both stages fall to silence, and both ride on the same figure:
+the engine spent one fall time travelling 40 dB.
+
+The shape was never wrong. Both sides are dB-linear -- at stage-2 time 90 the
+reference measures -6.6 dB/s early and -7.1 dB/s late, this engine a flat -8.2 --
+so only the depth needed moving. Sweeping it crosses unity between 32 and 34
+(34 gives 0.96, 32 gives 1.02), and **32.6** lands the decay at 0.99..1.03 and
+the release at 0.95..0.97 across the whole range. The remaining release gap is
+the 0.1 s the measurement window starts after note-off.
+
+The rise side is untouched and stays exact: at stage-1 time 70 the engine tracks
+the reference within 1 % at every point of a 2.4 s ramp, and reaches 90 % at
+2.0 s against 2.1 s.
+
+On A57 the mean envelope error over the first 1.4 s falls from 1.37 dB to
+**0.52 dB** at note 40, from 3.87 to 2.22 dB at note 48 and from 5.28 to 3.61 dB
+at note 43. Bank-wide at note 60 the change is a wash on third-octave band
+similarity (median 0.911 to 0.910) -- that measure is level-blind and most
+patches carry larger errors elsewhere -- while the mean absolute level error
+moves 4.01 to 3.97 dB.
+
+**Still wrong on A57:** notes 43 and 48 keep 2 to 4 dB after the fix, and both
+sit in zone 1 of the multisample (sample 160) while note 40 sits in zone 0 and
+is now exact. Whatever is left is zone-related, not envelope-related.
+
 ## Credit
 
 The patch and tone field layout comes from


### PR DESCRIPTION
A57 Slap Bass sat 1.8 dB over the reference and would not come closer. It turned out not to be a level error at all.

## Finding the shape of it

Tracked across the keyboard, the **attack matched within a decibel at every note** and everything after it drifted. At note 40 — the root of its zone, so unshifted — the two agreed at the transient and were 2.5 dB apart by 1.3 s. That is a decay rate, not a gain.

The patch's samples loop, so once the body runs out the level is whatever the envelope says, and the envelope is all this patch has: T1 = 0 to full, then T2 = 82 down to zero. There the reference decays at −11.3 dB/s and this engine at −13.8.

## The constant

Measured on a synthetic patch — one tone, one looping wave, held at full level with every modulator neutral — by timing a 12 dB drop after the body runs out:

| stage-2 time | reference | ours (40 dB) | ratio |
|---|---|---|---|
| 70 | 0.71 s | 0.60 s | 0.845 |
| 80 | 1.14 s | 0.94 s | 0.825 |
| 90 | 1.81 s | 1.48 s | 0.818 |
| 100 | 2.87 s | 2.32 s | 0.808 |
| 110 | 4.46 s | 3.65 s | 0.818 |

Releases came out at 0.74–0.79 of the reference. Both stages fall to silence and both rode on the same figure: **one fall time was taken to travel 40 dB.**

The *shape* was never wrong — both sides are dB-linear (at stage-2 time 90 the reference measures −6.6 dB/s early and −7.1 late, against a flat −8.2 here) — so only the depth moved. Sweeping crosses unity between 32 and 34:

| constant | decay ratio |
|---|---|
| 40 dB | 0.81 – 0.85 |
| 34 dB | 0.96 – 0.97 |
| **32.6 dB** | **0.99 – 1.03** |
| 32 dB | 1.01 – 1.03 |
| 30 dB | 1.07 – 1.10 |

At 32.6 the release lands at 0.95–0.97, the remaining gap being the 0.1 s the measurement window starts after note-off.

**The rise side is untouched and stays exact**: at stage-1 time 70 the engine tracks the reference within 1 % at every point of a 2.4 s ramp (90 % reached at 2.0 s against 2.1 s). Rise and fall use separate measured tables, so this only moves the fall.

## Effect

On A57, mean envelope error over the first 1.4 s:

| note | before | after |
|---|---|---|
| 40 (zone root) | 1.37 dB | **0.52 dB** |
| 48 | 3.87 dB | 2.22 dB |
| 43 | 5.28 dB | 3.61 dB |

Bank-wide at note 60 third-octave band similarity is a wash (median 0.911 → 0.910). That measure is level-blind and most patches carry larger errors elsewhere; the mean absolute level error moves 4.01 → 3.97 dB. The case for the change is the direct calibration, not the aggregate.

The figure is overridable as `JV_FALL_TO_SILENCE_DB` so it can be swept without editing the engine.

## Still wrong on A57

Notes 43 and 48 keep 2–4 dB after the fix. Both sit in **zone 1** of the multisample while note 40 sits in zone 0 and is now exact — so what remains is zone-related, not envelope-related.

🤖 Generated with [Claude Code](https://claude.com/claude-code)