### PR TITLE
A dead display should cost the display, not the instrument

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,24 @@ needs on a small board.
 The pin map is the same for every instrument and lives in
 [core/include/project_config.h](core/include/project_config.h).
 
+**If the screen stays dark.** The panel is on I2C at 1 MHz with only the chip's
+internal pull-ups. That is above what an SH1106 datasheet promises (400 kHz) and
+it is what the reference board runs, because the display push is paced in half
+tile rows of roughly 1.5 ms of I2C each -- the bus rate is directly the UI's
+frame time, and 400 kHz would make a full screen 60 ms instead of 24. On longer
+jumper leads it is the first thing to suspect. Build with
+`-DPICOFACE_OLED_I2C_HZ=400000`, and consider real 2.2k-4.7k pull-ups before
+blaming the display.
+
+A display that is simply absent costs nothing: the I2C write returns an error on
+a NACK and the firmware carries on. A display that *holds a line low* used to
+take the whole instrument down -- the wait for the bus is unbounded, and the
+first transfer happens before the splash loop, which is the only place USB gets
+serviced during startup, so the board would not even enumerate. It reads exactly
+like a firmware that does not boot. That write is now bounded at 5 ms and the
+panel is written off after twenty consecutive failures, so a broken display
+costs you the display and not the MIDI, the audio and the encoders.
+
 **On the board setting.** The build defaults to `PICO_BOARD=sparkfun_promicro_rp2350`,
 and that is a statement about flash size rather than about hardware: the
 prototype runs a Waveshare RP2350-Plus, and the SparkFun definition was picked

--- a/core/include/project_config.h
+++ b/core/include/project_config.h
@@ -30,6 +30,21 @@
 #define PIN_OLED_SDA  2
 #define PIN_OLED_SCL  3
 
+// OLED bus speed. 1 MHz is Fast-mode Plus, and it is what the reference board
+// runs: the display push is paced in half tile rows of roughly 1.5 ms of I2C
+// each, so the rate is directly the UI's frame time -- 400 kHz would make a
+// full screen 60 ms instead of 24.
+//
+// It is also above what an SH1106 datasheet promises (400 kHz), and the only
+// pull-ups are the chip's internal ones at around 50 kOhm. On the short, tidy
+// wiring of the prototype that is fine and has been for every board tested
+// here. On longer jumper leads it is the first thing to suspect when a panel
+// stays dark while the instrument is otherwise alive -- drop it to 400000 and
+// see. Worth adding real 2.2k-4.7k pull-ups before blaming the display.
+#ifndef PICOFACE_OLED_I2C_HZ
+#define PICOFACE_OLED_I2C_HZ (1000 * 1000)
+#endif
+
 //#define PIN_POT_0     28
 #define PIN_POT_1     29
 

--- a/core/src/pico_hw.cpp
+++ b/core/src/pico_hw.cpp
@@ -28,6 +28,14 @@
 // PICOFACE_SYS_CLOCK_HZ and PICOFACE_QMI_M0_TIMING_TARGET come from
 // project_config.h, which is where the flash-write sites can see them too.
 
