### PR TITLE
RD: one detent is 0.05 Hz, so the rate pages read round figures

### DIFF
--- a/instruments/PicoFaceRD/README.md
+++ b/instruments/PicoFaceRD/README.md
@@ -207,19 +207,28 @@ Encoder **Select** switches the page (with wrap-around), encoders **A** and **B*
 | Page | Encoder A | Encoder B |
 |---|---|---|
 | PATCH | Instrument 1–16 (header shows the bank: `MKS-20` / `MK-80`) | Volume |
-| CHORUS | Depth (0 % = off) | Rate, shown in Hz (0.37–5.71) |
-| TREMOLO | **Pan** (0 % = off) — it moves the image, it does not dip the level | Rate, shown in Hz (0.48–7.70) |
-| PHASER | Depth (0 % = off) | Rate, shown in Hz (0.10–5.00) |
+| CHORUS | Depth (0 % = off) | Rate in Hz, 0.35–5.70 in 0.05 steps |
+| TREMOLO | **Pan** (0 % = off) — it moves the image, it does not dip the level | Rate in Hz, 0.50–7.70 in 0.05 steps |
+| PHASER | Depth (0 % = off) | Rate in Hz, 0.10–5.00 in 0.05 steps |
 | EQ | Bass (50 % = neutral) | Treble (50 % = neutral) |
 | VOICES | Polyphony 8/16/24/32/**Auto** | — (line B shows live `Act <active>/<limit>`) |
 | TUNE | Master tune ±50 cents | — (line B shows the resulting A4 frequency) |
 | SYS | Vintage DAC filter ON/OFF | MIDI receive channel 1–16 / Omni |
 
-The chorus and tremolo rates are shown in Hz because the figures mean something:
-both service manuals tabulate the LFO period for all fifteen settings, and the
-laws live in one place (`rd_params.h`) so the display cannot drift away from the
-thing it is describing. Verified against the engine: 0.9 % at the slowest
-setting, 0.2 % elsewhere.
+The three rates are shown in Hz and **each detent is exactly 0.05 Hz**, so the
+display always reads a round figure. The stored value is the grid index itself
+rather than a percent, which is what makes it exact -- there is no scale for the
+display and the engine to disagree about. The laws live in one place
+(`rd_params.h`); measured across every grid position, display and engine differ
+by at most 0.014 Hz, well inside half a step.
+
+Chorus and tremolo endpoints come from the service manuals, snapped to the grid:
+0.35–5.70 Hz against a measured 0.370–5.714, and 0.50–7.70 against 0.476–7.692.
+That moves them by at most 5 % at the bottom and 0.2 % at the top, comfortably
+inside the scatter of the manuals' own tables. The phaser is not in either table
+-- it is an MK-80 effect -- and its rate went from exponential to linear for the
+sake of the same grid; if the slow end feels too coarse, that is the thing to
+revisit.
 
 The footer shows a live diagnostics line: `<instrument> P<peak-load %> U<buffer underruns> D<dropped events> A<active voices> N<note-on count>`.
 

--- a/instruments/PicoFaceRD/include/rd_params.h
+++ b/instruments/PicoFaceRD/include/rd_params.h
@@ -30,19 +30,63 @@
 enum RdParamId : uint8_t { RD_PARAM_VOLUME=0, RD_PARAM_CHORUS_ON, RD_PARAM_CHORUS_RATE, RD_PARAM_CHORUS_DEPTH, RD_PARAM_TREM_ON, RD_PARAM_TREM_RATE, RD_PARAM_TREM_DEPTH, RD_PARAM_BASS, RD_PARAM_TREBLE, RD_PARAM_DAC_FILTER_ON, RD_PARAM_PHASER_ON, RD_PARAM_PHASER_RATE, RD_PARAM_PHASER_DEPTH, RD_PARAM_VOICE_MODE, RD_PARAM_MASTER_TUNE, RD_PARAM_COUNT };
 
 /*
- * LFO rate laws, in Hz, for a 0..1 setting. One place, because the audio engine
- * sets the LFOs from these and the display prints them -- and a display that
- * disagrees with the thing it is describing is worse than one that says nothing.
+ * LFO rate laws, and the grid the panel steps them on.
  *
- * Chorus and tremolo are measured: both service manuals tabulate the LFO period
- * at a test point for all fifteen settings (MKS-20 p.7 at CP3 and CP4, MK-80 the
- * same). Chorus 2700..175 ms is 0.370..5.714 Hz, linear in the setting to within
- * 3.7 %; tremolo 2100..130 ms is 0.476..7.692 Hz, linear to within 5.2 %. The
- * phaser is not in either table -- it is an MK-80 effect and its range here is
- * ours, an exponential decade and a half.
+ * The three rate encoders move in exact 0.05 Hz detents, so the display always
+ * reads a round figure -- editing used to land on values like 3.04 Hz because
+ * the encoder stepped one percent of an arbitrary span. The stored value IS the
+ * grid index (Hz * 20), which is why these ranges are stated as indices: the
+ * panel counts grid positions and the display just multiplies by 0.05.
+ *
+ * Chorus and tremolo are measured. Both service manuals tabulate the LFO period
+ * at a test point for all fifteen settings (MKS-20 p.7 at CP3 and CP4, MK-80
+ * the same): chorus 2700..175 ms is 0.370..5.714 Hz, tremolo 2100..130 ms is
+ * 0.476..7.692 Hz, each linear in the setting to within 3.7 % and 5.2 %. The
+ * endpoints here are those figures snapped to the grid -- 0.35..5.70 and
+ * 0.50..7.70 -- which moves them by at most 5 % at the bottom and 0.2 % at the
+ * top, comfortably inside the scatter of the manuals' own tables.
+ *
+ * The phaser is not in either table; it is an MK-80 effect and its range is
+ * ours. It used to be an exponential decade and a half and is linear now, for
+ * the sake of the same grid. If the slow end turns out too coarse that is the
+ * thing to revisit.
  */
