### PR TITLE
PicoFaceJV: the chip's TVF is a naive SVF, and swapping topology is not enough

### DIFF
--- a/instruments/PicoFaceJV/src/jv_engine/jv_engine.cpp
+++ b/instruments/PicoFaceJV/src/jv_engine/jv_engine.cpp
@@ -388,6 +388,20 @@ void Engine::Lfo::tick() {
 
 // -------------------------------------------------------------------- filter
 
+// A zero-delay (TPT) state-variable filter. The CHIP's is the naive Chamberlin
+// form -- `lp += f*bp; hp = in - lp - q*bp; bp += f*hp`, mode bit picking lp or
+// hp -- and the difference shows: a zero-delay filter holds its Q as the corner
+// moves, the naive one sharpens, and the reference sharpens with it. Measured
+// through white noise, this engine's resonant peak matches at cutoff 40 and
+// falls 2.7 to 4.8 dB short at cutoffs 60 and 80.
+//
+// Rebuilding it as the naive form is not a drop-in and was tried: the isolated
+// peak error halves, but the coefficients here were fitted for a filter that
+// cannot run away, and the naive one can. Capping the corner at the stability
+// line darkens the bright half of the bank; clamping the states instead lets it
+// self-oscillate, and five patches went to negative correlation. It needs the
+// firmware's own f and q, not this engine's Hz-and-damping fit carried across.
+// See tools/jv_extract/README.md.
 float Engine::Filter::run(float in, float g, float k, int mode) {
     const float a1 = 1.0f / (1.0f + g * (g + k));
     const float a2 = g * a1;

--- a/tools/jv_extract/README.md
+++ b/tools/jv_extract/README.md
@@ -1681,6 +1681,58 @@ cost per sample is four multiply-adds and an index.
 fundamental: -9.8 dB at 200..400 Hz before the change and -9.8 after. The
 interpolator was a real fault sitting on top of it.
 
+## The TVF: the chip's filter is a naive SVF, and swapping topology is not enough
+
+`pcm.cpp` spells the filter out. Reading its registers:
+
+    lp_new = lp + f * bp
+    hp     = in - lp_new - q * bp
+    bp_new = bp + f * hp
+    out    = (ram2[6] & 2) ? hp : lp_new
+
+That is a Chamberlin state-variable filter -- the naive one, with a sample of
+delay in the loop -- and the mode bit picks the low-pass state or the high-pass
+term. The coefficient is two fields of `ram2[11]`, `f = (filter>>8)/64 +
+((filter>>1)&127)/8192`, so it spans 0..2 the way `2 sin(pi fc / fs)` does; the
+damping is `q = ((ram2[6]>>8)&127)/64`, spanning 0..2. `ram2[11]` is written by
+the same envelope generator that makes the volume, so the TVF envelope moves the
+*coefficient*, not a frequency.
+
+This engine carries a zero-delay (TPT) filter instead, with `g = tan(pi fc/fs)`.
+The two are the same family and agree at low corners, but a zero-delay filter
+holds its Q constant as the corner moves while the naive one sharpens. **The
+reference sharpens with it**, and the gap is measurable: white noise through the
+low-pass, resonant peak taken over the low passband,
+
+| resonance | cutoff 40 | cutoff 60 | cutoff 80 |
+|---|---|---|---|
+| 60  | -0.6 dB | -2.7 dB | -3.1 dB |
+| 100 | -1.0 dB | -3.8 dB | -4.7 dB |
+| 127 | -1.2 dB | -3.9 dB | -4.8 dB |
+
+(this engine minus the reference). At cutoff 40 it agrees, and above that it
+falls behind -- the shape of a Q that should be climbing and is not. It also
+explains why the damping law in `jv_calibration.h`, fitted at a single cutoff of
+48, held only near there.
+
+**Swapping the topology was tried and does not work on its own.** Rebuilt as the
+naive form with `f = 2 sin(pi fc/fs)`, the isolated peak error halves -- mean
+2.22 dB to 1.37, and cutoff 80 goes from -4.8 to -0.9 -- but the bank gets worse,
+because the naive form runs away where the zero-delay one cannot and the
+coefficients feeding it were fitted for a filter that could not. Holding the
+corner under the stability line `f < 2 - q` caps every low-resonance tone at
+about 4.5 kHz and darkens the bright half of the bank: median third-octave
+similarity 0.929 to 0.919, 46 patches below 0.90 becoming 53. Clamping the
+states instead, the way the chip clips at twenty bits, lets the corner stay open
+and lets the filter self-oscillate: median 0.929 to **0.671**, with Alto Sax,
+Sax Section, Flute mod and both Jazz Organs going to *negative* correlation.
+
+So the topology is right but it cannot be dropped in. What it needs is the
+mapping the firmware actually uses -- `f` and `q` as the firmware computes them
+from cutoff, resonance and the TVF envelope, read out of the reference the way
+the velocity curves were -- rather than this engine's Hz-and-damping fit carried
+across. That is the next step, and it is a bigger one than a topology swap.
+
 ## Credit
 
 The patch and tone field layout comes from


### PR DESCRIPTION
**Documentation only — the filter is unchanged.** Records what the reference's filter actually is, and why the obvious fix fails.

## What the chip does

`pcm.cpp` spells it out:

```
lp_new = lp + f * bp
hp     = in - lp_new - q * bp
bp_new = bp + f * hp
out    = (ram2[6] & 2) ? hp : lp_new
```

A **Chamberlin state-variable filter** — the naive one, with a sample of delay in the loop — and the mode bit picks the low-pass state or the high-pass term. The coefficient is two fields of `ram2[11]`: `f = (filter>>8)/64 + ((filter>>1)&127)/8192`, spanning 0..2 the way `2·sin(π·fc/fs)` does. Damping is `((ram2[6]>>8)&127)/64`. And `ram2[11]` is written by **the same envelope generator that makes the volume**, so the TVF envelope moves the *coefficient*, not a frequency.

## Where we differ

This engine carries a zero-delay (TPT) filter with `g = tan(π·fc/fs)`. Same family, agreeing at low corners — but a zero-delay filter holds its Q constant as the corner moves, while the naive one **sharpens**. The reference sharpens with it.

White noise through the low-pass, resonant peak over the low passband, this engine minus the reference:

| resonance | cutoff 40 | cutoff 60 | cutoff 80 |
|---|---|---|---|
| 60 | −0.6 dB | −2.7 dB | −3.1 dB |
| 100 | −1.0 dB | −3.8 dB | −4.7 dB |
| 127 | −1.2 dB | −3.9 dB | −4.8 dB |

It agrees at cutoff 40 and falls behind above — the shape of a Q that should be climbing and is not. It also explains why the damping law in `jv_calibration.h`, fitted at a single cutoff of 48, held only near there.

## The swap was tried, and it fails

Rebuilt as the naive form with `f = 2·sin(π·fc/fs)`, the **isolated** peak error halves: mean 2.22 dB → 1.37, cutoff 80 from −4.8 to −0.9. But the bank gets worse, because the coefficients feeding it were fitted for a filter that cannot run away and the naive one can.

| | median similarity | below 0.90 |
|---|---|---|
| current (TPT) | **0.929** | **46** |
| naive, corner held under `f < 2 − q` | 0.919 | 53 |
| naive, states clamped as the chip clips | **0.671** | 101 |

Holding the corner under the stability line caps every low-resonance tone near 4.5 kHz and darkens the bright half of the bank. Clamping the states instead lets it self-oscillate — Alto Sax, Sax Section, Flute mod and both Jazz Organs go to **negative** correlation.

## What it actually needs

The topology is right; it cannot be dropped in. It needs the mapping the firmware actually uses — `f` and `q` as computed from cutoff, resonance and the TVF envelope, read out of the reference the way the velocity curves were — rather than this engine's Hz-and-damping fit carried across. That is a bigger job than a topology swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)