### PR TITLE
PicoFaceJV: the TVF envelope multiplies the filter coefficient, it does not add

### DIFF
--- a/instruments/PicoFaceJV/src/jv_engine/jv_engine.cpp
+++ b/instruments/PicoFaceJV/src/jv_engine/jv_engine.cpp
@@ -33,6 +33,8 @@ float envFallSeconds(int v) { return lookup(JV_ENV_FALL_S, JV_ENV_FALL_N, v); }
 // ram2[11] over 16384 for cutoff 0, 4, 8 ... 124. It climbs by exactly 128 per
 // cutoff unit up to about 32, then accelerates, and saturates from 88 upward --
 // past that the cutoff byte does nothing at all. See tools/jv_extract/README.md.
+// The coefficient's floor, the value the chip shows at cutoff 0.
+#define JV_TVF_F_MIN 0.0078f
 static const float JV_TVF_F[32] = {
     0.0078f, 0.0391f, 0.0703f, 0.1016f, 0.1328f, 0.1641f, 0.1953f, 0.2266f,
     0.2578f, 0.2891f, 0.3281f, 0.3672f, 0.4062f, 0.4531f, 0.5078f, 0.5625f,
@@ -104,15 +106,15 @@ float envLevelToLinear(int v) {
     return powf(10.0f, db * (1.0f / 20.0f));
 }
 
-// A TVF envelope target scales the cutoff excursion and is near-linear.
+// A TVF envelope target is LINEAR in the byte. The curve that used to be here,
+// measured through audio, was this engine's additive cutoff model absorbing the
+// chip's exponential one -- see updateFilterCoeffs. Read off the chip's register,
+// depth 32 at level 32 lands exactly where depth 16 at level 64 does, so the
+// level enters the product linearly and nothing else.
 float tvfEnvLevel(int v) {
     if (v <= 0) return 0.0f;
     if (v > 127) v = 127;
-    const float x = v * (1.0f / 16.0f);
-    const int i = (int)x;
-    if (i >= 8) return JV_TVF_ENV_LEVEL[8];
-    return JV_TVF_ENV_LEVEL[i] +
-           (JV_TVF_ENV_LEVEL[i + 1] - JV_TVF_ENV_LEVEL[i]) * (x - (float)i);
+    return (float)v * (1.0f / 127.0f);
 }
 
 // The patch-common level has its own curve again, between the other two.
@@ -866,12 +868,25 @@ int Engine::allocVoice() {
 void Engine::updateFilterCoeffs(Voice& v) {
     // Cutoff moves with the TVF envelope, scaled by the bipolar depth. The depth
     // scaling is NOT calibrated -- see tools/jv_extract/README.md.
-    float cv = v.cutoffBase +
-               v.envDepth * v.tvf.level * JV_TVF_ENV_DEPTH_PER_UNIT + v.cutoffMod;
+    // The envelope does not add to the cutoff. It MULTIPLIES the chip's filter
+    // coefficient, by 2^(depth * level / (127 * 8)) -- an octave of coefficient
+    // per eight units of the product, with the level taken linearly. Measured
+    // off ram2[11]: for that product at 1, 2, 4, 6, 8, 12 and 16 the factor's
+    // log2 comes out 0.067, 0.251, 0.466, 0.736, 1.000, 1.514 and 2.034 against
+    // a predicted 0.125, 0.250, 0.500, 0.750, 1.000, 1.500 and 2.000. It is the
+    // same factor at every cutoff -- 4.00 at base 0 and 4.05 at base 20 for the
+    // same product -- which is what an additive model could never reproduce, and
+    // is why the level curve that used to sit in tvfEnvLevel looked exponential.
+    float cv = v.cutoffBase + v.cutoffMod;
     // Both coefficients come from the chip's own registers now, not from a
     // frequency and a fitted damping. The cutoff parameter -- envelope and
     // modulation already in it -- indexes the measured f table directly.
     v.coefF = tvfCoefF(cv);
+    if (v.envDepth != 0.0f) {
+        v.coefF *= exp2f(v.envDepth * v.tvf.level * (1.0f / 8.0f));
+        if (v.coefF > 1.0f) v.coefF = 1.0f;
+        else if (v.coefF < JV_TVF_F_MIN) v.coefF = JV_TVF_F_MIN;
+    }
     float res = v.resonance + v.resMod;
     if (res < 0.0f) res = 0.0f; else if (res > 127.0f) res = 127.0f;
     // HARD mode doubles the exponent of the damping law, which is what the

--- a/tools/jv_extract/README.md
+++ b/tools/jv_extract/README.md
@@ -1950,6 +1950,45 @@ wrong -- the envelope's timing or its shape rather than its depth is the obvious
 suspect, since the depth is now measured and the level curve independently
 confirmed. The engine keeps the old constant until that is found.
 
+## The TVF envelope multiplies, it does not add
+
+The note above ended on a contradiction: one set of patches wanted almost no TVF
+envelope, another a strong one, and the measured depth law suited neither. The
+contradiction was in the model, not the measurement.
+
+**The envelope multiplies the chip's filter coefficient.** Sweeping the depth at
+cutoff base 0 instead of 20 gave it away: depth 16 at full level moves the cutoff
+47 parameter units at base 20 and only 3 units at base 0 -- but in the
+coefficient it is the same factor both times, 4.05 and 4.00. An additive model
+cannot do that.
+
+Taken as a factor, the law is clean:
+
+| P = depth * level/127 | 1 | 2 | 4 | 6 | 8 | 12 | 16 |
+|---|---|---|---|---|---|---|---|
+| measured log2(factor) | 0.067 | 0.251 | 0.466 | 0.736 | 1.000 | 1.514 | 2.034 |
+| P/8 | 0.125 | 0.250 | 0.500 | 0.750 | 1.000 | 1.500 | 2.000 |
+
+So `f = f_base * 2^(depth * level / (127 * 8))` -- an octave of coefficient per
+eight units of the product, the level entering linearly.
+
+That also explains `JV_TVF_ENV_LEVEL`. Measured through audio it looked like a
+convex curve, within a few hundredths of `(level/127)^1.248`; it was this
+exponential seen through an additive model. Off the register the level is plainly
+linear, and the curve is gone.
+
+**Bank-wide** at note 60 and velocity 100, against the state before any of the
+filter work: median third-octave similarity **0.929 to 0.935**, patches below 0.90
+**46 to 42**, 53 better and 26 worse. Against the filter stage alone: 0.930 to
+0.935, 49 below 0.90 to 42, 35 better and 18 worse.
+
+The brass moves as a family -- TeaJay Brass 0.613 to 0.871, Trumpet 0.781 to
+0.918, Trombone 0.805 to 0.928, Harmon Mute2 0.783 to 0.906, French Horn 0.628 to
+0.806 -- and so do the Rhodes: Stiky Rhodes 0.707 to 0.939, Dig Rhodes 2 0.700 to
+0.903. B47 OverblownPan reaches 0.988. The worst loss is Big n Beefy 0.892 to
+0.755; the rest give up three or four hundredths at most. No NaN, nothing driven
+past full scale and nothing silenced at velocity 20, 40 or 127.
+
 ## Credit
 
 The patch and tone field layout comes from

--- a/tools/jv_extract/jv_calibration.h
+++ b/tools/jv_extract/jv_calibration.h
@@ -83,6 +83,12 @@ static const float JV_PATCH_LEVEL_DB[9] = {
 // with envDepth 24 over a base cutoff of 8, normalised to L=127. Feeding these
 // through the dB curve gave 0.09 where the machine gives 0.20 at L=32.
 // Index = value/16.
+// SUPERSEDED (27.08.2026) and kept only as a record. This was measured through
+// audio and looked like a curve because the engine was adding the envelope to
+// the cutoff while the chip MULTIPLIES its filter coefficient -- these numbers
+// are that exponential seen through an additive model. Read off the chip's
+// register the level is plainly linear: depth 32 at level 32 lands exactly where
+// depth 16 at level 64 does. See tvfEnvLevel() and updateFilterCoeffs().
 static const float JV_TVF_ENV_LEVEL[9] = {
     0.000f, 0.089f, 0.204f, 0.278f, 0.460f, 0.560f, 0.722f, 0.828f, 1.000f,
 };
@@ -190,6 +196,10 @@ static const float JV_LFO_PITCH_DEPTH_CENTS[9] = {
 // 19.1/37.5/60.5 parameter units, so about 2.4 each. Above 24 the corner leaves
 // the noise sample's bandwidth and the measurement, not the synth, saturates.
 // The field is signed like the LFO depths; negative depths close the filter.
+// SUPERSEDED (27.08.2026). The envelope does not add to the cutoff at all: it
+// multiplies the chip's filter coefficient by 2^(depth * level / (127 * 8)),
+// measured off ram2[11] and the same factor at every cutoff. Kept as a record of
+// what an additive model had to be fitted to.
 #define JV_TVF_ENV_DEPTH_PER_UNIT 2.4f
 
 // tvaVelocity (+72) only ever ATTENUATES, and it attenuates below velocity 127.


### PR DESCRIPTION
[#95](https://github.com/Michi71/PicoVintageSynthCollection/pull/95) ended on a contradiction: one set of patches wanted almost no TVF envelope, another a strong one, and the measured depth law suited neither. **The contradiction was in the model, not the measurement.**

## The envelope multiplies

Sweeping the depth at cutoff base **0** instead of 20 gave it away. Depth 16 at full level moves the cutoff **47 parameter units at base 20 and only 3 at base 0** — but in the coefficient it is the same factor both times, 4.05 and 4.00. An additive model cannot do that.

Taken as a factor, the law is clean:

| P = depth·level/127 | 1 | 2 | 4 | 6 | 8 | 12 | 16 |
|---|---|---|---|---|---|---|---|
| measured log₂(factor) | 0.067 | 0.251 | 0.466 | 0.736 | 1.000 | 1.514 | 2.034 |
| P/8 | 0.125 | 0.250 | 0.500 | 0.750 | 1.000 | 1.500 | 2.000 |

**`f = f_base · 2^(depth · level / (127·8))`** — an octave of coefficient per eight units of the product, the level entering linearly.

That also explains `JV_TVF_ENV_LEVEL`. Measured through audio it looked like a convex curve, within a few hundredths of `(level/127)^1.248` — it was this exponential seen through an additive model. Off the register the level is plainly linear, and the curve is gone. Both it and `JV_TVF_ENV_DEPTH_PER_UNIT` stay in `jv_calibration.h` as records, marked superseded.

## Bank-wide

Note 60, velocity 100, against the state **before any of the filter work**:

| | median | below 0.90 |
|---|---|---|
| before | 0.929 | 46 |
| **now** | **0.935** | **42** |

53 better, 26 worse. Against the filter stage alone: 0.930 → 0.935, 49 → 42, 35 better and 18 worse.

The brass moves as a family:

| | before | after |
|---|---|---|
| TeaJay Brass | 0.613 | **0.871** |
| Trumpet | 0.781 | 0.918 |
| Trombone | 0.805 | 0.928 |
| Harmon Mute2 | 0.783 | 0.906 |
| French Horn | 0.628 | 0.806 |
| Stiky Rhodes | 0.707 | **0.939** |
| Dig Rhodes 2 | 0.700 | 0.903 |
| OverblownPan | 0.851 | **0.988** |
| Big n Beefy *(worst loss)* | 0.892 | 0.755 |

The rest give up three or four hundredths at most. No NaN, nothing driven past full scale, nothing silenced at velocity 20, 40 or 127.

🤖 Generated with [Claude Code](https://claude.com/claude-code)