-static inline float rd_chorus_rate_hz(float x01) { return 0.370f + 5.344f * x01; }
-static inline float rd_trem_rate_hz  (float x01) { return 0.476f + 7.224f * x01; }
-static inline float rd_phaser_rate_hz(float x01) { return 0.1f * powf(10.0f, 1.69897000433601880479f * x01); }
+#define RD_RATE_STEP_HZ 0.05f
+
+// Grid index bounds, in units of 0.05 Hz.
+#define RD_CHORUS_IDX_MIN   7u    // 0.35 Hz
+#define RD_CHORUS_IDX_MAX 114u    // 5.70 Hz
+#define RD_TREM_IDX_MIN    10u    // 0.50 Hz
+#define RD_TREM_IDX_MAX   154u    // 7.70 Hz
+#define RD_PHASER_IDX_MIN   2u    // 0.10 Hz
+#define RD_PHASER_IDX_MAX 100u    // 5.00 Hz
+
+static inline bool rd_is_rate_param(uint8_t id)
+{
+    return id == RD_PARAM_CHORUS_RATE || id == RD_PARAM_TREM_RATE || id == RD_PARAM_PHASER_RATE;
+}
+
+static inline uint8_t rd_rate_idx_min(uint8_t id)
+{
+    if (id == RD_PARAM_CHORUS_RATE) return RD_CHORUS_IDX_MIN;
+    if (id == RD_PARAM_TREM_RATE)   return RD_TREM_IDX_MIN;
+    return RD_PHASER_IDX_MIN;
+}
+
+static inline uint8_t rd_rate_idx_max(uint8_t id)
+{
+    if (id == RD_PARAM_CHORUS_RATE) return RD_CHORUS_IDX_MAX;
+    if (id == RD_PARAM_TREM_RATE)   return RD_TREM_IDX_MAX;
+    return RD_PHASER_IDX_MAX;
+}
+
+// What the display prints. The grid index is the value, so this is exact.
+static inline float rd_rate_hz_from_idx(uint8_t idx) { return (float)idx * RD_RATE_STEP_HZ; }
+
+// What the engine computes from the 0..1 it receives over the wire. Endpoints
+// match the index bounds above, so the two agree to better than half a step.
+static inline float rd_chorus_rate_hz(float x01) { return 0.35f + 5.35f * x01; }
+static inline float rd_trem_rate_hz  (float x01) { return 0.50f + 7.20f * x01; }
+static inline float rd_phaser_rate_hz(float x01) { return 0.10f + 4.90f * x01; }
 
 #endif // RD_PARAMS_H

