### PR TITLE
RD: the effect pages say Hz, and the tremolo page says what it now does

### DIFF
--- a/instruments/PicoFaceRD/README.md
+++ b/instruments/PicoFaceRD/README.md
@@ -207,13 +207,19 @@ Encoder **Select** switches the page (with wrap-around), encoders **A** and **B*
 | Page | Encoder A | Encoder B |
 |---|---|---|
 | PATCH | Instrument 1–16 (header shows the bank: `MKS-20` / `MK-80`) | Volume |
-| CHORUS | Depth (0 % = off) | Rate |
-| TREMOLO | Depth (0 % = off) | Rate |
-| PHASER | Depth (0 % = off) | Rate (0.1–5 Hz) |
+| CHORUS | Depth (0 % = off) | Rate, shown in Hz (0.37–5.71) |
+| TREMOLO | **Pan** (0 % = off) — it moves the image, it does not dip the level | Rate, shown in Hz (0.48–7.70) |
+| PHASER | Depth (0 % = off) | Rate, shown in Hz (0.10–5.00) |
 | EQ | Bass (50 % = neutral) | Treble (50 % = neutral) |
 | VOICES | Polyphony 8/16/24/32/**Auto** | — (line B shows live `Act <active>/<limit>`) |
 | TUNE | Master tune ±50 cents | — (line B shows the resulting A4 frequency) |
 | SYS | Vintage DAC filter ON/OFF | MIDI receive channel 1–16 / Omni |
+
+The chorus and tremolo rates are shown in Hz because the figures mean something:
+both service manuals tabulate the LFO period for all fifteen settings, and the
+laws live in one place (`rd_params.h`) so the display cannot drift away from the
+thing it is describing. Verified against the engine: 0.9 % at the slowest
+setting, 0.2 % elsewhere.
 
 The footer shows a live diagnostics line: `<instrument> P<peak-load %> U<buffer underruns> D<dropped events> A<active voices> N<note-on count>`.
 

--- a/instruments/PicoFaceRD/include/rd_params.h
+++ b/instruments/PicoFaceRD/include/rd_params.h
@@ -4,6 +4,8 @@
 #ifndef RD_PARAMS_H
 #define RD_PARAMS_H
 
+#include <cmath>
+
 #include <stdint.h>
 
 // How many patches this build ships, and which patch number it starts at.
@@ -26,5 +28,21 @@
  * RD_PARAM_INSTRUMENT=0x7F lives separately in RD_Midi.h
  */
 enum RdParamId : uint8_t { RD_PARAM_VOLUME=0, RD_PARAM_CHORUS_ON, RD_PARAM_CHORUS_RATE, RD_PARAM_CHORUS_DEPTH, RD_PARAM_TREM_ON, RD_PARAM_TREM_RATE, RD_PARAM_TREM_DEPTH, RD_PARAM_BASS, RD_PARAM_TREBLE, RD_PARAM_DAC_FILTER_ON, RD_PARAM_PHASER_ON, RD_PARAM_PHASER_RATE, RD_PARAM_PHASER_DEPTH, RD_PARAM_VOICE_MODE, RD_PARAM_MASTER_TUNE, RD_PARAM_COUNT };
+
+/*
+ * LFO rate laws, in Hz, for a 0..1 setting. One place, because the audio engine
+ * sets the LFOs from these and the display prints them -- and a display that
+ * disagrees with the thing it is describing is worse than one that says nothing.
+ *
+ * Chorus and tremolo are measured: both service manuals tabulate the LFO period
+ * at a test point for all fifteen settings (MKS-20 p.7 at CP3 and CP4, MK-80 the
+ * same). Chorus 2700..175 ms is 0.370..5.714 Hz, linear in the setting to within
+ * 3.7 %; tremolo 2100..130 ms is 0.476..7.692 Hz, linear to within 5.2 %. The
+ * phaser is not in either table -- it is an MK-80 effect and its range here is
+ * ours, an exponential decade and a half.
+ */
+static inline float rd_chorus_rate_hz(float x01) { return 0.370f + 5.344f * x01; }
+static inline float rd_trem_rate_hz  (float x01) { return 0.476f + 7.224f * x01; }
+static inline float rd_phaser_rate_hz(float x01) { return 0.1f * powf(10.0f, 1.69897000433601880479f * x01); }
 
 #endif // RD_PARAMS_H

