### PR TITLE
Withdraw the RXDELAY throughput claim: it was noise in a maximum

### DIFF
--- a/core/include/project_config.h
+++ b/core/include/project_config.h
@@ -96,31 +96,36 @@
 // the data stays valid for an SCK period plus the device's output hold, so
 // even CD4's sample at 10.14 ns sits inside a window running past 12 ns.
 //
-// Which one is the default was settled by measurement, on the D5 -- the most
-// XIP-bound of the ten, because it reads its PCM from flash. Boot benchmark,
-// four voices, repeated over many power cycles (it varies by about half a
-// point, so these differences are real):
+// What the rungs cost, measured on the D5 -- the most XIP-bound of the ten,
+// because it reads its PCM from flash. Boot benchmark, four voices:
 //
-//   OC   148 MHz, RXDELAY=3    B51        8.1 voices before the governor trims
-//   RX4  148 MHz, RXDELAY=4    B53-54     7.5
-//   CD4  111 MHz, RXDELAY=5    B59        6.8
+//   OC   148 MHz, RXDELAY=3    B51 and B53 on different runs
+//   RX4  148 MHz, RXDELAY=4    B53, B54
+//   CD4  111 MHz, RXDELAY=5    B59
 //
-// The middle row is the surprise, and it is worth recording because the
-// datasheet does not mention it: RXDELAY costs throughput. RX4 runs the SAME
-// SCK as OC and moves only the sampling point, so it was expected to be free.
-// It is not -- it costs about 2.5 points, five percent. A back-of-envelope
-// says it should be a tenth of that: one extra half system clock cycle is
-// 1.13 ns at 444 MHz, against a cache line fill of some 200 ns. The
-// measurement wins and the explanation is missing.
+// Read those spreads before the differences. The benchmark reports the WORST
+// of 94 blocks, not the mean, and a maximum picks up whatever transient landed
+// in one of them -- so it swings by two points or more between runs of the
+// same image. That is the right statistic for the diagnostic it is (it shows
+// the worst case the governor has to survive) and the wrong one for comparing
+// timings two points apart.
 //
-// So there is no free rung, and margin costs voices at much the same rate
-// either way -- 0.37 ns per benchmark point for RX4, 0.42 for CD4. Which
-// leaves the question of whether to buy any, and the honest answer is not yet:
-// two boards are reported not to boot and neither reporter has tested a thing,
-// so nothing here is known to help. OC is the default because it is the
-// configuration that runs on every board actually tested, and the others are
-// the rungs to hand somebody whose board does not. Buy margin when there is
-// evidence it fixes something, not before.
+// So: OC and RX4 overlap and nothing separates them. An earlier version of
+// this comment claimed RXDELAY costs about five percent of throughput at
+// constant SCK, which would have been a finding the datasheet does not carry.
+// It was one OC run against one RX4 run, and the second OC run took it away.
+// Withdrawn.
+//
+// CD4's cost does stand: 59 against 51-53 is six to eight points, well outside
+// the spread, and about 1.3 voices before the governor starts trimming tails.
+//
+// Which leaves the question of whether to buy any margin at all, and the honest
+// answer is not yet: two boards are reported not to boot and neither reporter
+// has tested a thing, so nothing here is known to help. OC is the default
+// because it is the configuration that runs on every board actually tested and
+// the one nothing has argued against; the others are the rungs to hand somebody
+// whose board does not boot. Buy margin when there is evidence it fixes
+// something, not before.
 //
 // The upper bits (COOLDOWN=1, PAGEBREAK=2, MIN_DESELECT=7) are identical in
 // all values below; only CLKDIV and RXDELAY differ.
@@ -156,14 +161,16 @@
 #define PICOFACE_QMI_M0_TIMING_RD 0x60007304u
 
 // First rung. Full flash speed with a later sample point: 3.88 ns for the
-// device against OC's 2.76. Expected to be free, since only RXDELAY moves;
-// measured at about 2.5 benchmark points on the D5, roughly 0.6 voices. Still
-// under the 10.0 ns worst case -- this is more margin, not enough margin.
+// device against OC's 2.76, and only RXDELAY moves, so there is no reason to
+// expect it to cost anything. Measurement neither confirms nor denies that --
+// its benchmark numbers sit inside OC's own spread. Still under the 10.0 ns
+// worst case: this is more margin, not enough margin.
 #define PICOFACE_QMI_M0_TIMING_RX4 0x60007403u   // CLKDIV=3, RXDELAY=4
 
 // Second rung, and the first value here that satisfies the worst-case sum:
-// 6.14 ns for the device. Costs 111 MHz instead of 148, measured at 8 benchmark
-// points on the D5, roughly 1.3 voices. RXDELAY=5, not 4: at 4 the budget is 9.01 ns against a
+// 6.14 ns for the device. Costs 111 MHz instead of 148, which measured at six
+// to eight benchmark points on the D5 -- outside the spread, unlike RX4 --
+// roughly 1.3 voices. RXDELAY=5, not 4: at 4 the budget is 9.01 ns against a
 // requirement of 10.0 -- that value was picked against the part's 133 MHz
 // rating, before the pad delays made the real sum computable.
 #define PICOFACE_QMI_M0_TIMING_CD4 0x60007504u   // CLKDIV=4, RXDELAY=5

--- a/instruments/PicoFaceMD/README.md
+++ b/instruments/PicoFaceMD/README.md
@@ -417,35 +417,40 @@ are far better than their worst-case numbers -- but that is exactly the profile
 of a setting that works on one board and not the next, and two issues report
 boards that will not boot.
 