+// A transfer is at most 32 bytes, so 300 us at 1 MHz and 750 us at 400 kHz.
+// 5 ms is more than an order of magnitude of headroom and still bounded.
+static const uint32_t kOledXferTimeoutUs = 5000;
+// Twenty in a row: a healthy bus never produces one.
+static const uint8_t  kOledMaxFailures   = 20;
+static uint8_t s_oledFailures = 0;
+static bool    s_oledDead     = false;
+
 uint8_t u8x8_byte_pico_hw_i2c(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *arg_ptr)
 {
     static uint8_t buffer[32]; /* u8g2/u8x8 will never send more than 32 bytes between START_TRANSFER and END_TRANSFER */
@@ -46,8 +54,7 @@ uint8_t u8x8_byte_pico_hw_i2c(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *
         }
         break;
     case U8X8_MSG_BYTE_INIT:
-        // SH1106 supports Fast Mode up to 1 MHz for faster display refresh
-        i2c_init(i2c1, 1000 * 1000);
+        i2c_init(i2c1, PICOFACE_OLED_I2C_HZ);
         gpio_set_function(PIN_OLED_SDA, GPIO_FUNC_I2C);
         gpio_set_function(PIN_OLED_SCL, GPIO_FUNC_I2C);
         gpio_pull_up(PIN_OLED_SDA);
@@ -59,7 +66,33 @@ uint8_t u8x8_byte_pico_hw_i2c(u8x8_t *u8x8, uint8_t msg, uint8_t arg_int, void *
         buf_idx = 0;
         break;
     case U8X8_MSG_BYTE_END_TRANSFER:
-        i2c_write_blocking(i2c1, u8x8_GetI2CAddress(u8x8) >> 1, buffer, buf_idx, false);
+        // Bounded, and it gives up. i2c_write_blocking() waits forever for the
+        // TX FIFO to empty, and nothing bounds that wait: any wiring that holds
+        // SDA or SCL low spins there for good. The first transfer happens in
+        // u8g2_InitDisplay(), which runs BEFORE the splash loop -- the only
+        // place tud_task() gets called during startup -- so a shorted display
+        // cable takes the whole instrument down without so much as enumerating
+        // over USB. It reads exactly like "the firmware does not boot".
+        //
+        // A missing display was never the problem: the SDK checks
+        // tx_abrt_source and returns an error on a NACK, so an absent panel
+        // just leaves the screen dark. It is a held line that hangs.
+        //
+        // After kOledMaxFailures consecutive timeouts the panel is written off
+        // for this power cycle. A broken display should cost you the display,
+        // not the MIDI, the audio and the encoders. There is deliberately no
+        // retry: a loose wire that comes and goes would otherwise pay the
+        // timeout on every transfer forever, and a reboot is the honest cure.
+        if (!s_oledDead) {
+            const int r = i2c_write_timeout_us(i2c1, u8x8_GetI2CAddress(u8x8) >> 1,
+                                               buffer, buf_idx, false,
+                                               kOledXferTimeoutUs);
+            if (r < 0) {
+                if (++s_oledFailures >= kOledMaxFailures) s_oledDead = true;
+            } else {
+                s_oledFailures = 0;
+            }
+        }
         break;
     default:
         return 0;


### PR DESCRIPTION
Michael asked whether a wrong audio board or a miswired I2C display could look like *"the firmware does not boot"* — which is what [#107](https://github.com/Michi71/PicoVintageSynthCollection/issues/107) and [#122](https://github.com/Michi71/PicoVintageSynthCollection/issues/122) report. Checked both. The answers differ, and one of them was a real hole.

## The audio board cannot

I2S has no return path — the DAC acknowledges nothing — and `init_audio()` runs **after** the splash. A wrong or absent DAC gives a normal boot and silence.

## A missing display cannot either

I assumed otherwise until I read the SDK: `i2c_write_blocking()` checks `tx_abrt_source` and returns an error on a NACK. An absent panel just leaves the screen dark.

## A miswired one absolutely can

The wait for `TX_EMPTY` in that same function is **unbounded**. Any wiring that holds SDA or SCL low spins there for good — and it happens in `u8g2_InitDisplay()`, which runs **before** the splash loop, the only place `tud_task()` is called during startup. So the board does not even enumerate over USB.

From the outside that is indistinguishable from a firmware that will not start.

### What changes

The transfer is bounded at **5 ms** (a 32-byte transfer is 300 µs at 1 MHz — an order of magnitude of headroom) and the panel is written off after **twenty consecutive failures**. A broken display now costs you the display, not the MIDI, the audio and the encoders.

Deliberately **no retry**: a loose wire that comes and goes would otherwise pay the timeout on every transfer forever, and a reboot is the honest cure.

## The bus rate is a `#define` now

`1 MHz` stays the default — it is what the reference board runs, and the rate is directly the UI's frame time: the display push is paced in half tile rows of ~1.5 ms of I2C each, so 400 kHz would make a full screen 60 ms instead of 24.

But it is above what an SH1106 datasheet promises (400 kHz), the only pull-ups are the chip's internal ~50 kΩ, and on longer jumper leads that is the first thing to suspect when a panel stays dark while the instrument is otherwise alive. `-DPICOFACE_OLED_I2C_HZ=400000` now does it without editing code.

## Verification

Checked in the disassembly rather than assumed, because `i2c_write_timeout_us` is a `static inline` that calls the same `i2c_write_blocking_until` as the unbounded form — the symbol table cannot tell them apart:

```
10006246:  ldr   r3, [pc, #172]      ; s_oledDead
1000624a:  cmp   r3, #0
1000624c:  bne   ...                 ; skip the transfer
1000625a:  bl    time_us_64          ; <- deadline computed
1000625e:  movw  r2, #5000           ; <- 5 ms
```

The unbounded form does not call `time_us_64`; it loads `at_the_end_of_time`. And the rate literal reads `1000000`, or `400000` when the define is overridden — both read back out of `.text`.

All ten instruments build.

## For the two issues

This gives a triage ladder that did not exist before:

| symptom | meaning |
|---|---|
| no USB enumeration | hung at or before display init — clock/flash timing, or a held I2C line |
| enumerates, no picture | display: address, wiring, or 1 MHz too fast for the leads |
| splash, then frozen | the audio `panic()` |
| splash and UI fine, no sound | audio board or I2S wiring |

And with #109 in, a splash that appears also reports the stepping and the flash clock.

🤖 Generated with [Claude Code](https://claude.com/claude-code)