### PR TITLE
RD: the effect chain runs the machines' way round, and the tremolo pans

### DIFF
--- a/instruments/PicoFaceRD/README.md
+++ b/instruments/PicoFaceRD/README.md
@@ -170,7 +170,7 @@ are, which is why they sit in `roms/` rather than in the tree.
 | Sounds | All 16 patches: MKS-20 (Piano 1–3, Harpsichord, Clavi, Vibraphone, E-Piano 1–2) and MK-80 (Classic, Special, Blend, Contemporary, A. Piano 1–2, Clavi, Vibraphone). A 4 MB build ships one machine's eight — see [Fitting a 4 MB Pico 2](#fitting-a-4-mb-pico-2) |
 | Engine | Timeline-replay of captured S/A voice programming; 10 parts per voice, chip-exact envelope math, native 20 kHz / 32 kHz per patch (no resampling) |
 | Polyphony | 8 / 16 / 24 / 32 voices or **Auto** — a load-adaptive voice governor with active culling (default; the original is 16-voice) |
-| Effects | Vintage DAC stage (12-bit requantization + 2-pole reconstruction filter), bass/treble shelves, tremolo, mono 4-stage phaser, stereo BBD-style chorus |
+| Effects | In the machines' own order: vintage DAC stage (16-bit requantization + 2-pole reconstruction filter), bass/treble shelves, stereo BBD-style chorus, 4-stage phaser per channel, antiphase stereo tremolo |
 | MIDI | USB and DIN MIDI, implementation modeled on the MK-80 MIDI implementation chart (sounding range 21–108 with octave folding, damper, FX switches CC 92/93/95, reset CC 121, all-notes-off CC 123, program change, pitch bend ±2 semitones) — see [doc/MIDI.md](doc/MIDI.md) and the collection's CC table in [docs/ARCHITECTURE.md](../../docs/ARCHITECTURE.md), section 6a |
 | Tuning | Master tune ±50 cents in 1-cent steps with live A4 frequency display |
 | Persistence | All panel settings in a wear-leveled flash append log (versioned, CRC-protected), auto-saved 2 s after the last edit while idle |
@@ -365,6 +365,59 @@ anchor is the middle setting, chosen so the familiar depth stays where it was.
 And the depth that anchor preserves is very deep for a chorus -- ±135 cents at
 full depth, where a Roland chorus of the period is usually a few tens of cents.
 That is pre-existing and the notes cannot decide it.
