### PR TITLE
RD: the chorus keeps its detune across the rate range, not its sweep width

### DIFF
--- a/instruments/PicoFaceRD/README.md
+++ b/instruments/PicoFaceRD/README.md
@@ -379,11 +379,40 @@ to 175 ms. That is 0.370 to 5.714 Hz, linear in the setting to within 3.7 %.
 The code had 0.3 to 1.2 Hz. Tremolo, tabulated the same way at CP4, was already
 right (0.476 to 7.69 Hz against 0.5 to 8.0).
 
-**Still open from the same tables:** the LFO amplitude at CP3 scales with the
-period at a constant 3.98 mV/ms (±9 % across all fifteen settings) -- a
-constant-slew triangle, so on the original a slower chorus sweeps
-proportionally wider. Rate and depth are independent here. That is a change in
-character rather than a corrected number, so it is not in this change.
+**The chorus keeps its detune, not its sweep.** The CP3 table gives the LFO
+amplitude as well as the period, and their ratio is constant at 3.98 mV/ms
+(±9 % across all fifteen settings) -- a triangle of constant slope, so the
+amplitude is proportional to the period. What that buys is not width for its
+own sake: a constant slope on the BBD clock control is a constant rate of
+change of delay, which is a constant pitch deviation. The original holds its
+detune and only changes how fast it wobbles.
+
+The model here held the delay swing constant instead, so the detune grew with
+the rate. Measured at full depth on the wet path, peak deviation of a 1 kHz
+tone:
+
+| setting | LFO | before | after |
+|---|---|---|---|
+| 0.00 | 0.370 Hz | ±16 ct | ±27 ct |
+| 0.25 | 1.706 Hz | ±76 ct | ±126 ct |
+| 0.50 | 3.042 Hz | ±135 ct | ±135 ct |
+| 0.75 | 4.378 Hz | ±195 ct | ±135 ct |
+| 1.00 | 5.714 Hz | ±255 ct | ±135 ct |
+
+Flat across the fast half to 0.3 ct, against a fifteen-fold spread before.
+Below about 1.8 Hz at full depth it flattens off, because the swing is clamped
+to the centre delay -- that is physics, not a guard: a BBD's delay is
+stages / (2 × clock) and cannot go negative, and a swing equal to the centre is
+already a 2:1 clock sweep. Without the clamp the read index wraps to the far
+end of the line and the output is garbage.
+
+Two things this does **not** settle. The absolute width is not derivable from
+the notes: the table gives volts at the LFO, and the volts-to-delay law lives
+in the MN3101 clock oscillator, which the schematic does not break out. The
+anchor is the middle setting, chosen so the familiar depth stays where it was.
+And the depth that anchor preserves is very deep for a chorus -- ±135 cents at
+full depth, where a Roland chorus of the period is usually a few tens of cents.
+That is pre-existing and the notes cannot decide it.
 
 ## ROM data & credits
 

--- a/instruments/PicoFaceRD/src/rd_effects.cpp
+++ b/instruments/PicoFaceRD/src/rd_effects.cpp
@@ -88,6 +88,49 @@ void RD_VintageFX::init(float sampleRate)
     setSampleRate(sampleRate);
 }
 
