### PR TITLE
Boot: the dummy QMI access the datasheet asks for before the clock jump

### DIFF
--- a/core/src/pico_hw.cpp
+++ b/core/src/pico_hw.cpp
@@ -108,6 +108,27 @@ void pico_init()
     // status line goes through the roof.
     qmi_hw->m[0].timing = PICOFACE_QMI_M0_TIMING_SAFE;
     __dsb();
+    // The datasheet asks for one more thing here, which we were not doing:
+    //
+    //   "If software is increasing CLKDIV in anticipation of an increase in the
+    //    system clock frequency, a dummy access to either memory window (and
+    //    appropriate processor barriers/fences) must be inserted after the
+    //    Mx_TIMING write to ensure the SCK divisor change is in effect _before_
+    //    the system clock is changed."
+    //
+    // That is exactly this write: CLKDIV goes 4 -> 8 ahead of the clk_sys jump.
+    // The barriers order the APB write, but they do not make the QMI run a
+    // transaction, and until it does the new divisor need not be in effect. The
+    // only flash access that followed was the instruction fetch of the code
+    // below -- which the XIP cache may well serve, in which case no transaction
+    // happens at all and clk_sys moves while the old divisor still stands. That
+    // is a board-dependent failure by construction, and it sits in the same
+    // window that hung the 480 MHz build (see the MD README).
+    //
+    // Hence the read through XIP_NOCACHE_NOALLOC_BASE rather than XIP_BASE: a
+    // cached read is allowed to be silent, and a silent dummy access is not one.
+    (void)*(volatile uint32_t *)XIP_NOCACHE_NOALLOC_BASE;
+    __dsb();
     __isb();
 
     const bool clockOk = set_sys_clock_hz(PICOFACE_SYS_CLOCK_HZ, false);


### PR DESCRIPTION
Third piece for [#107](https://github.com/Michi71/PicoVintageSynthCollection/issues/107), independent of [#108](https://github.com/Michi71/PicoVintageSynthCollection/pull/108) and [#109](https://github.com/Michi71/PicoVintageSynthCollection/pull/109). Found while reading the `CLKDIV` field description for the splash line.

## The rule

The RP2350 datasheet is explicit about our exact sequence:

> If software is increasing `CLKDIV` in anticipation of an increase in the system clock frequency, **a dummy access to either memory window** (and appropriate processor barriers/fences) must be inserted after the `Mx_TIMING` write to ensure the SCK divisor change is in effect *before* the system clock is changed.

`pico_init()` raises `CLKDIV` from 4 to 8 ahead of the `clk_sys` jump — precisely the case named — and then did only `__dsb(); __isb();`.

## Why the barriers are not enough

They order the APB write, but they do not make the QMI *run a transaction*, and until it does the new divisor need not be in effect. The only flash access that followed was the instruction fetch of the code below — **which the XIP cache may serve**, in which case no transaction happens at all and `clk_sys` moves while the old divisor still stands.

Whether that bites depends on cache state and on how much margin the flash part has, which is to say it is a board-dependent failure by construction. It sits in the same window the [MD README](../blob/main/instruments/PicoFaceMD/README.md) records as having hung the 480 MHz build, and #107 is a board that will not boot at 444 MHz.

The read goes through `XIP_NOCACHE_NOALLOC_BASE`, not `XIP_BASE`: a cached read is allowed to be silent, and a silent dummy access is not one.

## Verification

Checked in the disassembly rather than assumed — `Ofast` is on in this file and a dropped access would have been invisible in the source:

```
1000b05c:  str    r4, [r3, #12]        M0_TIMING = SAFE
1000b05e:  dsb    sy
1000b062:  mov.w  r3, #0x14000000
1000b066:  ldr    r3, [r3, #0]         the dummy access
1000b068:  dsb    sy
1000b06c:  isb    sy
```

The success path still writes the right value: the compiler inlined `set_sys_clock_hz` and turned the ternary into two paths, reaching `OC` as `adds r4, #251` on the `SAFE` constant (`0x60007208 + 0xFB = 0x60007303`). All ten instruments build.

## Not addressed here

The same datasheet section says only `CLKDIV` may be changed on the fly and *"all other parameters must only be changed when the QMI is idle"*. Both our writes also change `RXDELAY`, and both execute from flash. Fixing that means moving the sequence into SRAM — a bigger change than this one, and it deserves its own hardware test.

Untested on hardware. This is the boot path, so it wants a smoke test on a known-good board before anything else: it should change nothing there. The interesting test is the reporter's board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)