--- a/instruments/PicoFaceRD/include/rd_settings.h
+++ b/instruments/PicoFaceRD/include/rd_settings.h
@@ -8,24 +8,27 @@
  * rd_settings.h -- persisted UI state record for RD_Controller.
  *
  * This struct is the payload handed to the veeprom append-log module.
- * All fields are in UI units (percent 0..100, toggles 0/1, etc.).
+ * All fields are in UI units (percent 0..100, toggles 0/1, etc.) --
+ * except the three LFO rates, which hold a 0.05 Hz grid index. Version 2
+ * is that change: a v1 record's rates would read as the wrong frequency,
+ * so those records are discarded rather than reinterpreted.
  * Bump RD_SETTINGS_VERSION and adjust static_assert if the layout
  * changes -- veeprom discards records whose version field mismatches.
  */
 
-#define RD_SETTINGS_VERSION 1u
+#define RD_SETTINGS_VERSION 2u
 
 struct __attribute__((packed)) RdSettingsV1 {
     uint8_t instrument;   // 0..15
     uint8_t volume;       // 0..100
     uint8_t chorusOn;     // 0/1
-    uint8_t chorusRate;   // 0..100
+    uint8_t chorusRate;   // 0.05 Hz grid index, 7..114
     uint8_t chorusDepth;  // 0..100
     uint8_t tremOn;       // 0/1
-    uint8_t tremRate;     // 0..100
+    uint8_t tremRate;     // 0.05 Hz grid index, 10..154
     uint8_t tremDepth;    // 0..100
     uint8_t phaserOn;     // 0/1
-    uint8_t phaserRate;   // 0..100
+    uint8_t phaserRate;   // 0.05 Hz grid index, 2..100
     uint8_t phaserDepth;  // 0..100
     uint8_t bass;         // 0..100
     uint8_t treble;       // 0..100

--- a/instruments/PicoFaceRD/src/RD_Controller.cpp
+++ b/instruments/PicoFaceRD/src/RD_Controller.cpp
@@ -16,16 +16,16 @@
 // UI units: percent 0..100; toggles 0/1.
 static constexpr uint8_t kDefVolume       = 80;
 static constexpr uint8_t kDefChorusOn     = 0;
-static constexpr uint8_t kDefChorusRate   = 40;
+static constexpr uint8_t kDefChorusRate   = 50;   // grid index: 2.50 Hz (was 40 % = 2.51 Hz)
 static constexpr uint8_t kDefChorusDepth  = 50;
 static constexpr uint8_t kDefTremOn       = 0;
-static constexpr uint8_t kDefTremRate     = 50;
+static constexpr uint8_t kDefTremRate     = 82;   // grid index: 4.10 Hz (was 50 % = 4.09 Hz)
 static constexpr uint8_t kDefTremDepth    = 50;
 static constexpr uint8_t kDefBass         = 50;
 static constexpr uint8_t kDefTreble       = 50;
 static constexpr uint8_t kDefDacFilterOn  = 1;
 static constexpr uint8_t kDefPhaserOn      = 0;
-static constexpr uint8_t kDefPhaserRate    = 50;
+static constexpr uint8_t kDefPhaserRate    = 14;  // grid index: 0.70 Hz (was 50 % of an exponential = 0.71 Hz)
 static constexpr uint8_t kDefPhaserDepth   = 50;
 
 // Step a percent value by delta (1% per detent), clamped to 0..100.
@@ -51,7 +51,26 @@ static uint8_t toWire(uint8_t id, uint8_t v) {
     if (isToggleParam(id)) {
         return v ? 255 : 0;
     }
+    if (rd_is_rate_param(id)) {
+        // Rates are stored as a 0.05 Hz grid index, not a percent. Map the
+        // index across its own range so the engine's law lands on the same
+        // frequency the display prints.
+        const int lo = (int)rd_rate_idx_min(id);
+        const int hi = (int)rd_rate_idx_max(id);
+        int n = (int)v; if (n < lo) n = lo; if (n > hi) n = hi;
+        return (uint8_t)(((n - lo) * 255 + (hi - lo) / 2) / (hi - lo));
+    }
     return (uint8_t)(((int)v * 255 + 50) / 100);
+}
+
+// One encoder detent = one grid position = exactly 0.05 Hz.
+static uint8_t stepRate(uint8_t id, uint8_t v, int delta) {
+    const int lo = (int)rd_rate_idx_min(id);
+    const int hi = (int)rd_rate_idx_max(id);
+    int n = (int)v + delta;
+    if (n < lo) n = lo;
+    if (n > hi) n = hi;
+    return (uint8_t)n;
 }
 
 // Send a shadow UI value to the engine, converting to wire format.
@@ -196,19 +215,19 @@ void RD_Controller::onEncoder3(int delta) {
             break;
         }
         case RdPage::CHORUS: {
-            uint8_t rate = stepPct(shadow_[RD_PARAM_CHORUS_RATE], delta);
+            uint8_t rate = stepRate(RD_PARAM_CHORUS_RATE, shadow_[RD_PARAM_CHORUS_RATE], delta);
             shadow_[RD_PARAM_CHORUS_RATE] = rate;
             sendParam(RD_PARAM_CHORUS_RATE, rate);
             break;
         }
         case RdPage::TREMOLO: {
-            uint8_t rate = stepPct(shadow_[RD_PARAM_TREM_RATE], delta);
+            uint8_t rate = stepRate(RD_PARAM_TREM_RATE, shadow_[RD_PARAM_TREM_RATE], delta);
             shadow_[RD_PARAM_TREM_RATE] = rate;
             sendParam(RD_PARAM_TREM_RATE, rate);
             break;
         }
         case RdPage::PHASER: {
-            uint8_t rate = stepPct(shadow_[RD_PARAM_PHASER_RATE], delta);
+            uint8_t rate = stepRate(RD_PARAM_PHASER_RATE, shadow_[RD_PARAM_PHASER_RATE], delta);
             shadow_[RD_PARAM_PHASER_RATE] = rate;
             sendParam(RD_PARAM_PHASER_RATE, rate);
             break;
@@ -336,6 +355,10 @@ void RD_Controller::importSettings(const RdSettingsV1& s)
     // Defensive clamping -- a corrupted/foreign record must never escape.
     auto clampPct = [](uint8_t v) -> uint8_t { return (v > 100u) ? 100u : v; };
     auto clampBit = [](uint8_t v) -> uint8_t { return (v != 0u) ? 1u : 0u; };
+    auto clampRate = [](uint8_t id, uint8_t v) -> uint8_t {
+        const uint8_t lo = rd_rate_idx_min(id), hi = rd_rate_idx_max(id);
+        return (v < lo) ? lo : ((v > hi) ? hi : v);
+    };
 
     instrument_        = (s.instrument >= RD_PATCH_COUNT) ? 0u : s.instrument;
     midiCh_            = (s.midiCh > 16u)    ? 16u : s.midiCh;
@@ -344,13 +367,13 @@ void RD_Controller::importSettings(const RdSettingsV1& s)
 
     shadow_[RD_PARAM_VOLUME]        = clampPct(s.volume);
     shadow_[RD_PARAM_CHORUS_ON]     = clampBit(s.chorusOn);
-    shadow_[RD_PARAM_CHORUS_RATE]   = clampPct(s.chorusRate);
+    shadow_[RD_PARAM_CHORUS_RATE]   = clampRate(RD_PARAM_CHORUS_RATE, s.chorusRate);
     shadow_[RD_PARAM_CHORUS_DEPTH]  = clampPct(s.chorusDepth);
     shadow_[RD_PARAM_TREM_ON]       = clampBit(s.tremOn);
-    shadow_[RD_PARAM_TREM_RATE]     = clampPct(s.tremRate);
+    shadow_[RD_PARAM_TREM_RATE]     = clampRate(RD_PARAM_TREM_RATE, s.tremRate);
     shadow_[RD_PARAM_TREM_DEPTH]    = clampPct(s.tremDepth);
     shadow_[RD_PARAM_PHASER_ON]     = clampBit(s.phaserOn);
-    shadow_[RD_PARAM_PHASER_RATE]   = clampPct(s.phaserRate);
+    shadow_[RD_PARAM_PHASER_RATE]   = clampRate(RD_PARAM_PHASER_RATE, s.phaserRate);
     shadow_[RD_PARAM_PHASER_DEPTH]  = clampPct(s.phaserDepth);
     shadow_[RD_PARAM_BASS]          = clampPct(s.bass);
     shadow_[RD_PARAM_TREBLE]        = clampPct(s.treble);

--- a/instruments/PicoFaceRD/src/RD_Instrument.cpp
+++ b/instruments/PicoFaceRD/src/RD_Instrument.cpp
@@ -224,13 +224,9 @@ private:
             // figures out of the service notes rather than a scale of our own
             // (see rd_params.h), so the number means something -- and the TUNE
             // page already sets the precedent of showing the physical value.
-            const float x = (float) controller_.param3Value() * 0.01f;
-            float hz;
-            switch (controller_.currentPage()) {
-                case RdPage::CHORUS:  hz = rd_chorus_rate_hz(x); break;
-                case RdPage::TREMOLO: hz = rd_trem_rate_hz(x);   break;
-                default:              hz = rd_phaser_rate_hz(x); break;
-            }
+            // The stored value IS the 0.05 Hz grid index, so this is exact --
+            // no scale conversion to disagree with the engine about.
+            const float hz = rd_rate_hz_from_idx(controller_.param3Value());
             snprintf(m.lineA, sizeof(m.lineA), "%s %d%%", controller_.param2Name(), (int) controller_.param2Value());
             snprintf(m.lineB, sizeof(m.lineB), "%s %.2fHz", controller_.param3Name(), (double) hz);
         } else {


### PR DESCRIPTION
Hardware test: *"bei der eingabe der rate kommen jetzt sehr krumme Hz-werte. wäre es möglich pro Drehung um exakt 0.05 Hz zu verstellen."*

Yes — but not by rounding the display. The encoder stepped one percent of an arbitrary span, and no amount of rounding makes that land on a grid.

Independent of [#119](https://github.com/Michi71/PicoVintageSynthCollection/pull/119) (different files).

## The stored value is the grid index now

In units of 0.05 Hz, and the display just multiplies. Nothing converts between two scales, so nothing can disagree:

| | index range | Hz | detents |
|---|---|---|---|
| chorus | 7 … 114 | 0.35 – 5.70 | 108 |
| tremolo | 10 … 154 | 0.50 – 7.70 | 145 |
| phaser | 2 … 100 | 0.10 – 5.00 | 99 |

The endpoints are the measured figures snapped to the grid — `0.370…5.714 → 0.35…5.70`, `0.476…7.692 → 0.50…7.70`. At most **5 %** at the bottom and **0.2 %** at the top, comfortably inside the scatter of the manuals' own tables, which are only linear to 3.7 % and 5.2 % themselves.

## One trade-off, stated plainly

The phaser went from **exponential to linear** for the sake of the same grid. It is not in either manual — an MK-80 effect, our range — so nothing is lost against a source, but the slow end is coarser than it was (0.10 → 0.15 is one detent). If that bothers the hand, that is the thing to revisit.

## Settings version 2

A v1 record's rate fields are percents and would read as the wrong frequency, so veeprom discards them and the defaults apply. The defaults were picked to land where they used to sound: chorus **2.50 Hz** against 2.51 before, tremolo **4.10** against 4.09, phaser **0.70** against 0.71.

MIDI CC is untouched — incoming controllers go straight to the engine as a 0..255 wire value and never through the shadow, so they still sweep the full range.

## Verification

Across every one of the **352 grid positions**:
- **0** steps that are not exactly 0.05 Hz
- display against engine, through the real wire conversion, never further apart than **0.0141 Hz** (half a step is 0.025)

Then measured on the engine itself at five tremolo positions:

| shown | measured |
|---|---|
| 0.50 Hz | 0.494 |
| 2.00 Hz | 2.000 |
| 4.10 Hz | 4.084 |
| 6.00 Hz | 6.001 |
| 7.70 Hz | 7.686 |

Firmware builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)