### PR TITLE
RD: the DAC is 16 bit and the chorus runs to 5.7 Hz — both from the schematic

### DIFF
--- a/instruments/PicoFaceRD/README.md
+++ b/instruments/PicoFaceRD/README.md
@@ -291,6 +291,52 @@ analysis toolchain is documented in
 
 [tools/rd_midi/](../../tools/rd_midi/) holds MIDI utilities for testing: `midi_keyboard_only.py` strips a Standard MIDI File down to pure keyboard performance (notes, damper, pitch bend) so sequencer dumps can be replayed against the device.
 
+### What the service notes settled
+
+The MKS-20 Service Notes (Roland, June 1986) turned up after the effect chain
+was already written from the block diagram and the ear. Three things came out
+of the CPU-B board schematic and the adjustment tables.
+
+**The reconstruction filter was right.** The DAC output runs through FL1
+(`0538-014`, a Roland custom low-pass module whose internals the schematic does
+not show) and then an inverting stage on IC1 (µPC4570) whose feedback is
+R14 33k in parallel with C7 1200 pF -- a pole at **4019 Hz**. Against the
+measured response of the vintage DAC stage in `rd_effects.cpp`:
+
+| | 2 kHz | 4 kHz | 6 kHz | 8 kHz | 12 kHz |
+|---|---|---|---|---|---|
+| this engine | −0.8 | −2.8 | −5.1 | −7.2 | −10.1 dB |
+| pole at 4019 Hz | −0.96 | −2.99 | −5.09 | −6.96 | −9.96 dB |
+
+Within 0.24 dB across the band. A stage that was guessed turns out to match the
+hardware; the guess stands, now with a source behind it.
+
+(The schematic also shows *two* channels with different poles -- the second is
+R11 33k with C6 820 pF, 5882 Hz -- fed from one time-multiplexed PCM54 through
+HI-201 analogue switches and summed by IC2 at a gain of 1.5. Whether those two
+correspond to the 20 kHz and 32 kHz voice groups is a guess the schematic does
+not support.)
+
+**The DAC is 16 bit, not 12.** The parts list names IC4 as a `PCM 54`, "16 bit
+D/A converter". The stage here requantized to 12 bits, and did it with a cast,
+which truncates toward zero and so leaves a dead band one LSB wide either side
+of silence. Measured on a 441 Hz tone, THD+N improved by 14.2 dB at −20 dBFS,
+27.3 dB at −40 dBFS and 33.1 dB at −60 dBFS. Worse than the numbers: the 12-bit
+step over ±1.0 is −66.2 dBFS, so with truncation **everything below about
+−66 dBFS came out as digital silence**. A piano tail did not fade, it stopped.
+
+**The chorus LFO was nearly five times too slow at the top.** The adjustment
+section tabulates the LFO period at CP3 for all fifteen settings, 2700 ms down
+to 175 ms. That is 0.370 to 5.714 Hz, linear in the setting to within 3.7 %.
+The code had 0.3 to 1.2 Hz. Tremolo, tabulated the same way at CP4, was already
+right (0.476 to 7.69 Hz against 0.5 to 8.0).
+
+**Still open from the same tables:** the LFO amplitude at CP3 scales with the
+period at a constant 3.98 mV/ms (±9 % across all fifteen settings) -- a
+constant-slew triangle, so on the original a slower chorus sweeps
+proportionally wider. Rate and depth are independent here. That is a change in
+character rather than a corrected number, so it is not in this change.
+
 ## ROM data & credits
 
 - **[giulioz/rdpiano](https://github.com/giulioz/rdpiano)** — the reverse

--- a/instruments/PicoFaceRD/src/rd_effects.cpp
+++ b/instruments/PicoFaceRD/src/rd_effects.cpp
@@ -107,7 +107,11 @@ void RD_VintageFX::setSampleRate(float sr)
     tremInc_ = (0.5f + 7.5f * tremRate_) / sr;
 
     // Chorus LFO: 0.3..1.2 Hz
-    chorusInc_ = (0.3f + 0.9f * chorusRate_) / sr;
+    // Measured, not guessed: the service notes tabulate the chorus LFO period at
+    // CP3 for all fifteen settings, 2700 ms down to 175 ms. That is 0.370 to
+    // 5.714 Hz, linear in the setting to within 3.7 %. The old 0.3..1.2 Hz was
+    // nearly five times too slow at the top of the range.
+    chorusInc_ = (0.370f + 5.344f * chorusRate_) / sr;
 
     // Phaser rate mapping: 0.1..5 Hz over normalized 0..1
     phRateHz_ = 0.1f * powf(10.0f, phaserRate_ * 1.69897000433601880479f);
@@ -140,7 +144,7 @@ void RD_VintageFX::setParam(uint8_t id, float v01)
 
     case RD_PARAM_CHORUS_RATE:
         chorusRate_ = v01;
-        chorusInc_  = (0.3f + 0.9f * chorusRate_) / sampleRate_;
+        chorusInc_  = (0.370f + 5.344f * chorusRate_) / sampleRate_;  // see setSampleRate
         break;
 
     case RD_PARAM_CHORUS_DEPTH:
@@ -220,7 +224,16 @@ void RAM_HOT(RD_VintageFX::process)(float in, float* outL, float* outR) {
     //    FULLY gated -- bypassing must restore the clean signal (the old code
     //    ran the lowpass unconditionally, so the toggle did nothing audible).
     if (dacOn_ > 0.5f) {
-        x = (float)((int32_t)(x * 2048.0f)) * (1.0f / 2048.0f);  // true 12 bit over +-1.0
+        // 16 bit, not 12: the MKS-20 service notes list IC4 on the CPU-B board
+        // as a PCM54 -- "16 bit D/A converter" in as many words. The 12 here was
+        // a guess from before the schematic turned up, and it cost 24 dB of
+        // quantization noise the machine never had.
+        //
+        // floorf(x+0.5) rather than a cast, too. A cast truncates toward zero,
+        // which leaves a dead band of one LSB either side of silence -- crossover
+        // distortion, worst exactly where a piano tail spends its time. This is a
+        // plain mid-tread quantizer with no dead band.
+        x = floorf(x * 32768.0f + 0.5f) * (1.0f / 32768.0f);
         dacLpState_  += dacLpCoef_ * (x - dacLpState_);
         dacLpState2_ += dacLpCoef_ * (dacLpState_ - dacLpState2_);
         x = dacLpState2_;


### PR DESCRIPTION
From the MKS-20 Service Notes (Roland, June 1986). The effect chain was written from the block diagram and the ear; the schematic settles two of its numbers — and confirms a third that had been marked as a guess.

Independent of [#111](https://github.com/Michi71/PicoVintageSynthCollection/pull/111) (different file). The rate/depth coupling from the same tables is deliberately **not** here — it gets its own change so it can be judged on its own.

## Confirmed: the reconstruction filter was right

The DAC output runs through **FL1** (`0538-014`, a Roland custom low-pass module whose internals the schematic does not show), then an inverting stage on **IC1 µPC4570** with **R14 33 k ∥ C7 1200 pF** in the feedback — a pole at **4019 Hz**.

| | 2 kHz | 4 kHz | 6 kHz | 8 kHz | 12 kHz |
|---|---|---|---|---|---|
| this engine (measured) | −0.8 | −2.8 | −5.1 | −7.2 | −10.1 dB |
| pole at 4019 Hz | −0.96 | −2.99 | −5.09 | −6.96 | −9.96 dB |
| difference | +0.16 | +0.19 | −0.01 | **−0.24** | −0.14 dB |

Within **0.24 dB** across the band. Nothing to change; a guess now has a source behind it.

## Corrected: the DAC is 16 bit, not 12

The parts list names IC4 as a `PCM 54` — *"16 bit D/A converter"*. This stage requantized to **12 bits**, with a cast, which truncates toward zero and so leaves a dead band one LSB wide either side of silence.

Measured on a 441.40625 Hz tone (bin-centred, so no leakage floor):

| level | 12 bit | 16 bit | gain |
|---|---|---|---|
| −6 dBFS | −67.7 dB | −71.0 dB | +3.3 dB |
| −20 dBFS | −56.6 dB | −70.8 dB | +14.2 dB |
| −40 dBFS | −36.5 dB | −63.8 dB | **+27.3 dB** |
| −60 dBFS | −12.3 dB | −45.4 dB | **+33.1 dB** |

Worse than the THD+N numbers is what the dead band did. The 12-bit step over ±1.0 is −66.2 dBFS, so:

| input | 12 bit out | 16 bit out |
|---|---|---|
| −60 dBFS | −66.5 dB | −63.4 dB |
| −66 dBFS | −76.6 dB | −69.4 dB |
| −70 dBFS | **silence** | −73.4 dB |
| −80 dBFS | **silence** | −83.5 dB |

**A piano tail did not fade out, it stopped.** Now `floorf(x·32768 + 0.5)` — a plain mid-tread quantizer, no dead band.

## Corrected: the chorus LFO was nearly 5× too slow

The adjustment section tabulates the LFO period at CP3 for all fifteen settings, 2700 ms down to 175 ms. That is **0.370 to 5.714 Hz**, linear in the setting to within 3.7 %. The code had `0.3f + 0.9f * rate` — **0.3 to 1.2 Hz**.

Tremolo, tabulated the same way at CP4, was already right (manual 0.476–7.69 Hz, code 0.5–8.0 Hz).

## Verification, and what it does not cover

The filter response was re-measured after the change and is unmoved (0.013 dB, which is the reduced quantization noise). The rate change was verified against the manual at settings 0.75 and 1.00 to **0.3 %** (4.365 vs 4.378 Hz, 5.729 vs 5.714 Hz).

The slow settings defeated my detector — too few LFO cycles in the analysis window, and peak-picking grabs a harmonic of the triangle. The mapping is linear by construction (`chorusInc_ = f/sr` into a phase accumulator that wraps at 1.0), so two points fix it, but I am not claiming a measured sweep. Two earlier attempts at that detector were wrong in ways worth naming: measuring `L−R` reads **twice** the LFO rate, because `triangle(p+0.5) = −triangle(p)` puts the two taps symmetrically about the base delay and the difference rectifies; and a zero-crossing count on the demodulated phase counts noise.

Firmware builds.

Untested by ear. Both changes should make quiet material cleaner and the chorus faster at the top of its range; the tail behaviour is the one to listen for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)