-**`OC` is the default, and the reason is three measurements.** The arithmetic
-alone made `CD4` look right, and it was the default briefly. Then the cost was
-measured on the D5 -- the most XIP-bound of the ten, because it reads its PCM
-from flash -- boot benchmark, four voices, over many power cycles:
+**`OC` is the default, and getting there took three tries and a lesson about
+the measuring instrument.** The arithmetic alone made `CD4` look right, and it
+was the default briefly. Then the cost was measured on the D5 -- the most
+XIP-bound of the ten, because it reads its PCM from flash. Boot benchmark,
+four voices:
 
-| | SCK | RXDELAY | B | voices before the governor trims | for the device |
-|---|---|---|---|---|---|
-| `OC` | 148 MHz | 3 | **51** | 8.1 | 2.76 ns |
-| `RX4` | 148 MHz | 4 | 53–54 | 7.5 | 3.88 ns |
-| `CD4` | 111 MHz | 5 | 59 | 6.8 | 6.14 ns |
+| | SCK | RXDELAY | B | for the device |
+|---|---|---|---|---|
+| `OC` | 148 MHz | 3 | **51** and **53** on different runs | 2.76 ns |
+| `RX4` | 148 MHz | 4 | 53, 54 | 3.88 ns |
+| `CD4` | 111 MHz | 5 | 59 | 6.14 ns |
 
-The benchmark varies by about half a point across boots, so those differences
-are real.
+**Read the spreads before the differences.** `bootBenchPercent()` reports the
+*worst* of 94 blocks, not the mean, and a maximum picks up whatever transient
+landed in one of them — so it swings by two points or more between runs of the
+same image. That is the right statistic for the diagnostic it is (it shows the
+worst case the governor has to survive) and the wrong one for comparing timings
+two points apart.
 
-**The middle row is a finding the datasheet does not carry: RXDELAY costs
-throughput.** `RX4` runs the *same* SCK as `OC` and moves only the sampling
-point, so it was expected to be free — that was the whole argument for making
-it the default. It costs about 2.5 points, five percent. A back-of-envelope says
-it should be a tenth of that: one extra half system clock cycle is 1.13 ns at
-444 MHz, against a cache line fill of some 200 ns. The measurement wins and the
-explanation is missing.
+An earlier version of this section claimed, on one `OC` run against one `RX4`
+run, that RXDELAY costs about five percent of throughput at constant SCK —
+which would have been a finding the datasheet does not carry. A second `OC` run
+came back at 53 and took it away. **Withdrawn.** `OC` and `RX4` overlap and
+nothing measured here separates them.
 
-So there is no free rung, and margin costs voices at much the same rate either
-way — 0.37 ns per benchmark point for `RX4`, 0.42 for `CD4`. Which leaves the
-question of whether to buy any, and the honest answer is *not yet*: two boards
-are reported not to boot and neither reporter has tested a thing, so nothing
-here is known to help. `OC` is the default because it is the configuration that
-runs on every board actually tested, and it is the only one that costs nothing.
-The others are the rungs to hand somebody whose board does not boot.
+`CD4`'s cost does stand: 59 against 51–53 is six to eight points, well outside
+the spread, and about **1.3 voices** before the governor starts trimming tails.
+
+Which leaves whether to buy any margin at all, and the honest answer is *not
+yet*: two boards are reported not to boot and neither reporter has tested a
+thing, so nothing here is known to help. `OC` is the default because it is the
+configuration that runs on every board actually tested and the one nothing has
+argued against. The others are the rungs to hand somebody whose board does not
+boot.
 
 `CD4` itself was wrong when it was added: `RXDELAY=4` gives 9.01 ns, a nanosecond
 short. It had been chosen against the part's 133 MHz rating rather than against


### PR DESCRIPTION
A second `OC` run came back at **B53** where the first had read **B51**, and that takes the finding away.

## What was claimed, and why it is gone

[#126](https://github.com/Michi71/PicoVintageSynthCollection/pull/126) recorded that RXDELAY costs about five percent of throughput at constant SCK — which would have been something the RP2350 datasheet does not carry, since it describes RXDELAY only as a delay on the input sampling register.

It rested on **one** `OC` run against **one** `RX4` run:

| | B, all runs | for the device |
|---|---|---|
| `OC` | **51**, **53** | 2.76 ns |
| `RX4` | 53, 54 | 3.88 ns |
| `CD4` | 59 | 6.14 ns |

`OC` and `RX4` overlap. Nothing measured here separates them.

## The instrument was the problem

```c
if (b >= 2 && us > worst) worst = us;   // a maximum, not a mean
```

`bootBenchPercent()` reports the **worst of 94 blocks**. A maximum picks up whatever transient landed in one of them, so it swings by two points or more between runs of the same image.

That is the right statistic for the diagnostic it is — it shows the worst case the governor has to survive — and the wrong one for comparing timings two points apart. I read a spread as a difference.

Worth stating for the same reason: **temperature is not a plausible explanation** either. The measured time and the block budget both derive from the same PLL-locked clock and the work is fixed, so warming the chip does not move the ratio. What moves is the outlier the maximum catches.

## Not withdrawn

**`CD4`'s cost stands.** B59 against 51–53 is six to eight points, well outside the spread — about 1.3 voices before the governor starts trimming tails.

## Nothing about the default changes

`OC` stays, for the reason that was already sufficient before the arithmetic and the benchmark got involved: it is the configuration that runs on every board actually tested, nothing has argued against it, and neither reporter of a non-booting board has yet tested anything that would say whether the rungs help.

Comments and documentation only — no functional change. All ten build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)