### PR TITLE
RD: the chorus detunes like a chorus, not like a vibrato

### DIFF
--- a/instruments/PicoFaceRD/README.md
+++ b/instruments/PicoFaceRD/README.md
@@ -414,7 +414,30 @@ end of the line and the output is garbage.
 
 The absolute width is not derivable from the notes -- the table gives volts at
 the LFO, and the volts-to-delay law lives in the MN3101 clock oscillator, which
-the schematic does not break out. So the anchor is a judgement, and it has been
+the schematic does not break out.
+
+**A period-correct bound, from a different Roland schematic.** A review of the
+MKS-20 describes its chorus as sounding like "a fat CE-1", and the Boss CE-1
+(ET-10D) service schematic is available -- and annotated. Test point G sits on
+the line from the Q3-Q6 multivibrator to pin 2 of IC-2, which is the BBD clock,
+and it is marked **5 µs to 16 µs**. A BBD delays by stages / (2 x clock), so
+with the CE-1's MN3002 at 512 stages that is 1.28 to 4.10 ms; the MKS-20's
+MN3007 has twice the stages, so the same clock range gives it **2.56 to
+8.19 ms**.
+
+Two things follow, neither of which the MKS-20's own notes could give:
+
+- The 5 ms centre delay used here sits inside that window and close to its
+  middle (5.38 ms). It had been simply chosen.
+- The sweep before this change was ±3 ms, which is 6 ms peak to peak -- **106 %
+  of the entire VCO span**, wider than the part can travel at all, and that span
+  covers the CE-1's deeper vibrato mode as well as its chorus. ±0.7 ms is 25 %
+  of it, which is where a chorus rather than a vibrato belongs.
+
+Stated as a dependency: the schematic names the ICs but not their stage counts,
+so 512 for the MN3002 and 1024 for the MN3007 come from the parts rather than
+from the drawing. Were the MN3002 a 1024-stage device the windows would double
+and the "wider than the part can travel" reading would soften to about half. So the anchor is a judgement, and it has been
 made twice. It first preserved whatever depth this engine already had, which
 measured 132 cents of peak detune at full depth and 67 at the shipped default
 of 50 %. Two thirds of a semitone is not a chorus, and hardware testing said so.

--- a/instruments/PicoFaceRD/README.md
+++ b/instruments/PicoFaceRD/README.md
@@ -412,13 +412,15 @@ stages / (2 × clock) and cannot go negative, and a swing equal to the centre is
 already a 2:1 clock sweep. Without the clamp the read index wraps to the far
 end of the line and the output is garbage.
 
-Two things this does **not** settle. The absolute width is not derivable from
-the notes: the table gives volts at the LFO, and the volts-to-delay law lives
-in the MN3101 clock oscillator, which the schematic does not break out. The
-anchor is the middle setting, chosen so the familiar depth stays where it was.
-And the depth that anchor preserves is very deep for a chorus -- ±135 cents at
-full depth, where a Roland chorus of the period is usually a few tens of cents.
-That is pre-existing and the notes cannot decide it.
+The absolute width is not derivable from the notes -- the table gives volts at
+the LFO, and the volts-to-delay law lives in the MN3101 clock oscillator, which
+the schematic does not break out. So the anchor is a judgement, and it has been
+made twice. It first preserved whatever depth this engine already had, which
+measured 132 cents of peak detune at full depth and 67 at the shipped default
+of 50 %. Two thirds of a semitone is not a chorus, and hardware testing said so.
+It is now 31 cents at full depth and 16 at the default, which puts the whole
+range inside the 10-to-30 a BBD chorus of the period sits in, with the default
+in the middle of it. Set by ear against what the part can plausibly do.
 
 ### What the MK-80 notes added
 