--- a/instruments/PicoFaceRD/src/RD_Controller.cpp
+++ b/instruments/PicoFaceRD/src/RD_Controller.cpp
@@ -254,7 +254,7 @@ const char *RD_Controller::param2Name() const {
     switch (page_) {
         case RdPage::PATCH:   return "Instr";
         case RdPage::CHORUS:  return "Depth";
-        case RdPage::TREMOLO: return "Depth";
+        case RdPage::TREMOLO: return "Pan";   // it moves the image, it does not dip the level
         case RdPage::PHASER:  return "Depth";
         case RdPage::EQ:      return "Bass";
         case RdPage::VOICES:  return "Voices";

--- a/instruments/PicoFaceRD/src/RD_Instrument.cpp
+++ b/instruments/PicoFaceRD/src/RD_Instrument.cpp
@@ -217,6 +217,22 @@ private:
             } else {
                 snprintf(m.lineB, sizeof(m.lineB), "MIDI Ch %d", (int) controller_.param3Value() + 1);
             }
+        } else if (controller_.currentPage() == RdPage::CHORUS ||
+                   controller_.currentPage() == RdPage::TREMOLO ||
+                   controller_.currentPage() == RdPage::PHASER) {
+            // Rates in Hz rather than percent. Two of the three are measured
+            // figures out of the service notes rather than a scale of our own
+            // (see rd_params.h), so the number means something -- and the TUNE
+            // page already sets the precedent of showing the physical value.
+            const float x = (float) controller_.param3Value() * 0.01f;
+            float hz;
+            switch (controller_.currentPage()) {
+                case RdPage::CHORUS:  hz = rd_chorus_rate_hz(x); break;
+                case RdPage::TREMOLO: hz = rd_trem_rate_hz(x);   break;
+                default:              hz = rd_phaser_rate_hz(x); break;
+            }
+            snprintf(m.lineA, sizeof(m.lineA), "%s %d%%", controller_.param2Name(), (int) controller_.param2Value());
+            snprintf(m.lineB, sizeof(m.lineB), "%s %.2fHz", controller_.param3Name(), (double) hz);
         } else {
             // Continuous params are stored as percent (0..100).
             snprintf(m.lineA, sizeof(m.lineA), "%s %d%%", controller_.param2Name(), (int) controller_.param2Value());

--- a/instruments/PicoFaceRD/src/rd_effects.cpp
+++ b/instruments/PicoFaceRD/src/rd_effects.cpp
@@ -94,7 +94,7 @@ void RD_VintageFX::init(float sampleRate)
 // Chorus LFO frequency for a 0..1 setting, from the service notes' CP3 table.
 static inline float chorusLfoHz(float rate01)
 {
-    return 0.370f + 5.344f * rate01;
+    return rd_chorus_rate_hz(rate01);          // law lives in rd_params.h
 }
 
 // Sweep width in samples. The CP3 table gives the LFO amplitude as well as the
@@ -149,7 +149,11 @@ void RD_VintageFX::setSampleRate(float sr)
     bbdLpCoef_ = onePoleCoef(fminf(6000.0f, 0.4f * sr), sr);
 
     // Tremolo LFO: 0.5..8 Hz
-    tremInc_ = (0.5f + 7.5f * tremRate_) / sr;
+    // Measured like the chorus: the CP4 table runs 2100 ms down to 130 ms, which
+    // is 0.476..7.692 Hz. The 0.5..8.0 that stood here was up to 9.8 % out; the
+    // measured fit halves that and hits both ends exactly. It also has to be
+    // right now that the display prints the figure.
+    tremInc_ = rd_trem_rate_hz(tremRate_) / sr;
 
     // Chorus LFO: 0.3..1.2 Hz
     // Measured, not guessed: the service notes tabulate the chorus LFO period at
@@ -159,7 +163,7 @@ void RD_VintageFX::setSampleRate(float sr)
     chorusInc_ = chorusLfoHz(chorusRate_) / sr;
 
     // Phaser rate mapping: 0.1..5 Hz over normalized 0..1
-    phRateHz_ = 0.1f * powf(10.0f, phaserRate_ * 1.69897000433601880479f);
+    phRateHz_ = rd_phaser_rate_hz(phaserRate_);
     phInc_    = phRateHz_ / sr;
 
     // Chorus delay centre + modulation depth in samples
@@ -218,7 +222,7 @@ void RD_VintageFX::setParam(uint8_t id, float v01)
 
     case RD_PARAM_TREM_RATE:
         tremRate_ = v01;
-        tremInc_  = (0.5f + 7.5f * tremRate_) / sampleRate_;
+        tremInc_  = rd_trem_rate_hz(tremRate_) / sampleRate_;
         break;
 
     case RD_PARAM_TREM_DEPTH:
@@ -245,7 +249,7 @@ void RD_VintageFX::setParam(uint8_t id, float v01)
 
     case RD_PARAM_PHASER_RATE:
         phaserRate_ = v01;
-        phRateHz_   = 0.1f * powf(10.0f, phaserRate_ * 1.69897000433601880479f);
+        phRateHz_   = rd_phaser_rate_hz(phaserRate_);
         phInc_      = phRateHz_ / sampleRate_;
         break;
 


### PR DESCRIPTION
Michael asked whether the menus were adjusted along with the effect chain. The question has two halves and they get different answers.

## The page order needs nothing

`PATCH → CHORUS → TREMOLO → PHASER → EQ → VOICES → TUNE → SYS`.

That never mirrored the signal chain — **EQ sits fourth and is the first stage** — so it did not become wrong when the chain was reordered. Rebuilding it around the chain now would only move pages out from under the fingers for no gain. Left alone.

## Two readouts had gone stale

**The tremolo page still said "Depth".** True when it modulated level; misleading now that it pans at constant loudness. Someone reading `Depth 80%` expects the volume to move. It says **`Pan`**.

**The rates were percent when the real figures are known.** Both service manuals tabulate the LFO period for all fifteen settings at a test point, so chorus and tremolo have *measured* laws rather than scales of our own — and the TUNE page already sets the precedent of printing the physical value (`A4 440.0Hz`).

What the three pages render now:

| page | line A | line B |
|---|---|---|
| CHORUS | `Depth 50%` | `Rate 3.04Hz` (0.37 – 5.71) |
| TREMOLO | `Pan 50%` | `Rate 4.09Hz` (0.48 – 7.70) |
| PHASER | `Depth 50%` | `Rate 0.71Hz` (0.10 – 5.00) |

## One correction it forced

The tremolo rate here was `0.5 … 8.0 Hz` against the CP4 table's `0.476 … 7.692` — up to **9.8 %** out. Tolerable while nobody printed it; not tolerable on a display. Refitted to the table (worst case 5.2 %, both ends exact).

The three rate laws moved into `rd_params.h` so the engine and the display read the same line. A display that disagrees with the thing it describes is worse than one that says nothing.

## Verification

- **Widths checked, not assumed.** Body font is `8x13B`, fifteen characters fit; the widest line any page can produce is eleven (`Rate 7.70Hz`).
- **Engine measured against the printed figure**: 0.9 % at the slowest setting, 0.2 % elsewhere. The first attempt read 14.7 % at 0.476 Hz — that was three LFO cycles in a six-second render, not a fault.
- Firmware builds.

Untested by ear; this is a display change plus a 4 % shift at the top of the tremolo rate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)