+
+### What the MK-80 notes added
+
+The MK-80 Service Notes (Roland, September 1989) arrived after the MKS-20 ones
+and mostly agreed with them -- which is itself worth having, because two of the
+agreements are checks that could not be run before.
+
+**The sample rates are right, confirmed twice.** Both manuals give polyphony
+per voice, 16 or 10. That split lands exactly on the rate table: every
+16-voice sound in either list is one of the 20 kHz patches, every 10-voice
+sound one of the 32 kHz ones, sixteen for sixteen. The rates came out of ROM;
+two service manuals agree with them independently. (The cap itself was wrong
+and is fixed separately -- 16 x 20000 = 10 x 32000 = 320000 voice slots per
+second, the S/A chip's fixed budget.)
+
+**The MK-80 uses the same converter and the same filter.** `PCM 54` and
+`LC Filter LPF 0538-014`, part number 12449269 in both parts lists. Giving both
+machines one reconstruction stage is correct rather than merely convenient.
+
+**The effect chain runs the other way round.** Both block diagrams are
+`EQ -> chorus -> phaser -> tremolo/VCA -> out` (MKS-20 p.4, MK-80 p.17; the
+MKS-20 has no phaser, so its chain is chorus -> tremolo). This engine ran
+`tremolo -> phaser -> chorus`, so the tremolo went *through* the delay line --
+smeared over five milliseconds and split unevenly across the two taps, where
+the original applies it last and cleanly.
+
+**And the tremolo is a pan, not a level wobble.** The MK-80 notes adjust the
+two VCAs separately (VR8 for OUTPUT-L, VR9 for OUTPUT-R) and the scope trace
+for that step shows the channels exactly interleaved: the right swells where
+the left is at its trough, each returning to the baseline. Measured before and
+after, envelope of a 1 kHz tone at full depth:
+
+| | L/R correlation | swing per channel | swing of the sum |
+|---|---|---|---|
+| before | **+1.000** | −14.0 dB | −14.0 dB |
+| after | **−1.000** | −69.8 dB | **−0.0 dB** |
+
+So it used to pump the whole signal by 14 dB and now moves it across the image
+at constant loudness. The trough reaching silence is from the same page: the
+instruction is to set it "at minimum level (possibly zero swing)", where the
+factor here stopped at 0.2 of full scale.
+
+The phaser is per channel now, as it is on the board (IC33 twice, each inside
+its own NE572 compander) -- after the chorus the two sides are no longer the
+same signal, so one mono phaser has nothing coherent to work on. Cost of the
+whole reordering, measured on the host: +5 % through the chain with the phaser
+off, +9 % with it on. The host understates it, as it always does for this kind
+of change, but the chain is a fraction of a percent of the render either way.
+
+One thing the MK-80 has that the MKS-20 does not, noted and not acted on: an
+`IR3109` VCF, and the phaser itself. Strictly the phaser should not be offered
+on MKS-20 patches at all. It is off by default and switchable, so this is
+cosmetic.
 
 ## ROM data & credits
 

--- a/instruments/PicoFaceRD/README.md
+++ b/instruments/PicoFaceRD/README.md
@@ -331,11 +331,40 @@ to 175 ms. That is 0.370 to 5.714 Hz, linear in the setting to within 3.7 %.
 The code had 0.3 to 1.2 Hz. Tremolo, tabulated the same way at CP4, was already
 right (0.476 to 7.69 Hz against 0.5 to 8.0).
 
-**Still open from the same tables:** the LFO amplitude at CP3 scales with the
-period at a constant 3.98 mV/ms (±9 % across all fifteen settings) -- a
-constant-slew triangle, so on the original a slower chorus sweeps
-proportionally wider. Rate and depth are independent here. That is a change in
-character rather than a corrected number, so it is not in this change.
+**The chorus keeps its detune, not its sweep.** The CP3 table gives the LFO
+amplitude as well as the period, and their ratio is constant at 3.98 mV/ms
+(±9 % across all fifteen settings) -- a triangle of constant slope, so the
+amplitude is proportional to the period. What that buys is not width for its
+own sake: a constant slope on the BBD clock control is a constant rate of
+change of delay, which is a constant pitch deviation. The original holds its
+detune and only changes how fast it wobbles.
+
+The model here held the delay swing constant instead, so the detune grew with
+the rate. Measured at full depth on the wet path, peak deviation of a 1 kHz
+tone:
+
+| setting | LFO | before | after |
+|---|---|---|---|
+| 0.00 | 0.370 Hz | ±16 ct | ±27 ct |
+| 0.25 | 1.706 Hz | ±76 ct | ±126 ct |
+| 0.50 | 3.042 Hz | ±135 ct | ±135 ct |
+| 0.75 | 4.378 Hz | ±195 ct | ±135 ct |
+| 1.00 | 5.714 Hz | ±255 ct | ±135 ct |
+
+Flat across the fast half to 0.3 ct, against a fifteen-fold spread before.
+Below about 1.8 Hz at full depth it flattens off, because the swing is clamped
+to the centre delay -- that is physics, not a guard: a BBD's delay is
+stages / (2 × clock) and cannot go negative, and a swing equal to the centre is
+already a 2:1 clock sweep. Without the clamp the read index wraps to the far
+end of the line and the output is garbage.
+
+Two things this does **not** settle. The absolute width is not derivable from
+the notes: the table gives volts at the LFO, and the volts-to-delay law lives
+in the MN3101 clock oscillator, which the schematic does not break out. The
+anchor is the middle setting, chosen so the familiar depth stays where it was.
+And the depth that anchor preserves is very deep for a chorus -- ±135 cents at
+full depth, where a Roland chorus of the period is usually a few tens of cents.
+That is pre-existing and the notes cannot decide it.
 
 ## ROM data & credits
 

--- a/instruments/PicoFaceRD/include/rd_effects.h
+++ b/instruments/PicoFaceRD/include/rd_effects.h
@@ -2,7 +2,9 @@
 // SPDX-FileCopyrightText: 2026 Michi71
 
 // RD_VintageFX: Vintage FX chain for MKS-20/MK-80 emulation.
-// Signal flow: in -> DAC filter -> bass shelf -> treble shelf -> tremolo -> BBD chorus (stereo) -> volume.
+// Signal flow: in -> DAC filter -> bass shelf -> treble shelf -> BBD chorus (stereo)
+//              -> phaser (one per channel) -> tremolo (stereo, antiphase) -> volume.
+// That order is the machines' own -- see rd_effects.cpp.
 // Mono in / stereo out. Native rate 20000/32000 Hz. RP2350 optimized.
 
 #ifndef RD_EFFECTS_H
@@ -61,9 +63,9 @@ private:
     float    phA_;                     // current allpass coefficient
     float    phFb_;                    // current feedback
     uint32_t phCnt_;                   // 8-sample coefficient decimation counter
-    float    phX1_[kPhaserStages];     // APF input history
-    float    phY1_[kPhaserStages];     // APF output history
-    float    phLast_;                  // last feedback sample
+    float    phX1_[2][kPhaserStages];  // APF input history, per channel
+    float    phY1_[2][kPhaserStages];  // APF output history, per channel
+    float    phLast_[2];               // last feedback sample, per channel
 
     // Chorus
     static constexpr int kDelayLen = 512;

--- a/instruments/PicoFaceRD/src/rd_effects.cpp
+++ b/instruments/PicoFaceRD/src/rd_effects.cpp
@@ -88,6 +88,49 @@ void RD_VintageFX::init(float sampleRate)
     setSampleRate(sampleRate);
 }
 