--- a/instruments/PicoFaceRD/src/rd_effects.cpp
+++ b/instruments/PicoFaceRD/src/rd_effects.cpp
@@ -109,15 +109,27 @@ static inline float chorusLfoHz(float rate01)
 // the detune grew with the rate -- nearly none at the slow end, most at the
 // fast end. That is the opposite character.
 //
-// Anchored at the middle setting so the familiar depth stays where it was. The
-// absolute width is NOT derivable from the notes: the table gives volts at the
-// LFO, and the volts-to-delay law lives in the MN3101 clock oscillator, which
-// the schematic does not break out. Proportionality is measured; this anchor
-// is a choice.
+// The absolute width is NOT derivable from the notes: the table gives volts at
+// the LFO, and the volts-to-delay law lives in the MN3101 clock oscillator,
+// which the schematic does not break out. Proportionality is measured; the
+// anchor is a judgement, and it has now been made twice.
+//
+// It first preserved whatever depth this engine already had, which measured
+// 132 cents of peak detune at full depth and 67 at the shipped default of
+// 50 %. Two thirds of a semitone is not a chorus, it is a vibrato, and Michael
+// said so on hardware -- "sehr verstimmt, ich kann nicht glauben, dass das so
+// in echt war". He is right, and the number that preserved it was never
+// evidence, only inertia.
+//
+// 0.0007 puts full depth at about 31 cents and the default at 15. A BBD chorus
+// of the period -- Juno, Dimension D -- sits around 10 to 30, so the whole
+// range now lands inside that band with the default in the middle of it. Set by
+// ear against what the part can plausibly do, not by the manuals, which cannot
+// settle it. Easy to move if it wants moving.
 static inline float chorusSweepSamples(float depth01, float rate01, float sr)
 {
     static const float kRefHz = 3.042f;          // setting 8 of fifteen
-    const float want = depth01 * 0.003f * sr * (kRefHz / chorusLfoHz(rate01));
+    const float want = depth01 * 0.0007f * sr * (kRefHz / chorusLfoHz(rate01));
 
     // The swing cannot exceed the centre delay, and that is physics rather than
     // a guard: the delay of a BBD is stages / (2 * clock), so it is positive by


### PR DESCRIPTION
Hardware test: *"der chorus klingt schon sehr verstimmt. ich kann nicht glauben, dass das so in echt war."*

He is right. This was the open question flagged in [#116](https://github.com/Michi71/PicoVintageSynthCollection/pull/116) and left there for want of evidence either way.

## Why the manuals could not settle it

The CP3 table gives **volts at the LFO**; the volts-to-delay law lives in the MN3101 clock oscillator, which the schematic does not break out. So the *proportionality* is measured but the *absolute width* is a judgement — and the judgement made last time was simply to preserve whatever this engine already had.

Measured, that was:

| depth | rate | before | after |
|---|---|---|---|
| 50 % | 0.40 | **67 ct** | **16 ct** ← the shipped default |
| 100 % | 0.40 | 132 ct | 31 ct |
| 100 % | 1.00 | 132 ct | 32 ct |
| 100 % | 0.00 | 27 ct | 27 ct ← slowest, where the clamp still binds |

Two thirds of a semitone at the default is not a chorus, it is a vibrato. Preserving it was inertia, not evidence.

`0.0007` in place of `0.003` puts full depth at ~31 cents and the default at 16. A BBD chorus of the period — Juno, Dimension D — sits around 10 to 30 cents, so the whole range now lands inside that band with the default in the middle of it. Set by ear against what the part can plausibly do, which is the only authority available here, and trivially moved if it wants moving.

## A side effect worth having

The sweep-to-centre clamp now binds only at the **very slowest setting at full depth**, where it used to bind below 1.8 Hz. So the constant-detune law from #116 now holds across almost the whole rate range instead of half of it — visible in the table above as 31/32 cents holding from 0.40 up, against 27 only at the extreme.

## Verification

All sixteen instruments with every effect on at full depth and the slowest chorus rate: **0 NaN**. Firmware builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)