+
+// Chorus LFO frequency for a 0..1 setting, from the service notes' CP3 table.
+static inline float chorusLfoHz(float rate01)
+{
+    return 0.370f + 5.344f * rate01;
+}
+
+// Sweep width in samples. The CP3 table gives the LFO amplitude as well as the
+// period, and their ratio is constant at 3.98 mV/ms (+-9 % over all fifteen
+// settings) -- a triangle of constant slope. So the amplitude is proportional
+// to the period, and the sweep widens as the rate falls.
+//
+// What that buys is not width for its own sake. A constant slope on the BBD
+// clock control is a constant rate of change of delay, which is a constant
+// pitch deviation: the original holds its detune and only changes how fast it
+// wobbles. The model here used to hold the delay swing constant instead, so
+// the detune grew with the rate -- nearly none at the slow end, most at the
+// fast end. That is the opposite character.
+//
+// Anchored at the middle setting so the familiar depth stays where it was. The
+// absolute width is NOT derivable from the notes: the table gives volts at the
+// LFO, and the volts-to-delay law lives in the MN3101 clock oscillator, which
+// the schematic does not break out. Proportionality is measured; this anchor
+// is a choice.
+static inline float chorusSweepSamples(float depth01, float rate01, float sr)
+{
+    static const float kRefHz = 3.042f;          // setting 8 of fifteen
+    const float want = depth01 * 0.003f * sr * (kRefHz / chorusLfoHz(rate01));
+
+    // The swing cannot exceed the centre delay, and that is physics rather than
+    // a guard: the delay of a BBD is stages / (2 * clock), so it is positive by
+    // construction. A swing equal to the centre is already a 2:1 clock sweep,
+    // about as far as an MN3007 chorus goes. Without this the delay goes
+    // negative at the slow settings, the read index wraps to the far end of the
+    // line, and the output is garbage rather than chorus.
+    //
+    // At full depth the proportional law therefore holds from the fast end down
+    // to about 1.8 Hz and flattens below that. At the depth settings the factory
+    // patches actually use it holds further down.
+    const float centre = 0.005f * sr;
+    return want < centre ? want : centre;
+}
+
 // Configure all rate/coef-dependent parameters
 void RD_VintageFX::setSampleRate(float sr)
 {
@@ -111,7 +154,7 @@ void RD_VintageFX::setSampleRate(float sr)
     // CP3 for all fifteen settings, 2700 ms down to 175 ms. That is 0.370 to
     // 5.714 Hz, linear in the setting to within 3.7 %. The old 0.3..1.2 Hz was
     // nearly five times too slow at the top of the range.
-    chorusInc_ = (0.370f + 5.344f * chorusRate_) / sr;
+    chorusInc_ = chorusLfoHz(chorusRate_) / sr;
 
     // Phaser rate mapping: 0.1..5 Hz over normalized 0..1
     phRateHz_ = 0.1f * powf(10.0f, phaserRate_ * 1.69897000433601880479f);
@@ -119,7 +162,7 @@ void RD_VintageFX::setSampleRate(float sr)
 
     // Chorus delay centre + modulation depth in samples
     chorusBaseSamples_ = 0.005f * sr;
-    chorusModSamples_  = chorusDepth_ * 0.003f * sr;
+    chorusModSamples_  = chorusSweepSamples(chorusDepth_, chorusRate_, sr);
 
     // Clamp so interpolation stays within the delay buffer
     float maxDelay = (float)(kDelayLen - 4);
@@ -144,12 +187,20 @@ void RD_VintageFX::setParam(uint8_t id, float v01)
 
     case RD_PARAM_CHORUS_RATE:
         chorusRate_ = v01;
-        chorusInc_  = (0.370f + 5.344f * chorusRate_) / sampleRate_;  // see setSampleRate
+        chorusInc_  = chorusLfoHz(chorusRate_) / sampleRate_;
+        // The sweep width follows the rate now, so it has to be recomputed here too.
+        chorusModSamples_ = chorusSweepSamples(chorusDepth_, chorusRate_, sampleRate_);
+        {
+            float maxDelay = (float)(kDelayLen - 4);
+            if (chorusBaseSamples_ + chorusModSamples_ > maxDelay)
+                chorusModSamples_ = maxDelay - chorusBaseSamples_;
+            if (chorusModSamples_ < 0.0f) chorusModSamples_ = 0.0f;
+        }
         break;
 
     case RD_PARAM_CHORUS_DEPTH:
         chorusDepth_ = v01;
-        chorusModSamples_ = chorusDepth_ * 0.003f * sampleRate_;
+        chorusModSamples_ = chorusSweepSamples(chorusDepth_, chorusRate_, sampleRate_);
         {
             float maxDelay = (float)(kDelayLen - 4);
             if (chorusBaseSamples_ + chorusModSamples_ > maxDelay)


### PR DESCRIPTION
Supersedes [#113](https://github.com/Michi71/PicoVintageSynthCollection/pull/113), which GitHub auto-closed when its base branch was deleted on merging #112. Same commit, rebased onto `main`, no content change.

Second half of the MKS-20 Service Notes findings, kept separate from the two corrected numbers because this one changes **character** rather than fixing a value.

## What the table says

The CP3 adjustment table gives the LFO **amplitude** as well as the period, and their ratio is constant at **3.98 mV/ms (±9 % over all fifteen settings)**. That is a triangle of constant slope: the amplitude is proportional to the period, so the sweep widens as the rate falls.

The point is not width. A constant slope on the BBD clock control is a constant *rate of change of delay*, which is a **constant pitch deviation**. The original holds its detune and only changes how fast it wobbles. This model held the delay swing constant instead, so the detune grew with the rate — nearly none at the slow end, over a semitone at the fast end. Opposite character.

## Measured, at full depth, peak deviation of a 1 kHz tone on the wet path

| setting | LFO | before | after |
|---|---|---|---|
| 0.00 | 0.370 Hz | ±16 ct | ±27 ct |
| 0.25 | 1.706 Hz | ±76 ct | ±126 ct |
| 0.50 | 3.042 Hz | ±135 ct | ±135 ct |
| 0.75 | 4.378 Hz | ±195 ct | **±135 ct** |
| 1.00 | 5.714 Hz | ±255 ct | **±135 ct** |

Flat across the fast half to 0.3 ct, against a fifteen-fold spread before.

## The version of this that was wrong

Worth recording, because the measurement is what caught it. Tying the sweep to the period made the slow settings ask for **789 samples of swing about a 160-sample centre** — so the delay went negative, the read index wrapped to the far end of the line, and the detune reading came back `NaN`.

The swing is now clamped to the centre delay. That is physics, not a guard: a BBD's delay is `stages / (2 × clock)` and cannot be negative, and a swing equal to the centre is already a 2:1 clock sweep — about as far as an MN3007 goes. At full depth the law therefore holds from the fast end down to about 1.8 Hz and flattens below.

An earlier version enlarged `kDelayLen` to 1024 to avoid the clamp. With the physical clamp in place 512 is enough again, so that is reverted — no RAM change.

## What the notes do not settle

**The absolute width.** The table gives volts at the LFO; the volts-to-delay law lives in the MN3101 clock oscillator, which the schematic does not break out. The anchor is the middle setting, chosen so the familiar depth stays put — proportionality is measured, the anchor is a choice.

And that depth is **very deep for a chorus**: ±135 cents at full depth, where a Roland chorus of the period is usually a few tens of cents. That is pre-existing, the notes cannot decide it, and it is worth its own look.

## Verification

All sixteen instruments rendered with chorus on, full depth, slowest rate — the clamping case — **0 NaN**, peaks −0.25 to −10.6 dBFS. Firmware builds after the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)