### PR TITLE
PicoFaceJV: the chip interpolates with a cubic B-spline, not a straight line

### DIFF
--- a/instruments/PicoFaceJV/include/jv_engine/jv_engine.h
+++ b/instruments/PicoFaceJV/include/jv_engine/jv_engine.h
@@ -198,7 +198,9 @@ private:
         int32_t  refAtLoop;   // accumulator when the loop point was first passed
         bool     loopSeen;    // ... and whether that has happened yet
         int8_t   dir;         // +1 forward, -1 retracing an alternating loop
-        int32_t  s0, s1;      // last two decoded samples, for interpolation
+        int32_t  sm1, s0, s1, s2;  // four consecutive decoded samples; the
+                                   // output sits between s0 and s1 and the
+                                   // other two are the B-spline's outer taps
         Sample   smp;
         Env      tva, tvf;
         PEnv     penv;

--- a/instruments/PicoFaceJV/src/jv_engine/jv_engine.cpp
+++ b/instruments/PicoFaceJV/src/jv_engine/jv_engine.cpp
@@ -29,6 +29,32 @@ float lookup(const float* tbl, int n, int v) {
 float envRiseSeconds(int v) { return lookup(JV_ENV_RISE_S, JV_ENV_RISE_N, v); }
 float envFallSeconds(int v) { return lookup(JV_ENV_FALL_S, JV_ENV_FALL_N, v); }
 
+// The chip does not join two samples with a straight line. It carries a
+// three-entry weight table indexed by the fractional position and applies it to
+// the DPCM deltas, which comes to a four-point kernel over the decoded samples:
+// at fractional position zero the weights are 0.174 / 0.653 / 0.173 / 0 rather
+// than 0 / 1 / 0 / 0, so it is smoothing even where a linear interpolator would
+// pass the sample through untouched. Read off the reference's table and turned
+// back into kernel form, those weights are a cubic B-spline to within 0.014 --
+// mean 0.008 -- across all 128 steps, so the formula stands in for the table and
+// nothing has to be copied out of it.
+//
+// The difference is audible because it is a filter. At fractional position zero
+// the spline is -2.3 dB at 6.4 kHz, -5.0 at 9.6 and -9.5 at 16 kHz where linear
+// interpolation is flat; that missing lowpass is why this engine ran bright.
+// 128 steps is the chip's own resolution, so the table is indexed the same way.
+static float kBSpline[128][4];
+static void buildBSpline() {
+    for (int i = 0; i < 128; i++) {
+        const float t = (float)i / 128.0f, u = 1.0f - t;
+        kBSpline[i][0] = u * u * u * (1.0f / 6.0f);
+        kBSpline[i][1] = (3.0f * t * t * t - 6.0f * t * t + 4.0f) * (1.0f / 6.0f);
+        kBSpline[i][3] = t * t * t * (1.0f / 6.0f);
+        // The four weights sum to one, so the last is what the others leave.
+        kBSpline[i][2] = 1.0f - kBSpline[i][0] - kBSpline[i][1] - kBSpline[i][3];
+    }
+}
+
 // How far a segment falling to silence travels over one fall time. The fall
 // table itself is measured; this is the depth that rides on it, and it is 32.6
 // dB, not the 40 that stood here before.
@@ -608,6 +634,7 @@ bool Engine::init(const RomView& rom, uint32_t sampleRate) {
     // one page's worth of exponent nibbles is the floor.
     if (!rom.wave || !rom.rom2 || rom.waveLen < 0x8000 || rom.rom2Len < 0x40000)
         return false;
+    buildBSpline();
     rom_ = rom;
     sr_ = sampleRate;
     memset(voices_, 0, sizeof(voices_));
@@ -922,7 +949,7 @@ void Engine::startVoice(Voice& v, int toneIndex, uint8_t note, uint8_t vel,
     v.refAtLoop = 0;
     v.loopSeen = false;
     v.dir = s.reverse ? -1 : 1;
-    v.s0 = v.s1 = 0;
+    v.sm1 = v.s0 = v.s1 = v.s2 = 0;
     v.age = ++ageCounter_;
     v.ctlPhase = 0;
 
@@ -1360,9 +1387,10 @@ void Engine::renderBlock(float* left, float* right, int frames) {
             v.phase += v.inc;
             int steps = (int)(v.phase >> 16);
             v.phase &= 0xFFFFu;
-            while (steps-- > 0) { v.s0 = v.s1; v.s1 = decodeStep(v); }
+            while (steps-- > 0) {
+                v.sm1 = v.s0; v.s0 = v.s1; v.s1 = v.s2; v.s2 = decodeStep(v);
+            }
 
-            float frac = (float)v.phase * (1.0f / 65536.0f);
             // 2^19 is the accumulator's full scale, but the ROM samples only
             // reach 13 % of it (median 7.7 %), so normalising to that throws
             // away 12 dB. This factor is what lines the engine up with the
@@ -1374,7 +1402,9 @@ void Engine::renderBlock(float* left, float* right, int frames) {
             // other way once the chorus and reverb existed -- until then it had
             // been carrying their missing energy too. Fitted over all 128
             // factory patches at both velocities.
-            float s = ((float)v.s0 + ((float)v.s1 - (float)v.s0) * frac) * (1.0f / 97867.0f);
+            const float* bw = kBSpline[v.phase >> 9];
+            float s = ((float)v.sm1 * bw[0] + (float)v.s0 * bw[1] +
+                       (float)v.s1  * bw[2] + (float)v.s2 * bw[3]) * (1.0f / 97867.0f);
 
             if (--v.ctlPhase <= 0) {
                 updateModulation(v, clock_ + (uint32_t)i);

--- a/tools/jv_extract/README.md
+++ b/tools/jv_extract/README.md
@@ -1625,6 +1625,62 @@ What remains is that this engine renders sample 160 with too little fundamental
 and too much midrange, at the right pitch, with the filter off on both sides.
 That is where it stands.
 
+## The sample path: the chip interpolates with a cubic B-spline
+
+Chasing A57 Slap Bass into the sample path turned up the largest single
+correction measured here, and it is not what A57 needed.
+
+The reference's PCM core reads **four** consecutive DPCM bytes per output sample,
+not two, and it does not join them with a straight line. It carries a
+three-entry weight table indexed by the fractional position and applies those
+weights to the deltas, adding them to the running reference. Turned back into a
+kernel over the decoded samples, the weights at fractional position zero are
+
+    0.174   0.653   0.173   0.000
+
+where a linear interpolator would use 0, 1, 0, 0. The chip is smoothing even
+where there is no fraction to interpolate.
+
+Those numbers are a **cubic B-spline**. Fitted across all 128 steps of the
+reference's table the largest coefficient error is 0.014 and the mean is 0.008,
+so the formula
+
+    a = (1-t)^3 / 6
+    b = (3t^3 - 6t^2 + 4) / 6
+    c = (-3t^3 + 3t^2 + 3t + 1) / 6
+    d = t^3 / 6
+
+stands in for the table exactly, and nothing has to be lifted out of the
+reference's source.
+
+The difference is a filter, and that is why it was audible. At fractional
+position zero the spline runs -2.3 dB at 6.4 kHz, -5.0 at 9.6 and -9.5 at
+16 kHz where linear interpolation is flat. This engine was missing that lowpass
+entirely, which showed up as imaging near Nyquist: on A57 at note 40, where the
+zone root makes the rate exactly 1.0 and the phase never moves, the octave from
+12.8 kHz was **29.3 dB** above the reference. With the spline it is -1.3.
+
+Bank-wide at note 60 and velocity 100, against the reference:
+
+| | third-octave similarity | patches below 0.90 |
+|---|---|---|
+| linear | median 0.910 | 57 |
+| **cubic B-spline** | **median 0.929** | **46** |
+
+87 patches improve, 16 lose more than 0.005. The largest gains are B48 Air Lead
+0.824 to 0.977, B47 OverblownPan 0.646 to 0.852, A28 and A29 E.Organ 1 and 2
+about +0.12 each, and A61 Yowza Bass 0.823 to 0.922. The largest loss is A84
+Beauty Vox 0.972 to 0.948. Levels barely move -- the spline has unity gain at DC
+and only takes off top end -- so this is a change of spectral shape, not of
+loudness.
+
+The table is built at init with 128 steps, the chip's own resolution, so the
+cost per sample is four multiply-adds and an index.
+
+**It is not what A57 needed.** Zone 1 there keeps its 3 dB and its missing
+fundamental: -9.8 dB at 200..400 Hz before the change and -9.8 after. The
+interpolator was a real fault sitting on top of it.
+
 ## Credit
 
 The patch and tone field layout comes from


### PR DESCRIPTION
Chasing A57 Slap Bass into the sample path turned up **the largest single correction measured on this engine** — and it is not what A57 needed.

## What the chip does

The reference's PCM core reads **four** consecutive DPCM bytes per output sample, not two, and does not join them with a straight line. It carries a three-entry weight table indexed by the fractional position and applies it to the deltas. Turned back into a kernel over the decoded samples:

| fractional position | s(−1) | s0 | s1 | s2 | linear would be |
|---|---|---|---|---|---|
| 0 | **0.174** | 0.653 | **0.173** | 0.000 | 0 / 1 / 0 / 0 |
| 0.5 | 0.025 | 0.475 | 0.476 | 0.024 | 0 / 0.5 / 0.5 / 0 |

**The chip smooths even where there is no fraction to interpolate.**

Those numbers are a **cubic B-spline**. Fitted across all 128 steps of the reference's table the largest coefficient error is **0.014** and the mean **0.008**, so the closed form stands in for the table — nothing is lifted out of the reference's source.

## Why it was audible

It is a filter. At fractional position zero the spline runs −2.3 dB at 6.4 kHz, −5.0 at 9.6 and −9.5 at 16 kHz, where linear interpolation is **flat**. This engine was missing that lowpass entirely, and it showed as imaging near Nyquist: on A57 at note 40 — where the zone root makes the rate exactly 1.0 and the phase never moves — the octave from 12.8 kHz sat **+29.3 dB** above the reference. With the spline it is −1.3.

## Bank-wide

Note 60, velocity 100, third-octave band similarity against the reference:

| | median | below 0.90 |
|---|---|---|
| linear | 0.910 | 57 |
| **cubic B-spline** | **0.929** | **46** |

87 patches improve, 16 lose more than 0.005.

| | before | after |
|---|---|---|
| B48 Air Lead | 0.824 | **0.977** |
| B47 OverblownPan | 0.646 | **0.852** |
| A28 E.Organ 1 | 0.760 | 0.883 |
| A29 E.Organ 2 | 0.765 | 0.872 |
| A61 Yowza Bass | 0.823 | 0.922 |
| A84 Beauty Vox *(worst loss)* | 0.972 | 0.948 |

Levels barely move — unity gain at DC, only top end removed — so this changes spectral shape rather than loudness. No patch goes silent, none produces NaN.

The table is built at init with 128 steps, the chip's own resolution, so the cost per sample is four multiply-adds and an index.

## It is not what A57 needed

Zone 1 there keeps its 3 dB and its missing fundamental: −9.8 dB at 200–400 Hz before the change and −9.8 after. The interpolator was a real fault sitting on top of it, and that one is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)