### PR TITLE
Flash timing: one macro for all four writers, and slower values to test with

### DIFF
--- a/core/include/project_config.h
+++ b/core/include/project_config.h
@@ -87,4 +87,40 @@
 // its instrument.cmake, not a hardware difference - the board is identical for
 // every instrument.
 
+// The clock/timing pair the build actually uses. Five instruments take the
+// defaults below; PicoFaceRD overrides both through DEFINES in its
+// instrument.cmake. They MUST move together -- the timing encodes a divider of
+// clk_sys, so a mismatched pair either runs the flash out of spec or leaves
+// performance on the table.
+//
+// These live here rather than in pico_hw.cpp because the boot is not the only
+// place that writes M0_TIMING: every flash write re-inits boot2, which clobbers
+// the register, and each of those sites has to restore the SAME value. With the
+// default sitting in pico_hw.cpp, a -DPICOFACE_QMI_M0_TIMING_TARGET=... on the
+// command line reached the boot and nothing else, so the device silently
+// reverted to the OC timing at the first settings save.
+#ifndef PICOFACE_SYS_CLOCK_HZ
+#define PICOFACE_SYS_CLOCK_HZ 444000000
+#endif
+
+#ifndef PICOFACE_QMI_M0_TIMING_TARGET
+#define PICOFACE_QMI_M0_TIMING_TARGET PICOFACE_QMI_M0_TIMING_OC
+#endif
+
+// Slower flash timings, for boards whose QSPI part does not survive the 148 MHz
+// the OC value asks for. RXDELAY counts HALF clk_sys cycles and a value of 0
+// samples on the SCK edge that launched the command, so the time a flash device
+// has to get its data back is (half an SCK period) + (RXDELAY half-cycles):
+//
+//   OC   at 444 MHz  148.0 MHz SCK   6.76 ns   <- the collection's tightest
+//   RD   at 480 MHz  120.0 MHz SCK   7.29 ns
+//   RX4  at 444 MHz  148.0 MHz SCK   7.88 ns   full speed, later sample point
+//   CD4  at 444 MHz  111.0 MHz SCK   7.88 ns   within any 133 MHz part's spec
+//   SAFE at 444 MHz   55.5 MHz SCK  11.26 ns   slack enough for anything
+//
+// A W25Q128JV is specified at 6 ns clock-to-Q plus the pad round trip, so the
+// OC value has no margin worth the name and depends on the individual part.
+#define PICOFACE_QMI_M0_TIMING_RX4 0x60007403u   // CLKDIV=3, RXDELAY=4
+#define PICOFACE_QMI_M0_TIMING_CD4 0x60007404u   // CLKDIV=4, RXDELAY=4
+
 #endif // __PROJECT_CONFIG_H__

--- a/core/src/pico_hw.cpp
+++ b/core/src/pico_hw.cpp
@@ -25,18 +25,8 @@
 #endif
 
 
