### PR TITLE
Flash timing: back to OC, and RXDELAY turns out not to be free

### DIFF
--- a/core/include/project_config.h
+++ b/core/include/project_config.h
@@ -96,18 +96,31 @@
 // the data stays valid for an SCK period plus the device's output hold, so
 // even CD4's sample at 10.14 ns sits inside a window running past 12 ns.
 //
-// Which one is the default is a trade, and it was measured rather than argued.
-// On the D5 -- the most XIP-bound of the ten, because it reads its PCM from
-// flash -- the boot benchmark went from B51 at 148 MHz to B59 at 111 MHz.
-// Four voices, so 10.0 % per voice against 12.0 %: about 1.3 voices of
-// headroom before the governor starts trimming tails. That is a real price for
-// margin nobody has yet shown we need, since neither reporter of a
-// non-booting board has tested anything.
+// Which one is the default was settled by measurement, on the D5 -- the most
+// XIP-bound of the ten, because it reads its PCM from flash. Boot benchmark,
+// four voices, repeated over many power cycles (it varies by about half a
+// point, so these differences are real):
 //
-// So RX4 is the default. Against the OC it replaces it is strictly better and
-// free: same SCK, same throughput, 1.1 ns more for the device purely by
-// sampling later. CD4 is the next rung and costs those 1.3 voices; it is
-// where to go if a board still will not boot on RX4.
+//   OC   148 MHz, RXDELAY=3    B51        8.1 voices before the governor trims
+//   RX4  148 MHz, RXDELAY=4    B53-54     7.5
+//   CD4  111 MHz, RXDELAY=5    B59        6.8
+//
+// The middle row is the surprise, and it is worth recording because the
+// datasheet does not mention it: RXDELAY costs throughput. RX4 runs the SAME
+// SCK as OC and moves only the sampling point, so it was expected to be free.
+// It is not -- it costs about 2.5 points, five percent. A back-of-envelope
+// says it should be a tenth of that: one extra half system clock cycle is
+// 1.13 ns at 444 MHz, against a cache line fill of some 200 ns. The
+// measurement wins and the explanation is missing.
+//
+// So there is no free rung, and margin costs voices at much the same rate
+// either way -- 0.37 ns per benchmark point for RX4, 0.42 for CD4. Which
+// leaves the question of whether to buy any, and the honest answer is not yet:
+// two boards are reported not to boot and neither reporter has tested a thing,
+// so nothing here is known to help. OC is the default because it is the
+// configuration that runs on every board actually tested, and the others are
+// the rungs to hand somebody whose board does not. Buy margin when there is
+// evidence it fixes something, not before.
 //
 // The upper bits (COOLDOWN=1, PAGEBREAK=2, MIN_DESELECT=7) are identical in
 // all values below; only CLKDIV and RXDELAY differ.
@@ -128,11 +141,10 @@
 // failure".
 #define PICOFACE_QMI_M0_TIMING_SAFE 0x60007208u
 
-// 148 MHz flash at 444 MHz, sampled as early as it goes. The default until
-// Table 1292 made the sum above computable. Superseded by RX4, which runs the
-// same SCK and gives the device 1.1 ns more for nothing -- there is no reason
-// to choose this one, and it is kept only because the 480 MHz boot-failure
-// note above refers to it.
+// The default. 148 MHz flash at 444 MHz, sampled as early as it goes, and
+// 2.76 ns for a device that may want 6 in the worst case -- which is why the
+// rungs below exist. It has run on every board tested here, and it is the only
+// value that costs nothing.
 #define PICOFACE_QMI_M0_TIMING_OC 0x60007303u
 
 // 480 MHz target: CLKDIV=4, RXDELAY=3 -> 120 MHz flash. Used by PicoFaceRD,
@@ -143,15 +155,15 @@
 // thing to try if an RD ever fails to boot.
 #define PICOFACE_QMI_M0_TIMING_RD 0x60007304u
 
-// The default. Full flash speed with a later sample point: 3.88 ns for the
-// device against OC's 2.76, bought by moving RXDELAY and nothing else, so the
-// throughput is identical. Still under the 10.0 ns worst case -- this is more
-// margin, not enough margin.
+// First rung. Full flash speed with a later sample point: 3.88 ns for the
+// device against OC's 2.76. Expected to be free, since only RXDELAY moves;
+// measured at about 2.5 benchmark points on the D5, roughly 0.6 voices. Still
+// under the 10.0 ns worst case -- this is more margin, not enough margin.
 #define PICOFACE_QMI_M0_TIMING_RX4 0x60007403u   // CLKDIV=3, RXDELAY=4
 
-// The next rung, and the first value here that satisfies the worst-case sum:
-// 6.14 ns for the device. Costs 111 MHz instead of 148, which measured as 1.3
-// voices on the D5. RXDELAY=5, not 4: at 4 the budget is 9.01 ns against a
+// Second rung, and the first value here that satisfies the worst-case sum:
+// 6.14 ns for the device. Costs 111 MHz instead of 148, measured at 8 benchmark
+// points on the D5, roughly 1.3 voices. RXDELAY=5, not 4: at 4 the budget is 9.01 ns against a
 // requirement of 10.0 -- that value was picked against the part's 133 MHz
 // rating, before the pad delays made the real sum computable.
 #define PICOFACE_QMI_M0_TIMING_CD4 0x60007504u   // CLKDIV=4, RXDELAY=5
@@ -177,7 +189,7 @@
 #endif
 
 #ifndef PICOFACE_QMI_M0_TIMING_TARGET
