### PR TITLE
RD: 6 dB of headroom ahead of the softclip, so transients survive

### DIFF
--- a/instruments/PicoFaceRD/README.md
+++ b/instruments/PicoFaceRD/README.md
@@ -289,6 +289,54 @@ compiled in, which is what the A/B test compares against. The extraction and
 analysis toolchain is documented in
 [tools/rd_extract/README.md](../../tools/rd_extract/README.md).
 
+### Output headroom, and the one thing the A/B test cannot see
+
+The A/B matrix measures correlation against the reference emulator, and
+correlation is scale-invariant. It has been fooled by this before -- a 16 dB
+level error once passed it untouched -- so anything about *level* has to be
+measured separately. This is the second such finding.
+
+The bridge scales the engine accumulator by 1/131072, runs the vintage FX, and
+ends on a rational softclip with its knee at 0.9. Measured across 720 cases
+(all sixteen instruments x 1..16 notes x velocity 60..127, at the shipped
+volume default of 80 %), that put **17.2 % of them into the softclip**, with
+the 99th percentile at 12.6 % distortion and the worst case at 20 %.
+
+Those are piano chords. Ten notes under the pedal is ordinary playing, not an
+edge case. And the mechanism is specifically a *transient* one -- the peak loss
+tracks the overdrive almost exactly:
+
+| past the knee | distortion | peak loss |
+|---|---|---|
+| +0.9 dB | 0.24 % | 0.45 dB |
+| +2.9 dB | 2.34 % | 2.19 dB |
+| +4.9 dB | 5.73 % | 4.11 dB |
+| +6.9 dB | 10.36 % | 6.07 dB |
+
+So the attack of a note was being flattened by up to 6 dB while the body of it
+stayed where it was. That is what "harder than the original" sounds like, and
+it is not something a reconstruction filter can fix: the same measurement run
+showed the RD's own output carries only 2.7 % of its attack energy above 4 kHz
+and nothing at all above 8 kHz, and the vintage DAC stage (on by default,
+-2.8 dB at 4 kHz, -7.2 dB at 8 kHz net) already moves the whole signal by
+0.3 dB RMS. There was never any brightness up there to take away.
+
+A trim of 0.5 sits after the FX stage -- after, because the 12-bit
+requantization and the phaser's tanh feedback are nonlinear and trimming ahead
+of them would move their operating point and coarsen the quantizer by a bit
+relative to the music. Re-measured on the changed code:
+
+| | in the softclip | 99th pct distortion | worst | loudest raw peak |
+|---|---|---|---|---|
+| before | 17.2 % | 12.55 % | 20.21 % | +9.33 dB |
+| after | **2.1 %** | **0.83 %** | **4.63 %** | +3.38 dB |
+
+It costs 6 dB of output, which the volume control and the amplifier take back.
+What it buys is the top of the dynamic range: from the 75th percentile to the
+loudest case there used to be 2.5 dB of room (-2.54 to -0.04 dBFS) because
+everything above was pinned against the ceiling. Now there is 8.4 dB
+(-8.56 to -0.13 dBFS), and the headroom is still being used.
+
 [tools/rd_midi/](../../tools/rd_midi/) holds MIDI utilities for testing: `midi_keyboard_only.py` strips a Standard MIDI File down to pure keyboard performance (notes, damper, pitch bend) so sequencer dumps can be replayed against the device.
 
 ## ROM data & credits

--- a/instruments/PicoFaceRD/src/RD_Synth_Bridge_v2.cpp
+++ b/instruments/PicoFaceRD/src/RD_Synth_Bridge_v2.cpp
@@ -197,6 +197,30 @@ void RAM_HOT(RD_Synth_Bridge::fill_buffer_i32)(int32_t* out, int length)
     const float a     = 0.9f;
     const float range = 1.0f - a;   // same rational softclip as the v1 bridge
 
+    // Headroom trim ahead of the softclip. Measured across 720 cases (all
+    // sixteen instruments x 1..16 notes x velocity 60..127, at the shipped
+    // volume default of 80 %): without it, 17.2 % of them drive the knee at
+    // 0.9, the 99th percentile reaches 12.6 % distortion and the worst case
+    // 20 %. Those are piano chords -- ten notes under the pedal is ordinary
+    // playing, not an edge case -- and a flattened attack is exactly what
+    // "harder than the original" sounds like. The peak loss is the mechanism:
+    // 6.9 dB past the knee costs 6.1 dB off the transient while the body of
+    // the note stays put.
+    //
+    // 0.5 rather than a fitted value: it is one binary exponent, it puts the
+    // 99th percentile at 0.82 % distortion and the worst case at 4.5 %, and
+    // only 2.1 % of cases reach the knee at all. Headroom is still used --
+    // the loudest case lands at -0.13 dBFS -- so this buys dynamics, not
+    // quiet. What it costs is 6 dB of output, which the volume control and
+    // the amplifier take back; what it stops costing is the transient.
+    //
+    // Placed AFTER fx_.process on purpose. The vintage DAC stage quantizes to
+    // 12 bits over +-1.0 and the phaser feedback runs through a tanh; both are
+    // nonlinear, so trimming ahead of them would move their operating point
+    // and coarsen the quantizer by a bit relative to the music. Everything
+    // between is linear, so the trim is free to sit here.
+    const float trim = 0.5f;
+
     static int32_t accBuf[64];
     int done = 0;
     while (done < length)
