### PR TITLE
PicoFaceJV: A57's remainder is one multisample zone, and the filter mode is now probed

### DIFF
--- a/tools/jv_extract/README.md
+++ b/tools/jv_extract/README.md
@@ -1579,6 +1579,52 @@ the crash's brightness barely changes across its length (5600 Hz to 5273 Hz), so
 position cannot be recovered that way. The field is narrower than it was, and
 the answer is not here yet.
 
+## A57 Slap Bass: what is left is one multisample zone, and it is not any of these
+
+After the fall-to-silence calibration above, A57 is exact where its note sits on
+a zone root and wrong where it does not. Swept across the keyboard against the
+reference, the level ratio steps at the zone boundaries and nowhere else:
+
+| notes | zone | sample | ratio |
+|---|---|---|---|
+| 38..42 | 0 | 159 | 0.90 .. 1.15 |
+| 43..49 | 1 | 160 | 0.69 .. 0.78 |
+| 50..51 | 2 | 161 | 0.91 .. 1.00 |
+
+So the zone *selection* is right -- the step lands exactly at 42/43 and 49/50,
+which is where the split points say it should. Zone 1 is simply rendered about
+3 dB quiet, and not as a gain: the transient matches within half a decibel and
+the deficit appears within 75 ms, long before the loop is reached at 0.63 s.
+
+Spectrally the two engines play the same sample at the same pitch -- the peaks
+line up at 58.3, 87.8 and 116.7 Hz to a tenth of a hertz -- but the balance is
+redistributed. The reference peaks at 116.7 Hz with everything above 145 Hz
+sitting 22 to 26 dB down; this engine peaks at 58.3 Hz, puts 116.7 at -8.3, and
+carries 800..1700 Hz content that the reference has 25 dB below its peak. In
+octave bands over the first 300 ms: -8.7 dB at 100..200 Hz, -9.8 at 200..400,
++3.7 at 800..1600 and +9.3 at 1600..3200.
+
+**Ruled out, each by measurement:**
+
+* *Zone selection* -- boundaries verified as above.
+* *The sample's level byte* -- +17 is 127 on every zone of both waves.
+* *The exponent decoder* -- the shift is `(10 - nib) & 15`, which wraps for
+  nibbles above 10, but a sweep of the whole ROM finds none: the distribution
+  runs 0..10 and stops.
+* *The filter* -- probed directly on the reference and genuinely off. Sweeping
+  +55 with a low cutoff leaves the output identical at every cutoff when
+  bits 3-4 are 0, while 8 closes the sound down to 0.2 % of its RMS at cutoff 0
+  and 16 cuts it progressively as the cutoff rises. So 0 = OFF, 8 = LPF,
+  16 = HPF is now measured rather than inferred, and A57's +55 = 0 means what
+  it says. A57's resonance byte of 128, which is out of the normal range and
+  looked like it might enable something, changes nothing either.
+* *Loop imbalance* -- the integrator drifts 5.3 % of RMS over zone 0's loop and
+  5.9 % over zone 1's, so the two are alike and neither is special.
+
+What remains is that this engine renders sample 160 with too little fundamental
+and too much midrange, at the right pitch, with the filter off on both sides.
+That is where it stands.
+
 ## Credit
 
 The patch and tone field layout comes from

--- a/tools/jv_extract/jv_tone_map.h
+++ b/tools/jv_extract/jv_tone_map.h
@@ -251,7 +251,11 @@ typedef struct {
                                 //     -100..+100, shortening T2..T4 as the note rises). Cutoff
                                 //     keyfollow is the one that matters: without it every tone
                                 //     filters at the same absolute frequency across the keyboard.
-    uint8_t tvfVeloCurveLpfHpf; // +55 VERIFIED bits3-4 = filter mode: 0 OFF, 8 LPF, 16 HPF, 24 OFF
+    uint8_t tvfVeloCurveLpfHpf; // +55 VERIFIED bits3-4 = filter mode: 0 OFF, 8 LPF, 16 HPF, 24 OFF.
+                                //     Probed directly on the reference rather than inferred: with a
+                                //     low cutoff, mode 0 leaves the output identical at every cutoff
+                                //     value, 8 closes it to 0.2 % of its RMS at cutoff 0 and opens by
+                                //     cutoff 20, and 16 cuts progressively as the cutoff rises.
                                 //     MANUAL: the byte also holds the TVF-ENV velocity curve
                                 //     (one of seven shapes, linear through hard knee) and the
                                 //     resonance mode SOFT/HARD.


### PR DESCRIPTION
**Documentation only — no engine change.** Where A57 Slap Bass stands after [#88](https://github.com/Michi71/PicoVintageSynthCollection/pull/88), plus one positive result found on the way.

## It is one zone

Swept across the keyboard, A57's level ratio against the reference steps at the multisample zone boundaries and nowhere else:

| notes | zone | sample | ratio |
|---|---|---|---|
| 38..42 | 0 | 159 | 0.90 – 1.15 |
| 43..49 | 1 | 160 | **0.69 – 0.78** |
| 50..51 | 2 | 161 | 0.91 – 1.00 |

The step lands exactly at 42/43 and 49/50, which is where the split points say it should — so **zone selection is right**. Zone 1 is simply rendered about 3 dB quiet, and not as a gain: the transient matches within half a decibel and the deficit appears within 75 ms, long before the loop is reached at 0.63 s.

Both engines play the same sample at the same pitch — peaks line up at 58.3, 87.8 and 116.7 Hz to a tenth of a hertz — but the balance is redistributed. The reference peaks at 116.7 Hz with everything above 145 Hz sitting 22–26 dB down; this engine peaks at 58.3 Hz, puts 116.7 at −8.3, and carries 800–1700 Hz content the reference has 25 dB below its peak. In octave bands over the first 300 ms: **−8.7 dB** at 100–200 Hz, **−9.8** at 200–400, **+3.7** at 800–1600, **+9.3** at 1600–3200.

## Ruled out, each by measurement

- **Zone selection** — boundaries verified above.
- **The sample's level byte** — `+17` is 127 on every zone of both waves.
- **The exponent decoder** — the shift is `(10 − nib) & 15`, which wraps above nibble 10, but a sweep of the whole ROM finds none: the distribution runs 0..10 and stops.
- **Loop imbalance** — the integrator drifts 5.3 % of RMS over zone 0's loop and 5.9 % over zone 1's. Alike; neither is special.
- **The filter** — see below.

## The filter mode, now measured rather than inferred

Byte `+55` was probed directly on the reference. With a low cutoff:

| bits 3–4 | behaviour |
|---|---|
| 0 | output identical at **every** cutoff value → OFF |
| 1 (byte 8) | RMS 0.00183 at cutoff 0, open again by cutoff 20 → LPF |
| 2 (byte 16) | cuts progressively as the cutoff rises → HPF |

So `0 = OFF, 8 = LPF, 16 = HPF` is now measured, and A57's `+55 = 0` means what it says. Its resonance byte of **128** — out of the normal range and a plausible hidden enable — changes nothing either.

## What remains

This engine renders sample 160 with too little fundamental and too much midrange, at the right pitch, with the filter off on both sides. That is where it stands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)