-#define PICOFACE_QMI_M0_TIMING_TARGET PICOFACE_QMI_M0_TIMING_RX4
+#define PICOFACE_QMI_M0_TIMING_TARGET PICOFACE_QMI_M0_TIMING_OC
 #endif
 
 

--- a/instruments/PicoFaceMD/README.md
+++ b/instruments/PicoFaceMD/README.md
@@ -417,22 +417,35 @@ are far better than their worst-case numbers -- but that is exactly the profile
 of a setting that works on one board and not the next, and two issues report
 boards that will not boot.
 
-**The default is `RX4`, and the reason is a measurement.** `CD4` was the default
-briefly, on the strength of the arithmetic alone. Then the cost turned up: on
-the D5 -- the most XIP-bound of the ten, because it reads its PCM from flash --
-the boot benchmark went from **B51 at 148 MHz to B59 at 111 MHz**. Four voices,
-so 10.0 % per voice against 12.0 %, which is about **1.3 voices** of headroom
-before the governor starts trimming tails.
+**`OC` is the default, and the reason is three measurements.** The arithmetic
+alone made `CD4` look right, and it was the default briefly. Then the cost was
+measured on the D5 -- the most XIP-bound of the ten, because it reads its PCM
+from flash -- boot benchmark, four voices, over many power cycles:
 
-That is a real price for margin nobody has yet shown we need: neither reporter
-of a non-booting board has tested anything. And it was paid while a free option
-sat unused. `RX4` runs the *same* 148 MHz SCK and moves only the sample point,
-so it costs nothing at all and still gives the device 3.88 ns instead of 2.76 --
-strictly better than the `OC` it replaces, in the one direction that matters.
+| | SCK | RXDELAY | B | voices before the governor trims | for the device |
+|---|---|---|---|---|---|
+| `OC` | 148 MHz | 3 | **51** | 8.1 | 2.76 ns |
+| `RX4` | 148 MHz | 4 | 53–54 | 7.5 | 3.88 ns |
+| `CD4` | 111 MHz | 5 | 59 | 6.8 | 6.14 ns |
 
-`CD4` remains the next rung, and the place to go if a board still will not boot
-on `RX4`. Which of the two is right is a question for the first reporter who
-tests something, not for arithmetic.
+The benchmark varies by about half a point across boots, so those differences
+are real.
+
+**The middle row is a finding the datasheet does not carry: RXDELAY costs
+throughput.** `RX4` runs the *same* SCK as `OC` and moves only the sampling
+point, so it was expected to be free — that was the whole argument for making
+it the default. It costs about 2.5 points, five percent. A back-of-envelope says
+it should be a tenth of that: one extra half system clock cycle is 1.13 ns at
+444 MHz, against a cache line fill of some 200 ns. The measurement wins and the
+explanation is missing.
+
+So there is no free rung, and margin costs voices at much the same rate either
+way — 0.37 ns per benchmark point for `RX4`, 0.42 for `CD4`. Which leaves the
+question of whether to buy any, and the honest answer is *not yet*: two boards
+are reported not to boot and neither reporter has tested a thing, so nothing
+here is known to help. `OC` is the default because it is the configuration that
+runs on every board actually tested, and it is the only one that costs nothing.
+The others are the rungs to hand somebody whose board does not boot.
 
 `CD4` itself was wrong when it was added: `RXDELAY=4` gives 9.01 ns, a nanosecond
 short. It had been chosen against the part's 133 MHz rating rather than against


### PR DESCRIPTION
Third change to this default, and the last until somebody tests a board. Each followed the evidence available at the time; the evidence got better.

## The measurement that decides it

On the D5 — the most XIP-bound of the ten, because it reads its PCM from flash. Boot benchmark, four voices, repeated over many power cycles. **It varies by about half a point**, so these differences are real:

| | SCK | RXDELAY | B | voices before the governor trims | for the device |
|---|---|---|---|---|---|
| `OC` | 148 MHz | 3 | **51** | 8.1 | 2.76 ns |
| `RX4` | 148 MHz | 4 | 53–54 | 7.5 | 3.88 ns |
| `CD4` | 111 MHz | 5 | 59 | 6.8 | 6.14 ns |

## The middle row is a finding, and it contradicts me

**RXDELAY costs throughput.** `RX4` runs the *same* SCK as `OC` and moves only the sampling point — which is exactly why [#125](https://github.com/Michi71/PicoVintageSynthCollection/pull/125) called it free and made it the default. It is not: about **2.5 points, five percent**.

A back-of-envelope says it should be a tenth of that — one extra half system clock cycle is 1.13 ns at 444 MHz, against a cache line fill of some 200 ns. The datasheet describes RXDELAY only as a delay on the input sampling register, with no throughput implication.

The measurement wins and the explanation is missing. Recorded in the header rather than explained away, because it is not obvious and the next person to reach for RXDELAY should know.

## What follows

There is no free rung. Margin costs voices at much the same rate either way — **0.37 ns per benchmark point for `RX4`, 0.42 for `CD4`**. That removes the argument for `RX4` and leaves the one that already stood against `CD4`: two boards are reported not to boot, **neither reporter has tested anything**, and nothing here is known to fix either of them.

So `OC` is the default again — the configuration that runs on every board actually tested, and the only one that costs nothing. `SAFE`, `RX4` and `CD4` stay as the rungs to hand somebody whose board does not boot, which is what [#108](https://github.com/Michi71/PicoVintageSynthCollection/pull/108) added them for.

Buy margin when there is evidence it fixes something.

## Verification

Constant read back out of **all ten ELFs**: nine carry `0x60007303`, RD carries its own `0x60007304`, no `RX4` or `CD4` left. The shipped timing is once again exactly what v1.11.0 has, so the release stays a valid reference for the two issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)