+
+// Chorus LFO frequency for a 0..1 setting, from the service notes' CP3 table.
+static inline float chorusLfoHz(float rate01)
+{
+    return 0.370f + 5.344f * rate01;
+}
+
+// Sweep width in samples. The CP3 table gives the LFO amplitude as well as the
+// period, and their ratio is constant at 3.98 mV/ms (+-9 % over all fifteen
+// settings) -- a triangle of constant slope. So the amplitude is proportional
+// to the period, and the sweep widens as the rate falls.
+//
+// What that buys is not width for its own sake. A constant slope on the BBD
+// clock control is a constant rate of change of delay, which is a constant
+// pitch deviation: the original holds its detune and only changes how fast it
+// wobbles. The model here used to hold the delay swing constant instead, so
+// the detune grew with the rate -- nearly none at the slow end, most at the
+// fast end. That is the opposite character.
+//
+// Anchored at the middle setting so the familiar depth stays where it was. The
+// absolute width is NOT derivable from the notes: the table gives volts at the
+// LFO, and the volts-to-delay law lives in the MN3101 clock oscillator, which
+// the schematic does not break out. Proportionality is measured; this anchor
+// is a choice.
+static inline float chorusSweepSamples(float depth01, float rate01, float sr)
+{
+    static const float kRefHz = 3.042f;          // setting 8 of fifteen
+    const float want = depth01 * 0.003f * sr * (kRefHz / chorusLfoHz(rate01));
+
+    // The swing cannot exceed the centre delay, and that is physics rather than
+    // a guard: the delay of a BBD is stages / (2 * clock), so it is positive by
+    // construction. A swing equal to the centre is already a 2:1 clock sweep,
+    // about as far as an MN3007 chorus goes. Without this the delay goes
+    // negative at the slow settings, the read index wraps to the far end of the
+    // line, and the output is garbage rather than chorus.
+    //
+    // At full depth the proportional law therefore holds from the fast end down
+    // to about 1.8 Hz and flattens below that. At the depth settings the factory
+    // patches actually use it holds further down.
+    const float centre = 0.005f * sr;
+    return want < centre ? want : centre;
+}
+
 // Configure all rate/coef-dependent parameters
 void RD_VintageFX::setSampleRate(float sr)
 {
@@ -111,7 +154,7 @@ void RD_VintageFX::setSampleRate(float sr)
     // CP3 for all fifteen settings, 2700 ms down to 175 ms. That is 0.370 to
     // 5.714 Hz, linear in the setting to within 3.7 %. The old 0.3..1.2 Hz was
     // nearly five times too slow at the top of the range.
-    chorusInc_ = (0.370f + 5.344f * chorusRate_) / sr;
+    chorusInc_ = chorusLfoHz(chorusRate_) / sr;
 
     // Phaser rate mapping: 0.1..5 Hz over normalized 0..1
     phRateHz_ = 0.1f * powf(10.0f, phaserRate_ * 1.69897000433601880479f);
@@ -119,7 +162,7 @@ void RD_VintageFX::setSampleRate(float sr)
 
     // Chorus delay centre + modulation depth in samples
     chorusBaseSamples_ = 0.005f * sr;
-    chorusModSamples_  = chorusDepth_ * 0.003f * sr;
+    chorusModSamples_  = chorusSweepSamples(chorusDepth_, chorusRate_, sr);
 
     // Clamp so interpolation stays within the delay buffer
     float maxDelay = (float)(kDelayLen - 4);
@@ -144,12 +187,20 @@ void RD_VintageFX::setParam(uint8_t id, float v01)
 
     case RD_PARAM_CHORUS_RATE:
         chorusRate_ = v01;
-        chorusInc_  = (0.370f + 5.344f * chorusRate_) / sampleRate_;  // see setSampleRate
+        chorusInc_  = chorusLfoHz(chorusRate_) / sampleRate_;
+        // The sweep width follows the rate now, so it has to be recomputed here too.
+        chorusModSamples_ = chorusSweepSamples(chorusDepth_, chorusRate_, sampleRate_);
+        {
+            float maxDelay = (float)(kDelayLen - 4);
+            if (chorusBaseSamples_ + chorusModSamples_ > maxDelay)
+                chorusModSamples_ = maxDelay - chorusBaseSamples_;
+            if (chorusModSamples_ < 0.0f) chorusModSamples_ = 0.0f;
+        }
         break;
 
     case RD_PARAM_CHORUS_DEPTH:
         chorusDepth_ = v01;
-        chorusModSamples_ = chorusDepth_ * 0.003f * sampleRate_;
+        chorusModSamples_ = chorusSweepSamples(chorusDepth_, chorusRate_, sampleRate_);
         {
             float maxDelay = (float)(kDelayLen - 4);
             if (chorusBaseSamples_ + chorusModSamples_ > maxDelay)

--- a/instruments/PicoFaceRD/src/rd_effects.cpp
+++ b/instruments/PicoFaceRD/src/rd_effects.cpp
@@ -75,8 +75,10 @@ void RD_VintageFX::init(float sampleRate)
     phA_     = 0.9f;
     phFb_    = 0.2f;
     phCnt_   = 0;
-    for (int i = 0; i < kPhaserStages; ++i) { phX1_[i] = 0.0f; phY1_[i] = 0.0f; }
-    phLast_  = 0.0f;
+    for (int c = 0; c < 2; ++c) {
+        for (int i = 0; i < kPhaserStages; ++i) { phX1_[c][i] = 0.0f; phY1_[c][i] = 0.0f; }
+        phLast_[c] = 0.0f;
+    }
 
     // Shelf gains derived from current bass_/treble_ params
     bassGain_   = powf(10.0f, (bass_   - 0.5f) * 18.0f / 20.0f) - 1.0f;
@@ -271,7 +273,7 @@ float RD_VintageFX::sinApprox(float phase01)
 void RAM_HOT(RD_VintageFX::process)(float in, float* outL, float* outR) {
     float x = in;
 
-    // 1. Vintage DAC: 12-bit requantization + 2-pole reconstruction lowpass.
+    // 1. Vintage DAC: 16-bit requantization + 2-pole reconstruction lowpass.
     //    FULLY gated -- bypassing must restore the clean signal (the old code
     //    ran the lowpass unconditionally, so the toggle did nothing audible).
     if (dacOn_ > 0.5f) {
@@ -298,15 +300,53 @@ void RAM_HOT(RD_VintageFX::process)(float in, float* outL, float* outR) {
     trebleLpState_ += trebleCoef_ * (x - trebleLpState_);
     x += trebleGain_ * (x - trebleLpState_);
 
-    // 4. Tremolo
-    if (tremOn_ > 0.5f) {
-        tremPhase_ += tremInc_;
-        if (tremPhase_ >= 1.0f) tremPhase_ -= 1.0f;
-        float g = 1.0f - tremDepth_ * 0.8f * (0.5f + 0.5f * sinApprox(tremPhase_));
-        x *= g;
+    // 4. Chorus (BBD), 5. phaser, 6. tremolo -- in that order, which is the
+    //    machines' own and the reverse of what stood here.
+    //
+    //    Both block diagrams run EQ -> chorus -> phaser -> tremolo/VCA -> out
+    //    (MKS-20 service notes p.4, MK-80 p.17; the MKS-20 has no phaser, so its
+    //    chain is chorus -> tremolo). The chain here ran tremolo -> phaser ->
+    //    chorus, so the tremolo went THROUGH the delay line: smeared over five
+    //    milliseconds and split unevenly across the two taps, where the original
+    //    applies it last and cleanly.
+    delay_[writeIdx_] = x;
+    float l, r;
+    if (chorusOn_ > 0.5f) {
+        chorusPhase_ += chorusInc_;
+        if (chorusPhase_ >= 1.0f) chorusPhase_ -= 1.0f;
+        float phB = chorusPhase_ + 0.5f;
+        if (phB >= 1.0f) phB -= 1.0f;
+
+        float delayA = chorusBaseSamples_ + chorusModSamples_ * triangle(chorusPhase_);
+        float delayB = chorusBaseSamples_ + chorusModSamples_ * triangle(phB);
+
+        float readPosA = writeIdx_ - delayA;
+        if (readPosA < 0.0f) readPosA += kDelayLen;
+        int i0A = (int)readPosA;
+        int i1A = (i0A + 1) & (kDelayLen - 1);
+        float fracA = readPosA - i0A;
+        float tapA = delay_[i0A] + fracA * (delay_[i1A] - delay_[i0A]);
+
+        float readPosB = writeIdx_ - delayB;
+        if (readPosB < 0.0f) readPosB += kDelayLen;
+        int i0B = (int)readPosB;
+        int i1B = (i0B + 1) & (kDelayLen - 1);
+        float fracB = readPosB - i0B;
+        float tapB = delay_[i0B] + fracB * (delay_[i1B] - delay_[i0B]);
+
+        bbdLpStateA_ += bbdLpCoef_ * (tapA - bbdLpStateA_);
+        bbdLpStateB_ += bbdLpCoef_ * (tapB - bbdLpStateB_);
+        l = (x + bbdLpStateA_) * 0.7f;
+        r = (x + bbdLpStateB_) * 0.7f;
+    } else {
+        l = x;
+        r = x;
     }
 
-    // 4b. Phaser (mono 4-stage allpass)
+    // 5. Phaser -- one per channel now, sharing the LFO. The MK-80 has two
+    //    (IC33 twice on the effect board, each inside its own NE572 compander),
+    //    and after the chorus the two sides are no longer the same signal, so a
+    //    single mono phaser has nothing coherent to work on.
     if (phaserOn_ > 0.5f) {
         if (++phCnt_ >= 8u) {
             phCnt_ = 0u;
@@ -319,56 +359,41 @@ void RAM_HOT(RD_VintageFX::process)(float in, float* outL, float* outR) {
         phPhase_ += phInc_;
         if (phPhase_ >= 1.0f) phPhase_ -= 1.0f;
 
-        float in = x + phFb_ * fastTanh(phLast_);
-        float sig = in;
-        for (int i = 0; i < kPhaserStages; ++i) {
-            float y = -phA_ * sig + phX1_[i] + phA_ * phY1_[i];
-            phX1_[i] = sig;
-            phY1_[i] = y;
-            sig = y;
+        float* ch[2] = { &l, &r };
+        for (int c = 0; c < 2; ++c) {
+            float sig = *ch[c] + phFb_ * fastTanh(phLast_[c]);
+            for (int i = 0; i < kPhaserStages; ++i) {
+                float y = -phA_ * sig + phX1_[c][i] + phA_ * phY1_[c][i];
+                phX1_[c][i] = sig;
+                phY1_[c][i] = y;
+                sig = y;
+            }
+            phLast_[c] = sig;
+            *ch[c] = 0.5f * *ch[c] + 0.5f * sig;
         }
-        phLast_ = sig;
-        x = 0.5f * x + 0.5f * sig;
     }
 
-    // 5. Chorus and Delay
-    delay_[writeIdx_] = x;
-    if (chorusOn_ > 0.5f) {
-        chorusPhase_ += chorusInc_;
-        if (chorusPhase_ >= 1.0f) chorusPhase_ -= 1.0f;
-        float phB = chorusPhase_ + 0.5f;
-        if (phB >= 1.0f) phB -= 1.0f;
-
-        // Calculate delays
-        float delayA = chorusBaseSamples_ + chorusModSamples_ * triangle(chorusPhase_);
-        float delayB = chorusBaseSamples_ + chorusModSamples_ * triangle(phB);
-
-        // Tap A
-        float readPosA = writeIdx_ - delayA;
-        if (readPosA < 0.0f) readPosA += kDelayLen;
-        int i0A = (int)readPosA;
-        int i1A = (i0A + 1) & (kDelayLen - 1);
-        float fracA = readPosA - i0A;
-        float tapA = delay_[i0A] + fracA * (delay_[i1A] - delay_[i0A]);
-
-        // Tap B
-        float readPosB = writeIdx_ - delayB;
-        if (readPosB < 0.0f) readPosB += kDelayLen;
-        int i0B = (int)readPosB;
-        int i1B = (i0B + 1) & (kDelayLen - 1);
-        float fracB = readPosB - i0B;
-        float tapB = delay_[i0B] + fracB * (delay_[i1B] - delay_[i0B]);
-
-        // BBD lowpass and output mix
-        bbdLpStateA_ += bbdLpCoef_ * (tapA - bbdLpStateA_);
-        *outL = (x + bbdLpStateA_) * 0.7f * volume_;
-
-        bbdLpStateB_ += bbdLpCoef_ * (tapB - bbdLpStateB_);
-        *outR = (x + bbdLpStateB_) * 0.7f * volume_;
-    } else {
-        *outL = x * volume_;
-        *outR = x * volume_;
+    // 6. Tremolo -- stereo and antiphase, which is what it is on the machine
+    //    rather than a stereo dressing. The MK-80 notes adjust the two VCAs
+    //    separately (VR8 for OUTPUT-L, VR9 for OUTPUT-R) and their scope trace
+    //    shows the two channels exactly interleaved: the right swells where the
+    //    left is at its trough. At full depth it is a pan, not a level wobble.
+    //
+    //    The trough goes to silence, too. The instruction is to set it "at
+    //    minimum level (possibly zero swing)", where the factor here used to
+    //    stop at 0.2 of full scale.
+    if (tremOn_ > 0.5f) {
+        tremPhase_ += tremInc_;
+        if (tremPhase_ >= 1.0f) tremPhase_ -= 1.0f;
+        float pR = tremPhase_ + 0.5f;
+        if (pR >= 1.0f) pR -= 1.0f;
+        l *= 1.0f - tremDepth_ * (0.5f + 0.5f * sinApprox(tremPhase_));
+        r *= 1.0f - tremDepth_ * (0.5f + 0.5f * sinApprox(pR));
     }
+
+    *outL = l * volume_;
+    *outR = r * volume_;
+
     writeIdx_ = (writeIdx_ + 1) & (kDelayLen - 1);
 }
 


### PR DESCRIPTION
From the MK-80 Service Notes (Roland, September 1989).

**Based on [#113](https://github.com/Michi71/PicoVintageSynthCollection/pull/113)** (same function). Independent of [#114](https://github.com/Michi71/PicoVintageSynthCollection/pull/114).

## Two agreements worth having

Before the corrections — the MK-80 notes let two checks run that could not run before:

- **The sample rates are right.** Both manuals give polyphony per voice, 16 or 10, and that split lands exactly on our rate table: every 16-voice sound is a 20 kHz patch, every 10-voice sound a 32 kHz one, sixteen for sixteen. The rates came out of ROM; two service manuals agree independently. (The *cap* was wrong — that is #114.)
- **The MK-80 uses the same converter and the same filter.** `PCM 54` and `LC Filter LPF 0538-014`, part number 12449269 in both parts lists. One reconstruction stage for both machines is correct, not merely convenient.

## The chain was back to front

Both block diagrams: `EQ → chorus → phaser → tremolo/VCA → out` (MKS-20 p.4, MK-80 p.17; the MKS-20 has no phaser, so its chain is chorus → tremolo).

This engine ran `tremolo → phaser → chorus`. So the tremolo went **through the delay line** — smeared over five milliseconds and split unevenly across the two taps — where the original applies it last and cleanly.

## And the tremolo is a pan, not a level wobble

The MK-80 notes adjust the two VCAs **separately** (VR8 for OUTPUT-L, VR9 for OUTPUT-R), and the scope trace for that step shows the two channels exactly interleaved: the right swells where the left is at its trough, each returning to the baseline.

Measured on the envelope of a 1 kHz tone at full depth:

| | L/R correlation | swing per channel | swing of the sum |
|---|---|---|---|
| before | **+1.000** | −14.0 dB | −14.0 dB |
| after | **−1.000** | −69.8 dB | **−0.0 dB** |

It used to pump the whole signal by 14 dB. It now moves it across the image at constant loudness. The trough reaching silence is from the same page — the instruction is to set it *"at minimum level (possibly zero swing)"*, where the factor here stopped at 0.2 of full scale.

The phaser runs **per channel** now, as it does on the board (IC33 twice, each inside its own NE572 compander). After the chorus the two sides are no longer the same signal, so one mono phaser has nothing coherent to work on.

## Cost

Measured on the host through the whole chain: **+5 %** with the phaser off, **+9 %** with it on. The host understates this kind of change, but the chain is a fraction of a percent of the render either way, and the phaser is off by default.

## Verification

All sixteen instruments with **every** effect on at full depth and the slowest chorus rate: **0 NaN**, peaks −6.8 to −11.9 dBFS. Firmware builds.

Untested by ear, and this is the one that will be most obvious: switch the tremolo on and it should move rather than pump.

## Noted, not acted on

The MK-80 has an `IR3109` VCF and the phaser; the MKS-20 has neither. Strictly the phaser should not be offered on MKS-20 patches at all. It is off by default and switchable, so this is cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)