### PR TITLE
PicoFaceJV: on short loops the error is not at the wrap

### DIFF
--- a/tools/jv_extract/README.md
+++ b/tools/jv_extract/README.md
@@ -2204,6 +2204,32 @@ Short loops: a real difference in what comes out of the decoder, with the level
 offset riding on it. Those want separate investigations, and only the second is
 about the sample path.
 
+## Short loops: the wrap is not where the error is
+
+The obvious suspect on the short-loop zone was the loop wrap itself. This engine
+snapshots the DPCM accumulator at the loop point and restores it there, which puts
+a step in the middle of the four-sample window the B-spline is reading -- and on
+a 37-frame loop that boundary is an eighth of the waveform and comes round some
+900 times a second. It is a good story and it is wrong.
+
+Aligned against the chip's own interpolated value at note 82 and folded onto the
+95-sample period, the residual does not sit at any one phase. It is spread across
+the whole cycle and **tracks the signal**: the largest error, 2.49, falls at
+phase 9 where the signal itself is largest at 3.05, and the smallest error at
+phase 65 where the signal is quiet. A glitch at the wrap would show as a spike at
+one phase and does not.
+
+What it looks like instead is distortion rather than displacement. Fitting the
+best scale factor between the two gives 0.58 with a residual of **0.82 against a
+unity signal** -- so barely a third of the energy is common. The two waveforms
+share their gross shape and differ everywhere within it.
+
+That is where this stops. The wrap is excluded, the loop drift is excluded, the
+rate difference is excluded (-3.37 cents at this note, far too small), aliasing
+is excluded, and the chip's gain path is flat. What remains is the decoder itself
+on short loops, and finding it needs a fresh look rather than another lap of the
+same probe.
+
 ## Credit
 
 The patch and tone field layout comes from


### PR DESCRIPTION
**Documentation only.** One hypothesis excluded, and the point where this stops.

## The hypothesis

The obvious suspect on the short-loop zone was the loop wrap. This engine snapshots the DPCM accumulator at the loop point and restores it there — which puts a step in the middle of the four-sample window the B-spline reads. On a 37-frame loop that boundary is an eighth of the waveform and comes round some 900 times a second.

Good story. Wrong.

## What the measurement says

Aligned against the chip's own interpolated value at note 82 and folded onto the 95-sample period, the residual **does not sit at any one phase**:

| phase | 9 | 24 | 45 | 65 | 81 |
|---|---|---|---|---|---|
| error | **2.49** | 0.14 | 0.15 | 0.20 | 1.35 |
| signal | **3.05** | 0.56 | 0.12 | 0.83 | 1.09 |

It is spread across the cycle and **tracks the signal** — largest where the signal is largest, smallest where it is quiet. A glitch at the wrap would spike at one phase, and does not.

It looks like **distortion rather than displacement**. The best scale factor between the two is 0.58 with a residual of **0.82 against a unity signal** — barely a third of the energy is common. The waveforms share their gross shape and differ everywhere within it.

## Where this stops

Excluded on this question so far:

- the loop wrap (this note)
- loop drift — both engines stable, same period, no DC
- the rate difference — −3.37 cents at this note, far too small to decorrelate over 25 ms
- aliasing — 128 kHz oversampling changes nothing
- the chip's gain path — flat to the last digit across the keyboard

What remains is the decoder itself on short loops. Finding it wants a fresh look rather than another lap of the same probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)