### PR TITLE
RD: the effect chain runs the machines' way round, and the tremolo pans

### DIFF
--- a/instruments/PicoFaceRD/README.md
+++ b/instruments/PicoFaceRD/README.md
@@ -170,7 +170,7 @@ are, which is why they sit in `roms/` rather than in the tree.
 | Sounds | All 16 patches: MKS-20 (Piano 1–3, Harpsichord, Clavi, Vibraphone, E-Piano 1–2) and MK-80 (Classic, Special, Blend, Contemporary, A. Piano 1–2, Clavi, Vibraphone). A 4 MB build ships one machine's eight — see [Fitting a 4 MB Pico 2](#fitting-a-4-mb-pico-2) |
 | Engine | Timeline-replay of captured S/A voice programming; 10 parts per voice, chip-exact envelope math, native 20 kHz / 32 kHz per patch (no resampling) |
 | Polyphony | 8 / 16 / 24 / 32 voices or **Auto** — a load-adaptive voice governor with active culling (default; the original is 16-voice) |
-| Effects | Vintage DAC stage (12-bit requantization + 2-pole reconstruction filter), bass/treble shelves, tremolo, mono 4-stage phaser, stereo BBD-style chorus |
+| Effects | In the machines' own order: vintage DAC stage (16-bit requantization + 2-pole reconstruction filter), bass/treble shelves, stereo BBD-style chorus, 4-stage phaser per channel, antiphase stereo tremolo |
 | MIDI | USB and DIN MIDI, implementation modeled on the MK-80 MIDI implementation chart (sounding range 21–108 with octave folding, damper, FX switches CC 92/93/95, reset CC 121, all-notes-off CC 123, program change, pitch bend ±2 semitones) — see [doc/MIDI.md](doc/MIDI.md) and the collection's CC table in [docs/ARCHITECTURE.md](../../docs/ARCHITECTURE.md), section 6a |
 | Tuning | Master tune ±50 cents in 1-cent steps with live A4 frequency display |
 | Persistence | All panel settings in a wear-leveled flash append log (versioned, CRC-protected), auto-saved 2 s after the last edit while idle |
@@ -413,6 +413,59 @@ anchor is the middle setting, chosen so the familiar depth stays where it was.
 And the depth that anchor preserves is very deep for a chorus -- ±135 cents at
 full depth, where a Roland chorus of the period is usually a few tens of cents.
 That is pre-existing and the notes cannot decide it.
