### PR TITLE
PicoFaceJV: the keyfollow table was already right — now it is measured too

### DIFF
--- a/tools/jv_extract/README.md
+++ b/tools/jv_extract/README.md
@@ -2298,12 +2298,20 @@ table says. **This engine's zone selection is right.**
 everywhere else in this ROM. Nibble 7 is about +18 %; nibble 0 runs the pitch
 *down* as the key rises, so it is around -100 %.
 
-That matters because this engine reads none of +40 and assumes +100 % for every
-tone. Across the three banks, **507 of 539 tones carry 12 and 32 do not** -- they
-carry 5, 6, 7, 8 or 10, which on the two measured points would be somewhere
-between -30 % and +100 %. Those 32 tones track the keyboard wrongly here, and
-they are the ones to check next. The high nibble is 7 on 534 of 539, so whatever
-it holds is near enough constant to ignore for now.
+**And the engine already had it right.** The claim written here first -- that
+this engine reads none of +40 and assumes +100 % for every tone -- was taken from
+a stale comment in `jv_tone_map.h` and is wrong: `startVoice` has read
+`jv_kf16(t[40] & 15)` all along. Swept across all sixteen values and timed at
+notes 57 and 63, the keyfollow measures -98.7, -70.7, -49.6, -30.6, -9.5, 0,
++9.5, +21.2, +30.6, +40.1, +49.6, +70.7, +98.7, +121.8, +151.7 and +198.3 per
+cent, against a table already holding -100, -70, -50, -30, -10, 0, 10, 20, 30,
+40, 50, 70, 100, 120, 150, 200. **Every entry within about 1.5 %**, with index 12
+landing on +98.7 where the standard tone must be.
+
+So the 32 tones that carry something other than 12 are handled correctly, and
+there was nothing to fix. What the round bought is that `JV_KF16` is now measured
+rather than read off the manual, and that the stale comment which caused the
+false alarm is gone. The high nibble is 7 on 534 of 539 tones and is not read.
 
 ## Credit
 

--- a/tools/jv_extract/jv_calibration.h
+++ b/tools/jv_extract/jv_calibration.h
@@ -319,6 +319,14 @@ static const float JV_KF15[15] = {   // 0..14, neutral at index 7
     -100.0f, -70.0f, -50.0f, -40.0f, -30.0f, -20.0f, -10.0f, 0.0f,
       10.0f,  20.0f,  30.0f,  40.0f,  50.0f,  70.0f, 100.0f,
 };
+// MEASURED (27.08.2026) and it confirms the manual exactly. Sweeping the low
+// nibble of +40 on a synthetic single tone and timing the period at notes 57 and
+// 63 gives -98.7, -70.7, -49.6, -30.6, -9.5, 0, +9.5, +21.2, +30.6, +40.1,
+// +49.6, +70.7, +98.7, +121.8, +151.7 and +198.3 per cent -- every entry within
+// about 1.5 % of the values below, index 12 landing on +98.7 where the standard
+// one-octave-per-twelve-keys tone must be. The steps are 20 at the ends and 10
+// in the middle, which is why a linear reading of "0..15 spans -100..+200" comes
+// out wrong in the middle of the range.
 static const float JV_KF16[16] = {   // 0..15, neutral at index 5
     -100.0f, -70.0f, -50.0f, -30.0f, -10.0f, 0.0f, 10.0f, 20.0f,
       30.0f,  40.0f,  50.0f,  70.0f, 100.0f, 120.0f, 150.0f, 200.0f,

--- a/tools/jv_extract/jv_tone_map.h
+++ b/tools/jv_extract/jv_tone_map.h
@@ -195,10 +195,16 @@ typedef struct {
                                 //     C4; random pitch is one of 16 cent amounts
                                 //     0/5/10/20/30/40/50/70/100/200/300/400/500/600/800/1200,
                                 //     redrawn per note.
-    uint8_t tvpKFtvaTimeKF;     // +40 MANUAL  packed keyfollows. Pitch keyfollow is 0..15
-                                //     (-100..+200, normal is +100 = one octave per twelve keys)
-                                //     and a tone set away from +100 does not track the keyboard
-                                //     at all -- the engine assumes +100 for every tone.
+    uint8_t tvpKFtvaTimeKF;     // +40 VERIFIED packed keyfollows. The PITCH keyfollow is the LOW
+                                //     nibble, 0..15 spanning -100..+200 about C4, and index 12 --
+                                //     not 7 -- is the normal one octave per twelve keys. Measured
+                                //     across all sixteen values; see JV_KF16 in jv_calibration.h.
+                                //     The engine reads it: `jv_kf16(t[40] & 15)` in startVoice.
+                                //     An earlier note here said the engine "assumes +100 for every
+                                //     tone", which was stale and cost an afternoon -- 507 of 539
+                                //     factory tones carry 12 and the other 32 are handled too.
+                                //     The high nibble is the TVA-ENV time keyfollow and is 7 on
+                                //     534 of 539 tones; it is not read.
     uint8_t tvpVelocity;        // +41 MANUAL  P-ENV velocity level sense, -63..+63
     uint8_t tvpT1T4Velocity;    // +42 MANUAL  P-ENV velocity on/off time sense, two 15-step fields
     uint8_t tvpEnvDepth;        // +43 VERIFIED pitch env depth; saturates above ~16


### PR DESCRIPTION
**Documentation only, and a correction to my own claim of an hour ago.**

[#104](https://github.com/Michi71/PicoVintageSynthCollection/pull/104) said this engine reads none of `+40` and assumes +100 % pitch keyfollow for every tone, so the 32 factory tones carrying something else would track the keyboard wrongly.

**That was taken from a stale comment in `jv_tone_map.h` and it is wrong.** `startVoice` has read `jv_kf16(t[40] & 15)` all along.

## The sweep

All sixteen values of the low nibble, timed at notes 57 and 63:

| nibble | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 |
|---|---|---|---|---|---|---|---|---|
| measured | −98.7 | −70.7 | −49.6 | −30.6 | −9.5 | 0 | +9.5 | +21.2 |
| table | −100 | −70 | −50 | −30 | −10 | 0 | +10 | +20 |

| nibble | 8 | 9 | 10 | 11 | **12** | 13 | 14 | 15 |
|---|---|---|---|---|---|---|---|---|
| measured | +30.6 | +40.1 | +49.6 | +70.7 | **+98.7** | +121.8 | +151.7 | +198.3 |
| table | +30 | +40 | +50 | +70 | **+100** | +120 | +150 | +200 |

**Every entry within about 1.5 %**, and index 12 lands on +98.7 where the standard one-octave-per-twelve-keys tone must be — which is the positive control for the whole sweep.

## What the round bought

The 32 tones are handled correctly and there was nothing to fix. What is worth keeping:

- `JV_KF16` is now **measured** rather than read off the manual.
- The manual's "0..15 spans −100..+200" is confirmed as **non-linear** — steps of 20 at the ends and 10 in the middle, which is exactly why a linear reading comes out wrong in the middle of the range (and why `+40 = 119`, nibble 7, gave ~18 % tracking rather than the ~47 % a linear reading would predict).
- The stale comment that caused the false alarm is corrected in `jv_tone_map.h`, with a note saying what it cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)