### PR TITLE
Splash: show the chip stepping and the flash clock actually in force

### DIFF
--- a/core/src/picoface_main.cpp
+++ b/core/src/picoface_main.cpp
@@ -14,6 +14,10 @@
 #include "pico/stdlib.h"
 #include "hardware/irq.h"
 #include "pico/bootrom.h"
+#include "hardware/clocks.h"
+#if PICO_RP2350
+#include "hardware/structs/qmi.h"
+#endif
 
 #include "project_config.h"
 #include "pico_hw.h"
@@ -293,6 +297,26 @@ int main(void)
     u8g2_DrawStr(&g_u8g2, (128 - u8g2_GetStrWidth(&g_u8g2, name)) / 2, 28, name);
     u8g2_SetFont(&g_u8g2, u8g2_font_6x10_tf);
     u8g2_DrawStr(&g_u8g2, (128 - u8g2_GetStrWidth(&g_u8g2, PICOFACE_VERSION)) / 2, 44, PICOFACE_VERSION);
+
+    // Bottom line: which silicon this is, and the flash clock actually in force.
+    // Both come up in bug reports (issue #107 turned on exactly this pair) and
+    // neither is otherwise readable: picotool does not report the stepping, and
+    // the flash timing is a compile-time choice with a runtime fallback -- if
+    // set_sys_clock_hz() misses its target the boot keeps the slack timing, so
+    // only the register knows what is really running. Read it, do not assume it.
+#if PICO_RP2350
+    {
+        // CLKDIV encodes the SCK period in system clock cycles; 0 means 256.
+        const uint32_t clkdivRaw = qmi_hw->m[0].timing & QMI_M0_TIMING_CLKDIV_BITS;
+        const uint32_t clkdiv = clkdivRaw ? clkdivRaw : 256u;
+        const uint32_t flashMHz = (clock_get_hz(clk_sys) / clkdiv + 500000u) / 1000000u;
+        char hw[24];
+        snprintf(hw, sizeof hw, "A%u  %uMHz", (unsigned)rp2350_chip_version(),
+                 (unsigned)flashMHz);
+        u8g2_SetFont(&g_u8g2, u8g2_font_5x7_tf);
+        u8g2_DrawStr(&g_u8g2, (128 - u8g2_GetStrWidth(&g_u8g2, hw)) / 2, 60, hw);
+    }
+#endif
     u8g2_SendBuffer(&g_u8g2);   // blocking is fine here, audio is not running yet
 
     // hold the splash for 2000 ms, keeping USB alive


### PR DESCRIPTION
Follow-on to [#108](https://github.com/Michi71/PicoVintageSynthCollection/pull/108), for [#107](https://github.com/Michi71/PicoVintageSynthCollection/issues/107).

That issue arrived as *"not compatible with RP2350 A4?"* and **neither half of the question could be answered from the device.**

- **The stepping**: `picotool` does not report it. Identifying the silicon means reading the part number off the package with a loupe — which is what [PCN 32](https://pip-assets.raspberrypi.com/categories/1262-pcn/documents/RP-008978-PC/Pico-2-Products-Moving-to-RP2350-A4-Silicon-Stepping) names as the identification method.
- **The flash clock**: worse than unknown. It is a compile-time choice *with a runtime fallback* — `pico_init()` calls `set_sys_clock_hz(..., false)` and keeps the slack timing if the target turns out unreachable. Nothing announced which of the two had happened.

Both now sit under the version string in a 5x7 line:

```
        PicoFaceDX
           v1.2.0
         A4  148MHz
```

The stepping comes from `rp2350_chip_version()`. Worth noting what that function does: `(v & 3) | ((v & 8) >> 1)` — the bit shuffle exists precisely so raw `REVISION`&nbsp;8 reads as A4, which is how SDK 2.3.0 recognises the stepping at all. The clock is computed from the `CLKDIV` field of `qmi_hw->m[0].timing` itself, not from the macro that was supposed to have been written there. Read it, do not assume it.

**The failed-clock case becomes visible for free.** A boot that misses 444 MHz falls back to 150 MHz with `CLKDIV=8` and shows `A4  19MHz` rather than `A4  148MHz` — previously that only showed up as a wild CPU-load percentage, and only if you knew to look.

## What it renders

| configuration | line |
|---|---|
| shipping, 444 MHz | `A4  148MHz` |
| PicoFaceRD, 480 MHz | `A4  120MHz` |
| `CD4` test build | `A4  111MHz` |
| `SAFE` test build | `A4  56MHz` |
| clock switch failed | `A4  19MHz` |

50 px of 128 at worst; `CLKDIV=0` (which encodes 256) is handled.

## Cost

1612 bytes for `u8g2_font_5x7_tf` plus a few dozen for the code, per instrument. All ten build clean.

Untested on hardware — the display cannot be checked from here, so the layout (baseline y=60, under the version at y=44) wants one look on the device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)