### PR TITLE
PicoFaceJV: the chip's filter stage, rebuilt from its own registers

### DIFF
--- a/instruments/PicoFaceJV/include/jv_engine/jv_engine.h
+++ b/instruments/PicoFaceJV/include/jv_engine/jv_engine.h
@@ -164,9 +164,9 @@ private:
     // filtering altogether by 64, which is squarely inside the range the
     // modulation matrix reaches.
     struct Filter {
-        float ic1, ic2;
-        void  reset() { ic1 = ic2 = 0.0f; }
-        float run(float in, float g, float k, int mode);
+        float bp, lp;
+        void  reset() { bp = lp = 0.0f; }
+        float run(float in, float f, float q, int mode);
     };
 
     // One LFO. Runs at control rate, not per sample. `out` is UNIPOLAR: 1.0 is

--- a/instruments/PicoFaceJV/src/jv_engine/jv_engine.cpp
+++ b/instruments/PicoFaceJV/src/jv_engine/jv_engine.cpp
@@ -29,6 +29,25 @@ float lookup(const float* tbl, int n, int v) {
 float envRiseSeconds(int v) { return lookup(JV_ENV_RISE_S, JV_ENV_RISE_N, v); }
 float envFallSeconds(int v) { return lookup(JV_ENV_FALL_S, JV_ENV_FALL_N, v); }
 
+// The filter coefficient the firmware writes, read out of the reference's
+// ram2[11] over 16384 for cutoff 0, 4, 8 ... 124. It climbs by exactly 128 per
+// cutoff unit up to about 32, then accelerates, and saturates from 88 upward --
+// past that the cutoff byte does nothing at all. See tools/jv_extract/README.md.
+static const float JV_TVF_F[32] = {
+    0.0078f, 0.0391f, 0.0703f, 0.1016f, 0.1328f, 0.1641f, 0.1953f, 0.2266f,
+    0.2578f, 0.2891f, 0.3281f, 0.3672f, 0.4062f, 0.4531f, 0.5078f, 0.5625f,
+    0.6172f, 0.6797f, 0.7500f, 0.8125f, 0.8906f, 0.9609f, 1.0000f, 1.0000f,
+    1.0000f, 1.0000f, 1.0000f, 1.0000f, 1.0000f, 1.0000f, 1.0000f, 1.0000f
+};
+static float tvfCoefF(float cv) {
+    if (cv <= 0.0f) return JV_TVF_F[0];
+    if (cv >= 124.0f) return 1.0f;
+    const float x = cv * 0.25f;
+    const int i = (int)x;
+    const float t = x - (float)i;
+    return JV_TVF_F[i] + (JV_TVF_F[i + 1] - JV_TVF_F[i]) * t;
+}
+
 // The chip does not join two samples with a straight line. It carries a
 // three-entry weight table indexed by the fractional position and applies it to
 // the DPCM deltas, which comes to a four-point kernel over the decoded samples:
@@ -388,30 +407,34 @@ void Engine::Lfo::tick() {
 
 // -------------------------------------------------------------------- filter
 
-// A zero-delay (TPT) state-variable filter. The CHIP's is the naive Chamberlin
-// form -- `lp += f*bp; hp = in - lp - q*bp; bp += f*hp`, mode bit picking lp or
-// hp -- and the difference shows: a zero-delay filter holds its Q as the corner
-// moves, the naive one sharpens, and the reference sharpens with it. Measured
-// through white noise, this engine's resonant peak matches at cutoff 40 and
-// falls 2.7 to 4.8 dB short at cutoffs 60 and 80.
+// The chip's filter, in the chip's form: a naive state-variable filter with a
+// sample of delay in the loop, exactly as the reference's PCM core runs it --
 //
-// Rebuilding it as the naive form is not a drop-in and was tried: the isolated
-// peak error halves, but the coefficients here were fitted for a filter that
-// cannot run away, and the naive one can. Capping the corner at the stability
-// line darkens the bright half of the bank; clamping the states instead lets it
-// self-oscillate, and five patches went to negative correlation. It needs the
-// firmware's own f and q, not this engine's Hz-and-damping fit carried across.
-// See tools/jv_extract/README.md.
-float Engine::Filter::run(float in, float g, float k, int mode) {
-    const float a1 = 1.0f / (1.0f + g * (g + k));
-    const float a2 = g * a1;
-    const float a3 = g * a2;
-    const float v3 = in - ic2;
-    const float v1 = a1 * ic1 + a2 * v3;
-    const float v2 = ic2 + a2 * ic1 + a3 * v3;
-    ic1 = 2.0f * v1 - ic1;
-    ic2 = 2.0f * v2 - ic2;
-    return (mode == JV_TVF_MODE_HPF) ? (in - k * v1 - v2) : v2;
+//     lp += f * bp;   hp = in - lp - q * bp;   bp += f * hp;
+//
+// with the mode bit picking the low-pass state or the high-pass term, which is
+// what it does with `ram1[3]` against `v3`.
+//
+// This replaced a zero-delay (TPT) filter, and the reason matters. A zero-delay
+// filter holds its Q as the corner moves; the naive one sharpens, and the
+// reference sharpens with it. Measured through white noise, the old filter's
+// resonant peak matched at cutoff 40 and fell 2.7 to 4.8 dB short at cutoffs 60
+// and 80 across resonance 60, 100 and 127 -- the shape of a Q that should have
+// been climbing.
+//
+// An earlier attempt at this swap failed and is worth remembering: it kept the
+// old coefficient, f = 2 sin(pi fc/fs), which runs to 1.98. The naive form is
+// only stable while f + q stays under 2, so that either had to be capped --
+// darkening the bright half of the bank -- or left to self-oscillate, which sent
+// five patches to negative correlation. The chip never has that problem because
+// its own coefficient SATURATES AT 1.0, read straight out of ram2[11]. With the
+// measured table below, f + q reaches 2.0 only at the single corner where
+// resonance is 0 and the cutoff is wide open, and never crosses it.
+float Engine::Filter::run(float in, float f, float q, int mode) {
+    lp += f * bp;
+    const float hp = in - lp - q * bp;
+    bp += f * hp;
+    return (mode == JV_TVF_MODE_HPF) ? hp : lp;
 }
 
 // -------------------------------------------------------------------- chorus
@@ -845,17 +868,22 @@ void Engine::updateFilterCoeffs(Voice& v) {
     // scaling is NOT calibrated -- see tools/jv_extract/README.md.
     float cv = v.cutoffBase +
                v.envDepth * v.tvf.level * JV_TVF_ENV_DEPTH_PER_UNIT + v.cutoffMod;
-    float hz = cutoffToHz(cv);
-    const float nyq = (float)sr_ * 0.49f;
-    if (hz > nyq) hz = nyq;
-    if (hz < 20.0f) hz = 20.0f;
-    v.coefF = tanf(3.14159265f * hz / (float)sr_);          // g
+    // Both coefficients come from the chip's own registers now, not from a
+    // frequency and a fitted damping. The cutoff parameter -- envelope and
+    // modulation already in it -- indexes the measured f table directly.
+    v.coefF = tvfCoefF(cv);
     float res = v.resonance + v.resMod;
     if (res < 0.0f) res = 0.0f; else if (res > 127.0f) res = 127.0f;
     // HARD mode doubles the exponent of the damping law, which is what the
     // measured 0 / 2.8 / 5.1 / 8.3 / 12.1 dB of extra peak comes to.
     v.coefQ = JV_TVF_DAMPING(res * (v.resoHard ? JV_TVF_RESO_HARD_MUL : 1.0f));
     if (v.coefQ < 0.08f) v.coefQ = 0.08f;
+    // At resonance 0 alone the chip adds damping at low cutoffs, its register
+    // sliding 74 down to 64 across cutoffs 0 to 64 and flat above.
+    if (res < 1.0f) {
+        const float extra = (74.0f - 0.15625f * (cv < 0.0f ? 0.0f : cv)) * (1.0f / 64.0f);
+        if (extra > v.coefQ) v.coefQ = (extra > 1.15625f) ? 1.15625f : extra;
+    }
 }
 
 void Engine::updateModulation(Voice& v, uint32_t clock) {

--- a/tools/jv_extract/README.md
+++ b/tools/jv_extract/README.md
@@ -1849,6 +1849,61 @@ form does not have at those coefficients -- or there is structure in the chip's
 filter stage not yet found in `pcm.cpp`. That is the question to answer before
 this is worth another attempt.
 
+## The filter stage, finished -- and the harness fault that hid it
+
+The note above named a blocker: the chip's coefficient seemed not to map to a
+corner the way a naive filter at the output rate would. **It does. The blocker
+was the measuring harness.**
+
+Two measurements settled it. First, the filter's update rate, counted rather
+than inferred: instrumented, the reference runs its filter **31938 times in
+32000 output samples** -- once per sample, exactly. So it is not running faster.
+
+Second, the filter measured as a black box. Logging its own input and output
+sample by sample and taking the transfer function from those two signals, with
+no assumption about what the coefficient means, the chip agrees with
+
+    lp += f * bp;   hp = in - lp - q * bp;   bp += f * hp
+
+at `f = ram2[11]/16384` and `q = (ram2[6]>>8)/64` **to 0.0 dB at every frequency**,
+at cutoff 20 and cutoff 80 alike. The model was right all along; at cutoff 80 its
+-3 dB point is 10156 Hz against the reference's 9984, not the 4.7 kHz that
+`f = 2 sin(pi fc/fs)` would have put it at. That identity is simply not how the
+naive filter's corner behaves at large coefficients.
+
+**What was wrong** was the engine-side harness: it reused one `jv::Engine` across
+the whole cutoff sweep, so the voice from the previous cutoff was still sounding
+into the next one's spectrum and darkening it, while the reference side got a
+fresh instance every time. Caught by a diagnostic that printed the cutoff
+parameter and saw it alternating between 20 and 40 within one run.
+
+With a fresh engine per point, the rebuilt stage tracks:
+
+| cutoff | reference -3 dB | rebuilt |
+|---|---|---|
+| 20 | 1016 Hz | 1000 Hz |
+| 40 | 2156 Hz | 2109 Hz |
+| 60 | 4227 Hz | 3930 Hz |
+| 80 | 9984 Hz | 10805 Hz |
+| 100 | open past 14 kHz | open past 14 kHz |
+
+Two to eight per cent, against the old filter's seventeen -- and with the
+resonance now behaving, where the old one ran 2.7 to 4.8 dB short at cutoffs 60
+and 80.
+
+**Bank-wide it is a wash**, and that is the honest headline: median third-octave
+similarity 0.929 to 0.930, patches below 0.90 46 to 49, 42 better and 24 worse.
+Winners RevCymBend 0.807 to 0.858, Log Drum 0.737 to 0.788, Space Ahh 0.808 to
+0.849, Nylon+Steel 0.754 to 0.790, Thumpin Bass 0.836 to 0.869, Rubber Bs 1
+0.909 to 0.941; losers Soft Lead 0.843 to 0.789, Pop Piano 3 0.910 to 0.863,
+NightShade 0.935 to 0.890, Ocarina 0.933 to 0.901. No NaN and no runaway at
+velocity 20, 40 or 127.
+
+The losers are all bright patches, and since the *static* cutoff now matches
+across the range, what is left points at the envelope's path into the cutoff --
+`JV_TVF_ENV_DEPTH_PER_UNIT`, fitted against the old filter and not yet re-fitted
+against this one. That is the next thing to look at, and it is bounded.
+
 ## Credit
 
 The patch and tone field layout comes from

--- a/tools/jv_extract/jv_calibration.h
+++ b/tools/jv_extract/jv_calibration.h
@@ -748,7 +748,17 @@ static const float JV_MOD_LEVEL_DB[5]   = { 1.29f, 2.37f, 4.31f, 6.28f, 6.28f };
 // engine and reference compared by the same method -- white noise through the
 // low-pass at cutoff 48, peak against the 300-600 Hz passband -- the engine sat
 // a consistent 1.2 to 2.4 dB high across the range. 0.893 -> 1.125 closes it.
-#define JV_TVF_DAMPING(res) (1.125f * expf(-0.0104f * (res)))
+// MEASURED (27.08.2026), not fitted. The damping the firmware writes into the
+// chip is `ram2[6] >> 8` over 64, and read out for a sweep of the resonance byte
+// it runs 64, 61, 58, 56, 53, 49, 45, 41, 38, 34, 32, 29, 26, 24, 22, 20, 19,
+// 17, 16 for resonance 0, 4, 8, 12, 16, 24, 32, ..., 127 -- a halving every 63.5
+// units. `floor(64 * 2^(-res/63.5))` hits 18 of those 19 exactly (resonance 112
+// comes out 18 against the chip's 19).
+//
+// The law that stood here, 1.125 * exp(-0.0104 * res), was fitted through audio
+// at a single cutoff and ran 15 to 21 % high. Too much damping is too little
+// resonance.
+#define JV_TVF_DAMPING(res) (floorf(64.0f * exp2f(-(res) * (1.0f / 63.5f))) * (1.0f / 64.0f))
 
 // The matrix's contribution to an LFO's PITCH depth is linear in cents, not in
 // depth-parameter units: the swing runs 55 and 122 cents at sensitivity 4 and 8,


### PR DESCRIPTION
[#93](https://github.com/Michi71/PicoVintageSynthCollection/pull/93) named a blocker: the chip's coefficient seemed not to map to a corner the way a naive filter at the output rate would. **It does. The blocker was my measuring harness.**

## Clearing it

**The update rate, counted rather than inferred.** Instrumented, the reference runs its filter **31938 times in 32000 output samples** — once per sample, exactly. It is not running faster.

**The filter as a black box.** Logging its own input and output sample by sample and taking the transfer function from those two signals — no assumption about what the coefficient means — the chip agrees with

```
lp += f * bp;   hp = in - lp - q * bp;   bp += f * hp
```

at `f = ram2[11]/16384` and `q = (ram2[6]>>8)/64` **to 0.0 dB at every frequency**, at cutoff 20 and cutoff 80 alike. At cutoff 80 that model's −3 dB point is 10156 Hz against the reference's 9984 — not the 4.7 kHz `f = 2·sin(π·fc/fs)` would have put it at. That identity is simply not how the naive filter's corner behaves at large `f`.

**The fault** was engine-side: the harness reused one `jv::Engine` across the cutoff sweep, so the previous point's voice was still sounding into the next one's spectrum and darkening it, while the reference side got a fresh instance each time. Caught by a diagnostic that printed the cutoff parameter and saw it alternating between 20 and 40 inside one run.

## With that fixed

| cutoff | reference −3 dB | rebuilt |
|---|---|---|
| 20 | 1016 Hz | 1000 Hz |
| 40 | 2156 Hz | 2109 Hz |
| 60 | 4227 Hz | 3930 Hz |
| 80 | 9984 Hz | 10805 Hz |
| 100 | open past 14 kHz | open past 14 kHz |

Two to eight per cent, against the old filter's seventeen — **and the resonance now behaves**, where the old one ran 2.7 to 4.8 dB short at cutoffs 60 and 80.

The damping law moves with it, from a fit to the measured register values: `floor(64·2^(−res/63.5))/64`, reproducing 18 of 19 sampled points exactly where the old fit ran 15–21 % high.

## Bank-wide it is a wash — that is the honest headline

| | median | below 0.90 |
|---|---|---|
| current | 0.929 | 46 |
| rebuilt | 0.930 | 49 |

42 better, 24 worse. Winners: RevCymBend 0.807→0.858, Log Drum 0.737→0.788, Space Ahh 0.808→0.849, Nylon+Steel 0.754→0.790, Thumpin Bass 0.836→0.869, Rubber Bs 1 0.909→0.941. Losers: Soft Lead 0.843→0.789, Pop Piano 3 0.910→0.863, NightShade 0.935→0.890, Ocarina 0.933→0.901. No NaN and no runaway at velocity 20, 40 or 127.

**This is a judgement call, so it is yours.** The filter is now the chip's, verified against it directly, and it is measurably closer in both corner and resonance — but the aggregate does not move and roughly two dozen patches lose a little. My recommendation is to take it: the project's rule is that the reference is the master template, and the isolated measurement is unambiguous.

## What is left

The losers are all bright patches, and since the *static* cutoff now matches across the range, what remains points at the envelope's path into the cutoff — `JV_TVF_ENV_DEPTH_PER_UNIT`, fitted against the old filter and not yet re-fitted against this one. Bounded, and the obvious next step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)