+
+### What the MK-80 notes added
+
+The MK-80 Service Notes (Roland, September 1989) arrived after the MKS-20 ones
+and mostly agreed with them -- which is itself worth having, because two of the
+agreements are checks that could not be run before.
+
+**The sample rates are right, confirmed twice.** Both manuals give polyphony
+per voice, 16 or 10. That split lands exactly on the rate table: every
+16-voice sound in either list is one of the 20 kHz patches, every 10-voice
+sound one of the 32 kHz ones, sixteen for sixteen. The rates came out of ROM;
+two service manuals agree with them independently. (The cap itself was wrong
+and is fixed separately -- 16 x 20000 = 10 x 32000 = 320000 voice slots per
+second, the S/A chip's fixed budget.)
+
+**The MK-80 uses the same converter and the same filter.** `PCM 54` and
+`LC Filter LPF 0538-014`, part number 12449269 in both parts lists. Giving both
+machines one reconstruction stage is correct rather than merely convenient.
+
+**The effect chain runs the other way round.** Both block diagrams are
+`EQ -> chorus -> phaser -> tremolo/VCA -> out` (MKS-20 p.4, MK-80 p.17; the
+MKS-20 has no phaser, so its chain is chorus -> tremolo). This engine ran
+`tremolo -> phaser -> chorus`, so the tremolo went *through* the delay line --
+smeared over five milliseconds and split unevenly across the two taps, where
+the original applies it last and cleanly.
+
+**And the tremolo is a pan, not a level wobble.** The MK-80 notes adjust the
+two VCAs separately (VR8 for OUTPUT-L, VR9 for OUTPUT-R) and the scope trace
+for that step shows the channels exactly interleaved: the right swells where
+the left is at its trough, each returning to the baseline. Measured before and
+after, envelope of a 1 kHz tone at full depth:
+
+| | L/R correlation | swing per channel | swing of the sum |
+|---|---|---|---|
+| before | **+1.000** | −14.0 dB | −14.0 dB |
+| after | **−1.000** | −69.8 dB | **−0.0 dB** |
+
+So it used to pump the whole signal by 14 dB and now moves it across the image
+at constant loudness. The trough reaching silence is from the same page: the
+instruction is to set it "at minimum level (possibly zero swing)", where the
+factor here stopped at 0.2 of full scale.
+
+The phaser is per channel now, as it is on the board (IC33 twice, each inside
+its own NE572 compander) -- after the chorus the two sides are no longer the
+same signal, so one mono phaser has nothing coherent to work on. Cost of the
+whole reordering, measured on the host: +5 % through the chain with the phaser
+off, +9 % with it on. The host understates it, as it always does for this kind
+of change, but the chain is a fraction of a percent of the render either way.
+
+One thing the MK-80 has that the MKS-20 does not, noted and not acted on: an
+`IR3109` VCF, and the phaser itself. Strictly the phaser should not be offered
+on MKS-20 patches at all. It is off by default and switchable, so this is
+cosmetic.
 
 ## ROM data & credits
 

--- a/instruments/PicoFaceRD/include/rd_effects.h
+++ b/instruments/PicoFaceRD/include/rd_effects.h
@@ -2,7 +2,9 @@
 // SPDX-FileCopyrightText: 2026 Michi71
 
 // RD_VintageFX: Vintage FX chain for MKS-20/MK-80 emulation.
-// Signal flow: in -> DAC filter -> bass shelf -> treble shelf -> tremolo -> BBD chorus (stereo) -> volume.
+// Signal flow: in -> DAC filter -> bass shelf -> treble shelf -> BBD chorus (stereo)
+//              -> phaser (one per channel) -> tremolo (stereo, antiphase) -> volume.
+// That order is the machines' own -- see rd_effects.cpp.
 // Mono in / stereo out. Native rate 20000/32000 Hz. RP2350 optimized.
 
 #ifndef RD_EFFECTS_H
@@ -61,9 +63,9 @@ private:
     float    phA_;                     // current allpass coefficient
     float    phFb_;                    // current feedback
     uint32_t phCnt_;                   // 8-sample coefficient decimation counter
-    float    phX1_[kPhaserStages];     // APF input history
-    float    phY1_[kPhaserStages];     // APF output history
-    float    phLast_;                  // last feedback sample
+    float    phX1_[2][kPhaserStages];  // APF input history, per channel
+    float    phY1_[2][kPhaserStages];  // APF output history, per channel
+    float    phLast_[2];               // last feedback sample, per channel
 
     // Chorus
     static constexpr int kDelayLen = 512;

--- a/instruments/PicoFaceRD/src/rd_effects.cpp
+++ b/instruments/PicoFaceRD/src/rd_effects.cpp
@@ -75,8 +75,10 @@ void RD_VintageFX::init(float sampleRate)
     phA_     = 0.9f;
     phFb_    = 0.2f;
     phCnt_   = 0;
-    for (int i = 0; i < kPhaserStages; ++i) { phX1_[i] = 0.0f; phY1_[i] = 0.0f; }
-    phLast_  = 0.0f;
+    for (int c = 0; c < 2; ++c) {
+        for (int i = 0; i < kPhaserStages; ++i) { phX1_[c][i] = 0.0f; phY1_[c][i] = 0.0f; }
+        phLast_[c] = 0.0f;
+    }
 
     // Shelf gains derived from current bass_/treble_ params
     bassGain_   = powf(10.0f, (bass_   - 0.5f) * 18.0f / 20.0f) - 1.0f;
@@ -271,7 +273,7 @@ float RD_VintageFX::sinApprox(float phase01)
 void RAM_HOT(RD_VintageFX::process)(float in, float* outL, float* outR) {
     float x = in;
 
-    // 1. Vintage DAC: 12-bit requantization + 2-pole reconstruction lowpass.
+    // 1. Vintage DAC: 16-bit requantization + 2-pole reconstruction lowpass.
     //    FULLY gated -- bypassing must restore the clean signal (the old code
     //    ran the lowpass unconditionally, so the toggle did nothing audible).
     if (dacOn_ > 0.5f) {
@@ -298,15 +300,53 @@ void RAM_HOT(RD_VintageFX::process)(float in, float* outL, float* outR) {
     trebleLpState_ += trebleCoef_ * (x - trebleLpState_);
     x += trebleGain_ * (x - trebleLpState_);
 
-    // 4. Tremolo
-    if (tremOn_ > 0.5f) {
-        tremPhase_ += tremInc_;
-        if (tremPhase_ >= 1.0f) tremPhase_ -= 1.0f;
-        float g = 1.0f - tremDepth_ * 0.8f * (0.5f + 0.5f * sinApprox(tremPhase_));
-        x *= g;
+    // 4. Chorus (BBD), 5. phaser, 6. tremolo -- in that order, which is the
+    //    machines' own and the reverse of what stood here.
+    //
+    //    Both block diagrams run EQ -> chorus -> phaser -> tremolo/VCA -> out
+    //    (MKS-20 service notes p.4, MK-80 p.17; the MKS-20 has no phaser, so its
+    //    chain is chorus -> tremolo). The chain here ran tremolo -> phaser ->
+    //    chorus, so the tremolo went THROUGH the delay line: smeared over five
+    //    milliseconds and split unevenly across the two taps, where the original
+    //    applies it last and cleanly.
+    delay_[writeIdx_] = x;
+    float l, r;
+    if (chorusOn_ > 0.5f) {
+        chorusPhase_ += chorusInc_;
+        if (chorusPhase_ >= 1.0f) chorusPhase_ -= 1.0f;
+        float phB = chorusPhase_ + 0.5f;
+        if (phB >= 1.0f) phB -= 1.0f;
+
+        float delayA = chorusBaseSamples_ + chorusModSamples_ * triangle(chorusPhase_);
+        float delayB = chorusBaseSamples_ + chorusModSamples_ * triangle(phB);
+
+        float readPosA = writeIdx_ - delayA;
+        if (readPosA < 0.0f) readPosA += kDelayLen;
+        int i0A = (int)readPosA;
+        int i1A = (i0A + 1) & (kDelayLen - 1);
+        float fracA = readPosA - i0A;
+        float tapA = delay_[i0A] + fracA * (delay_[i1A] - delay_[i0A]);
+
+        float readPosB = writeIdx_ - delayB;
+        if (readPosB < 0.0f) readPosB += kDelayLen;
+        int i0B = (int)readPosB;
+        int i1B = (i0B + 1) & (kDelayLen - 1);
+        float fracB = readPosB - i0B;
+        float tapB = delay_[i0B] + fracB * (delay_[i1B] - delay_[i0B]);
+
+        bbdLpStateA_ += bbdLpCoef_ * (tapA - bbdLpStateA_);
+        bbdLpStateB_ += bbdLpCoef_ * (tapB - bbdLpStateB_);
+        l = (x + bbdLpStateA_) * 0.7f;
+        r = (x + bbdLpStateB_) * 0.7f;
+    } else {
+        l = x;
+        r = x;
     }
 
-    // 4b. Phaser (mono 4-stage allpass)
+    // 5. Phaser -- one per channel now, sharing the LFO. The MK-80 has two
+    //    (IC33 twice on the effect board, each inside its own NE572 compander),
+    //    and after the chorus the two sides are no longer the same signal, so a
+    //    single mono phaser has nothing coherent to work on.
     if (phaserOn_ > 0.5f) {
         if (++phCnt_ >= 8u) {
             phCnt_ = 0u;
@@ -319,56 +359,41 @@ void RAM_HOT(RD_VintageFX::process)(float in, float* outL, float* outR) {
         phPhase_ += phInc_;
         if (phPhase_ >= 1.0f) phPhase_ -= 1.0f;
 
-        float in = x + phFb_ * fastTanh(phLast_);
-        float sig = in;
-        for (int i = 0; i < kPhaserStages; ++i) {
-            float y = -phA_ * sig + phX1_[i] + phA_ * phY1_[i];
-            phX1_[i] = sig;
-            phY1_[i] = y;
-            sig = y;
+        float* ch[2] = { &l, &r };
+        for (int c = 0; c < 2; ++c) {
+            float sig = *ch[c] + phFb_ * fastTanh(phLast_[c]);
+            for (int i = 0; i < kPhaserStages; ++i) {
+                float y = -phA_ * sig + phX1_[c][i] + phA_ * phY1_[c][i];
+                phX1_[c][i] = sig;
+                phY1_[c][i] = y;
+                sig = y;
+            }
+            phLast_[c] = sig;
+            *ch[c] = 0.5f * *ch[c] + 0.5f * sig;
         }
-        phLast_ = sig;
-        x = 0.5f * x + 0.5f * sig;
     }
 
-    // 5. Chorus and Delay
-    delay_[writeIdx_] = x;
-    if (chorusOn_ > 0.5f) {
-        chorusPhase_ += chorusInc_;
-        if (chorusPhase_ >= 1.0f) chorusPhase_ -= 1.0f;
-        float phB = chorusPhase_ + 0.5f;
-        if (phB >= 1.0f) phB -= 1.0f;
-
-        // Calculate delays
-        float delayA = chorusBaseSamples_ + chorusModSamples_ * triangle(chorusPhase_);
-        float delayB = chorusBaseSamples_ + chorusModSamples_ * triangle(phB);
-
-        // Tap A
-        float readPosA = writeIdx_ - delayA;
-        if (readPosA < 0.0f) readPosA += kDelayLen;
-        int i0A = (int)readPosA;
-        int i1A = (i0A + 1) & (kDelayLen - 1);
-        float fracA = readPosA - i0A;
-        float tapA = delay_[i0A] + fracA * (delay_[i1A] - delay_[i0A]);
-
-        // Tap B
-        float readPosB = writeIdx_ - delayB;
-        if (readPosB < 0.0f) readPosB += kDelayLen;
-        int i0B = (int)readPosB;
-        int i1B = (i0B + 1) & (kDelayLen - 1);
-        float fracB = readPosB - i0B;
-        float tapB = delay_[i0B] + fracB * (delay_[i1B] - delay_[i0B]);
-
-        // BBD lowpass and output mix
-        bbdLpStateA_ += bbdLpCoef_ * (tapA - bbdLpStateA_);
-        *outL = (x + bbdLpStateA_) * 0.7f * volume_;
-
-        bbdLpStateB_ += bbdLpCoef_ * (tapB - bbdLpStateB_);
-        *outR = (x + bbdLpStateB_) * 0.7f * volume_;
-    } else {
-        *outL = x * volume_;
-        *outR = x * volume_;
+    // 6. Tremolo -- stereo and antiphase, which is what it is on the machine
+    //    rather than a stereo dressing. The MK-80 notes adjust the two VCAs
+    //    separately (VR8 for OUTPUT-L, VR9 for OUTPUT-R) and their scope trace
+    //    shows the two channels exactly interleaved: the right swells where the
+    //    left is at its trough. At full depth it is a pan, not a level wobble.
+    //
+    //    The trough goes to silence, too. The instruction is to set it "at
+    //    minimum level (possibly zero swing)", where the factor here used to
+    //    stop at 0.2 of full scale.
+    if (tremOn_ > 0.5f) {
+        tremPhase_ += tremInc_;
+        if (tremPhase_ >= 1.0f) tremPhase_ -= 1.0f;
+        float pR = tremPhase_ + 0.5f;
+        if (pR >= 1.0f) pR -= 1.0f;
+        l *= 1.0f - tremDepth_ * (0.5f + 0.5f * sinApprox(tremPhase_));
+        r *= 1.0f - tremDepth_ * (0.5f + 0.5f * sinApprox(pR));
     }
+
+    *outL = l * volume_;
+    *outR = r * volume_;
+
     writeIdx_ = (writeIdx_ + 1) & (kDelayLen - 1);
 }
 


### PR DESCRIPTION
Supersedes [#115](https://github.com/Michi71/PicoVintageSynthCollection/pull/115), which GitHub auto-closed when its base branch was deleted on merge. Same commit, rebased onto `main`, no content change.

From the MK-80 Service Notes (Roland, September 1989).

## Two agreements worth having

Before the corrections — the MK-80 notes let two checks run that could not run before:

- **The sample rates are right.** Both manuals give polyphony per voice, 16 or 10, and that split lands exactly on our rate table: every 16-voice sound is a 20 kHz patch, every 10-voice sound a 32 kHz one, sixteen for sixteen. The rates came out of ROM; two service manuals agree independently. (The *cap* was wrong — that was #114.)
- **The MK-80 uses the same converter and the same filter.** `PCM 54` and `LC Filter LPF 0538-014`, part number 12449269 in both parts lists. One reconstruction stage for both machines is correct, not merely convenient.

## The chain was back to front

Both block diagrams: `EQ → chorus → phaser → tremolo/VCA → out` (MKS-20 p.4, MK-80 p.17; the MKS-20 has no phaser, so its chain is chorus → tremolo).

This engine ran `tremolo → phaser → chorus`. So the tremolo went **through the delay line** — smeared over five milliseconds and split unevenly across the two taps — where the original applies it last and cleanly.

## And the tremolo is a pan, not a level wobble

The MK-80 notes adjust the two VCAs **separately** (VR8 for OUTPUT-L, VR9 for OUTPUT-R), and the scope trace for that step shows the two channels exactly interleaved: the right swells where the left is at its trough, each returning to the baseline.

Measured on the envelope of a 1 kHz tone at full depth:

| | L/R correlation | swing per channel | swing of the sum |
|---|---|---|---|
| before | **+1.000** | −14.0 dB | −14.0 dB |
| after | **−1.000** | −69.8 dB | **−0.0 dB** |

It used to pump the whole signal by 14 dB. It now moves it across the image at constant loudness. The trough reaching silence is from the same page — the instruction is to set it *"at minimum level (possibly zero swing)"*, where the factor here stopped at 0.2 of full scale.

The phaser runs **per channel** now, as it does on the board (IC33 twice, each inside its own NE572 compander). After the chorus the two sides are no longer the same signal, so one mono phaser has nothing coherent to work on.

## Cost

Measured on the host through the whole chain: **+5 %** with the phaser off, **+9 %** with it on. The host understates this kind of change, but the chain is a fraction of a percent of the render either way, and the phaser is off by default.

## Verification

All sixteen instruments with **every** effect on at full depth and the slowest chorus rate: **0 NaN**, peaks −6.8 to −11.9 dBFS. Firmware builds after the rebase.

Untested by ear, and this is the one that will be most obvious: switch the tremolo on and it should move rather than pump.

## Noted, not acted on

The MK-80 has an `IR3109` VCF and the phaser; the MKS-20 has neither. Strictly the phaser should not be offered on MKS-20 patches at all. It is off by default and switchable, so this is cosmetic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)