-// Clock target and the matching flash timing. Five instruments run at 444 MHz
-// with the OC timing; PicoFaceRD sets both to its 480 MHz pair through DEFINES
-// in its instrument.cmake. The two MUST be changed together - the timing encodes
-// a divider of the system clock, so a mismatched pair either runs the flash out
-// of spec or leaves performance on the table.
-#ifndef PICOFACE_SYS_CLOCK_HZ
-#define PICOFACE_SYS_CLOCK_HZ 444000000
-#endif
-
-#ifndef PICOFACE_QMI_M0_TIMING_TARGET
-#define PICOFACE_QMI_M0_TIMING_TARGET PICOFACE_QMI_M0_TIMING_OC
-#endif
+// PICOFACE_SYS_CLOCK_HZ and PICOFACE_QMI_M0_TIMING_TARGET come from
+// project_config.h, which is where the flash-write sites can see them too.
 
 uint8_t u8x8_byte_pico_hw_i2c(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr)
 {

--- a/core/src/veeprom.cpp
+++ b/core/src/veeprom.cpp
@@ -89,7 +89,7 @@ static void __no_inline_not_in_flash_func(flash_write_locked)(int eraseSectorIdx
     }
     flash_range_program(VEEPROM_FLASH_OFFSET + progOff, buf, VEEPROM_RECORD_SIZE);
 #if PICO_RP2350
-    qmi_hw->m[0].timing = PICOFACE_QMI_M0_TIMING_OC;  // undo boot2 re-init clobber
+    qmi_hw->m[0].timing = PICOFACE_QMI_M0_TIMING_TARGET;  // undo boot2 re-init clobber
     // Returning from this SRAM-resident function is the first instruction fetch
     // to go through the QMI again, so the timing write must have landed by then.
     // __compiler_memory_barrier() only constrains the compiler; __dsb() is what

--- a/instruments/PicoFaceJ6/src/j6_patchstore.cpp
+++ b/instruments/PicoFaceJ6/src/j6_patchstore.cpp
@@ -85,7 +85,7 @@ static void __no_inline_not_in_flash_func(bank_write_locked)(const uint8_t* buf)
     flash_range_program(J6_PATCH_FLASH_OFFSET, buf, FLASH_SECTOR_SIZE);
 
 #if PICO_RP2350
-    qmi_hw->m[0].timing = PICOFACE_QMI_M0_TIMING_OC;   /* undo boot2 clobber */
+    qmi_hw->m[0].timing = PICOFACE_QMI_M0_TIMING_TARGET;   /* undo boot2 clobber */
     /* Returning from this SRAM-resident function is the first fetch to go
      * through the QMI again, so the write must have landed. __dsb orders the
      * APB write against those fetches; a compiler barrier would not. */

--- a/instruments/PicoFaceMD/README.md
+++ b/instruments/PicoFaceMD/README.md
@@ -395,6 +395,67 @@ peak load stays under a third of one core even with 2× oversampling, the
 Model D does not need the headroom, and at a core voltage of 1.60 V the slower
 clock is the kinder choice when it costs nothing.
 
+### The steady-state flash timing, and the boards it does not fit
+
+The section above ends on "the flash chip was never the limit". That was true
+of *that* failure, on *this* board. Issue #107 is the other case, and it is
+worth having both written down next to each other.
+
+A user with third-party 16 MB RP2350 boards could not get any instrument to
+start, while official Pico 2 boards worked. The boards carried the newer A4
+stepping, which is what the report suspected. A4 is documented by Raspberry Pi
+as a drop-in replacement for A2, so that is unlikely on its face -- and the
+decisive observation is in the report itself: lowering `clk_sys` to 300 MHz
+made the boards boot. That change is usually read as "the core cannot hold the
+overclock", but `M0_TIMING` encodes a *divider* of `clk_sys`, so lowering the
+core clock lowers the flash clock with it. The 300 MHz test moved the flash
+from 148 MHz to 100 MHz. Nothing distinguishes the two readings yet.
+
+`RXDELAY` counts half `clk_sys` cycles, and a value of 0 samples on the SCK
+edge that launched the command. In SPI mode 0 the device presents its data
+half an SCK period before that, so the time a flash part has to get data back
+through the pads is `(half an SCK period) + RXDELAY`:
+
+| build | SCK | budget |
+|---|---|---|
+| 444 MHz, `OC` (`CLKDIV=3`, `RXDELAY=3`) | 148.0 MHz | **6.76 ns** |
+| 480 MHz, `RD` (`CLKDIV=4`, `RXDELAY=3`) | 120.0 MHz | 7.29 ns |
+| 444 MHz, `RX4` (`CLKDIV=3`, `RXDELAY=4`) | 148.0 MHz | 7.88 ns |
+| 444 MHz, `CD4` (`CLKDIV=4`, `RXDELAY=4`) | 111.0 MHz | 7.88 ns |
+| 300 MHz, `OC` (the reporter's working test) | 100.0 MHz | 10.00 ns |
+| 444 MHz, `SAFE` (`CLKDIV=8`, `RXDELAY=2`) | 55.5 MHz | 11.26 ns |
+
+So the shipping 444 MHz build has the tightest flash timing in the collection
+-- tighter than the 480 MHz one -- and a W25Q128JV is specified at 6 ns
+clock-to-Q before the pad round trip is counted. There is no margin there at
+all; whether a given part makes it is a property of that part. That is the
+straightforward reason this project fails on a board where, as the report puts
+it, other RP2350 firmware runs fine: none of it drives the flash 11 % past the
+nominal 133 MHz.
+
+This is a hypothesis with a clean experiment behind it, not a conclusion. The
+experiment is to hold `clk_sys` at 444 MHz and change only the flash timing,
+which no test so far has done -- both variables moved together every time. If
+a `SAFE` build boots on those boards, the stepping is exonerated.
+
+The second half of the report is separate and needs no new explanation: at
+300 MHz the DX froze after menu navigation and the D5 and MD made no sound.
+These engines are budgeted for 444 MHz -- the D5's own load figures are about
+7 % of a block per voice plus 11 % fixed -- so at 68 % of the design clock they
+simply do not finish their blocks. That is the downclock, not a second fault.
+
+Groundwork landed with this: `PICOFACE_SYS_CLOCK_HZ` and
+`PICOFACE_QMI_M0_TIMING_TARGET` now live in `core/include/project_config.h`
+rather than in `pico_hw.cpp`, because the boot is not the only place that
+writes `M0_TIMING`. Every flash write re-inits boot2 and clobbers the register,
+and the three restore sites (`core/src/veeprom.cpp`,
+`instruments/PicoFaceRD/src/veeprom.cpp`,
+`instruments/PicoFaceJ6/src/j6_patchstore.cpp`) each held their own copy of the
+value. A `-DPICOFACE_QMI_M0_TIMING_TARGET=...` therefore reached the boot and
+nothing else, and the device reverted to the `OC` timing at the first settings
+save -- which would have quietly spoiled exactly the experiment above. All four
+sites now read one macro.
+
 The same defect was present in PicoFaceRD, PicoFaceCP, PicoFaceDX and
 PicoFaceYC, which share this hardware layer — today they share it as
 `core/src/pico_hw.cpp`. RD ran at 480 MHz

--- a/instruments/PicoFaceRD/src/veeprom.cpp
+++ b/instruments/PicoFaceRD/src/veeprom.cpp
@@ -89,11 +89,7 @@ static void __no_inline_not_in_flash_func(flash_write_locked)(int eraseSectorIdx
     }
     flash_range_program(VEEPROM_FLASH_OFFSET + progOff, buf, VEEPROM_RECORD_SIZE);
 #if PICO_RP2350
-#ifdef RD_CLOCK_504
-    qmi_hw->m[0].timing = PICOFACE_QMI_M0_TIMING_RD;  // undo boot2 re-init clobber (480 MHz target)
-#else
-    qmi_hw->m[0].timing = PICOFACE_QMI_M0_TIMING_OC;  // undo boot2 re-init clobber
-#endif
+    qmi_hw->m[0].timing = PICOFACE_QMI_M0_TIMING_TARGET;  // undo boot2 re-init clobber
     // Returning from this SRAM-resident function is the first instruction fetch
     // to go through the QMI again, so the timing write must have landed by then.
     // __compiler_memory_barrier() only constrains the compiler; __dsb() is what


### PR DESCRIPTION
Groundwork for [#107](https://github.com/Michi71/PicoVintageSynthCollection/issues/107) (*"not compatible with RP2350A0A4?"*), plus a latent bug found on the way.

## What the report actually shows

The suspicion is the A4 stepping. Raspberry Pi document A4 as a drop-in replacement for A2, and the linked evidence (gusmanb/logicanalyzer#367) is a user whose firmware does not enumerate, not a stepping incompatibility. The decisive fact is in the report itself: **dropping `clk_sys` to 300 MHz made the boards boot.**

That is usually read as "the core cannot hold the overclock". But `M0_TIMING` encodes a *divider* of `clk_sys`, so lowering the core clock lowers the flash clock with it — the 300 MHz test moved the flash from 148 MHz to 100 MHz. Core and flash have moved together in every test so far, and nothing yet separates them.

## What the flash actually gets

`RXDELAY` counts **half `clk_sys` cycles**, and 0 samples on the SCK edge that launched the command. In SPI mode 0 the device presents data half an SCK period before that, so the budget for clock-to-Q plus pad round trip is `(half an SCK period) + RXDELAY`:

| build | SCK | budget |
|---|---|---|
| 444 MHz `OC` (`CLKDIV=3`, `RXDELAY=3`) — shipping | 148.0 MHz | **6.76 ns** |
| 480 MHz `RD` (`CLKDIV=4`, `RXDELAY=3`) | 120.0 MHz | 7.29 ns |
| 444 MHz `RX4` (`CLKDIV=3`, `RXDELAY=4`) — new | 148.0 MHz | 7.88 ns |
| 444 MHz `CD4` (`CLKDIV=4`, `RXDELAY=4`) — new | 111.0 MHz | 7.88 ns |
| 300 MHz `OC` — the reporter's working test | 100.0 MHz | 10.00 ns |
| 444 MHz `SAFE` (`CLKDIV=8`, `RXDELAY=2`) | 55.5 MHz | 11.26 ns |

The shipping 444 MHz build has the tightest flash timing in the collection — tighter than the 480 MHz one — against a W25Q128JV's 6 ns clock-to-Q before pads are counted. There is no margin; whether a given part makes it is a property of that part. Which is a straightforward reason this project fails where, as the report puts it, other RP2350 firmware runs fine: none of it drives the flash 11 % past the nominal 133 MHz.

**This is a hypothesis with a clean experiment behind it, not a conclusion.** Hold `clk_sys` at 444 MHz, change only the flash timing. If a `SAFE` build boots on those boards, the stepping is exonerated.

## The latent bug

That experiment was not possible before this PR. `PICOFACE_QMI_M0_TIMING_TARGET` lived in `pico_hw.cpp`, while the three sites that restore the register after a flash write (boot2 re-init clobbers it) each hardcoded their own copy:

- `core/src/veeprom.cpp` → `OC`
- `instruments/PicoFaceRD/src/veeprom.cpp` → `RD`/`OC` behind `#ifdef RD_CLOCK_504`
- `instruments/PicoFaceJ6/src/j6_patchstore.cpp` → `OC`

So `-DPICOFACE_QMI_M0_TIMING_TARGET=...` reached the boot and nothing else, and the device silently reverted to the `OC` timing at the first settings save — which would have quietly spoiled exactly the experiment above. Both macros now live in `core/include/project_config.h` and all four sites read the one name.

## Changes

- `PICOFACE_SYS_CLOCK_HZ` and `PICOFACE_QMI_M0_TIMING_TARGET` move to `project_config.h`
- all four `M0_TIMING` writers use `PICOFACE_QMI_M0_TIMING_TARGET`; RD's `#ifdef RD_CLOCK_504` fork drops out
- new `PICOFACE_QMI_M0_TIMING_RX4` and `..._CD4`, with the budget table as a comment
- `instruments/PicoFaceMD/README.md`: a companion to "The 480 MHz boot failure" — that section ends on *"the flash chip was never the limit"*, true of that failure on that board; this is the other case

**No default changes.** Nine instruments still get `OC`, RD still gets `RD`.

## Verification

All ten instruments build. The timing constant was read back out of every ELF: nine carry `0x60007303` (`OC`), RD carries `0x60007304` (`RD`), none leaks. Test images built for DX and MD at `SAFE`, `CD4` and `RX4` and confirmed to carry the intended constant and no `OC`.

Untested on hardware — by construction, since the boards it is about are the reporter's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)