@@ -212,6 +236,8 @@ void RAM_HOT(RD_Synth_Bridge::fill_buffer_i32)(int32_t* out, int length)
 
         float l, r;
         fx_.process(f, &l, &r);
+        l *= trim;
+        r *= trim;
 
         if (l > a)       l =  a + range * (1.0f - 1.0f / (1.0f + (l - a) / range));
         else if (l < -a) l = -a - range * (1.0f - 1.0f / (1.0f + (-l - a) / range));


### PR DESCRIPTION
Answers "would modelling the analogue output stage make it softer?" — measured, and the answer is **no**, but the same measurement found something else that fits "harder" exactly.

## The output-stage idea does not hold

Rendered offline and measured the energy distribution. Reference point: an **ideal** sawtooth at 262 Hz carries 8.1 % of its energy above 2 kHz and 1.1 % above 8 kHz.

| | >2 kHz | >4 kHz | >8 kHz |
|---|---|---|---|
| MD, presets 0/3/7/14 (filter open, resonance 0) | 1.9–3.9 % | 0.5–1.0 % | **0.06–0.12 %** |
| J6, presets 0/3/7/14 (filter open, resonance 0) | 4.2–13.3 % | 1.2–2.1 % | **0.18–0.44 %** |
| RD instrument 4, attack window | — | 2.7 % | **0.00 %** |

All three sit at or below an ideal sawtooth. There is nothing up there to soften.

And the RD **already has** the stage: `kDefDacFilterOn = 1`, so it ships on. Measured with noise (Welch-averaged), its net effect is −0.3 dB at 1 kHz, −2.8 dB at 4 kHz, −7.2 dB at 8 kHz — a textbook analogue reconstruction curve — and it moves the whole signal by **0.3 dB RMS**, because so little energy lives there.

<sub>One correction against myself: a first pass showed J6 preset 3 with 37 % of its energy above 12 kHz. That was my own artifact — I opened the cutoff and left the preset's resonance, so I measured self-oscillation. With resonance zeroed it is 0.02 %.</sub>

## What was actually happening

While measuring levels: at an eight-note chord, **ten of sixteen instruments peaked within 0.2 dB of full scale with zero hard clips**. That is what a softclip working hard looks like. The bridge ends on a rational softclip with its knee at 0.9 (−0.92 dBFS); inverting it across **720 cases** (all sixteen instruments × 1..16 notes × velocity 60..127, at the shipped volume default of 80 %):

- **17.2 %** of cases drive the knee
- 99th percentile: **12.6 %** distortion
- worst case: **20 %**

Ten notes under the pedal is ordinary piano playing, not an edge case.

The mechanism is specifically a *transient* one. Measured on real E-Piano 2 material:

| past the knee | distortion | peak loss |
|---|---|---|
| +0.9 dB | 0.24 % | 0.45 dB |
| +2.9 dB | 2.34 % | 2.19 dB |
| +4.9 dB | 5.73 % | 4.11 dB |
| +6.9 dB | 10.36 % | 6.07 dB |

The attack was being flattened by up to 6 dB while the body of the note stayed put. That is what "harder than the original" sounds like — and no reconstruction filter can fix it.

## The change

A trim of `0.5`, placed **after** `fx_.process`. After, because the 12-bit requantization and the phaser's tanh feedback are nonlinear — trimming ahead of them would move their operating point and coarsen the quantizer by a bit relative to the music. Everything between is linear, so the trim is free to sit there.

`0.5` rather than a fitted value: it is one binary exponent, and it lands where a fit would.

## Verification — re-measured on the changed code, not predicted

| | in the softclip | 99th pct distortion | worst | loudest raw peak |
|---|---|---|---|---|
| before | 17.2 % | 12.55 % | 20.21 % | +9.33 dB |
| after | **2.1 %** | **0.83 %** | **4.63 %** | +3.38 dB |

It costs 6 dB of output, which the volume control and the amplifier take back. What it buys is the top of the dynamic range: from the 75th percentile to the loudest case there used to be **2.5 dB** of room (−2.54 to −0.04 dBFS) because everything above was pinned; now there is **8.4 dB** (−8.56 to −0.13 dBFS), and the headroom is still used.

Firmware builds.

## Note for the harness

`run_regression.sh`'s A/B matrix **cannot see any of this**. Correlation is scale-invariant, and a 16 dB level error once passed it untouched. This is the second finding of that shape after the D5 level base — a standing headroom check in the regression runner would be worth adding, but that is its own change.

Untested by ear. The listening test: play E-Piano 1 or 2 densely. It should sound *softer*, not merely quieter — the volume control compensates the level, and what is left is the difference.

🤖 Generated with [Claude Code](https://claude.com/claude-code)