### PR TITLE
Flash: don't overwrite a bootrom mode we never looked at

### DIFF
--- a/core/include/pico_hw.h
+++ b/core/include/pico_hw.h
@@ -64,4 +64,17 @@ static inline void pico_fpu_ftz_enable(void)
 
 void pico_init();
 
+// What the bootrom left in the QMI, captured at the first instruction of
+// pico_init() before anything is changed, plus what we concluded from it.
+// The three registers are diagnostics; the last two are what the flash is
+// actually running with, and every site that restores M0_TIMING after a flash
+// write must use picoface_qmi_timing_effective rather than the compile-time
+// target -- on a board where the bootrom did not establish quad mode, the
+// target is not what we are running.
+extern uint32_t picoface_boot_qmi_timing;
+extern uint32_t picoface_boot_qmi_rfmt;
+extern uint32_t picoface_boot_qmi_rcmd;
+extern bool     picoface_flash_is_quad;
+extern uint32_t picoface_qmi_timing_effective;
+
 #endif // __PICO_HW_H__

--- a/core/src/pico_hw.cpp
+++ b/core/src/pico_hw.cpp
@@ -106,6 +106,12 @@ uint8_t u8x8_gpio_and_delay_pico(u8x8_t *u8x8, uint8_t msg,uint8_t arg_int, void
   return 1;
 }
 
+uint32_t picoface_boot_qmi_timing      = 0;
+uint32_t picoface_boot_qmi_rfmt        = 0;
+uint32_t picoface_boot_qmi_rcmd        = 0;
+bool     picoface_flash_is_quad        = true;   // assumed until pico_init() looks
+uint32_t picoface_qmi_timing_effective = PICOFACE_QMI_M0_TIMING_SAFE;
+
 void pico_init()
 {
     // FPU flush-to-zero + default-NaN for THIS core (see pico_hw.h for the
@@ -139,6 +145,58 @@ void pico_init()
     // so keep the slack timing in that case. The symptom is then loud rather
     // than subtle: the synth runs at 150 MHz and the load percentage on the
     // status line goes through the roof.
+    // What did the bootrom actually leave here? On RP2350 boot_stage2 is
+    // compiled but never runs -- the bootrom configures the flash, and every
+    // firmware inherits its read mode, command byte, address and dummy widths
+    // without looking (raspberrypi/pico-sdk#1903). This one used to inherit
+    // them and then overwrite CLKDIV as if quad mode were a given.
+    //
+    // It is not. A board in issue #107 reported RCMD=0xBB and two-bit widths
+    // with DUMMY_LEN=0 and CLKDIV=35 -- the bootrom had failed to establish
+    // quad on that flash and fallen back to a dual-I/O configuration with no
+    // dummy cycles, which is a low-clock arrangement. Writing CLKDIV=3 over
+    // that runs the part twelve times faster than its own bootrom judged safe,
+    // in a mode we never checked. The board does not boot.
+    picoface_boot_qmi_timing = qmi_hw->m[0].timing;
+    picoface_boot_qmi_rfmt   = qmi_hw->m[0].rfmt;
+    picoface_boot_qmi_rcmd   = qmi_hw->m[0].rcmd;
+
+    // Quad means the EBh read command AND a four-bit data phase. Either alone
+    // is not enough to trust: the command byte says what was asked for, the
+    // width says what the QMI will actually clock.
+    const uint32_t bootDataWidth =
+        (picoface_boot_qmi_rfmt & QMI_M0_RFMT_DATA_WIDTH_BITS) >> QMI_M0_RFMT_DATA_WIDTH_LSB;
+    picoface_flash_is_quad =
+        ((picoface_boot_qmi_rcmd & 0xFFu) == 0xEBu) && (bootDataWidth == 2u);
+
+    if (!picoface_flash_is_quad) {
+        // Keep the flash where the bootrom put it. CLKDIV is a divider of
+        // clk_sys, so raising the clock raises the flash with it unless the
+        // divider grows to match -- scale it, keep every other field the
+        // bootrom chose (RXDELAY, cooldown, deselect), and never write the
+        // compile-time target at all.
+        //
+        // The result is slow: preserving a bootrom that chose CLKDIV=35 gives
+        // a few MHz of XIP, and the sample-reading instruments will be far
+        // from usable. That is the point. A board that boots and shows its
+        // flash clock on the splash can be diagnosed; a dead one cannot.
+        uint32_t bootDiv = picoface_boot_qmi_timing & QMI_M0_TIMING_CLKDIV_BITS;
+        if (bootDiv == 0u) bootDiv = 256u;                 // 0 encodes 256
+        const uint32_t clkNow = clock_get_hz(clk_sys);
+        // ceil(target * bootDiv / clkNow), clamped into the 1..255 the field holds
+        uint64_t want = ((uint64_t)PICOFACE_SYS_CLOCK_HZ * bootDiv + clkNow - 1u) / clkNow;
+        if (want < 1u)   want = 1u;
+        if (want > 255u) want = 255u;
+        picoface_qmi_timing_effective =
+            (picoface_boot_qmi_timing & ~QMI_M0_TIMING_CLKDIV_BITS) | (uint32_t)want;
+        qmi_hw->m[0].timing = picoface_qmi_timing_effective;
+        __dsb();
+        (void)*(volatile uint32_t *)XIP_NOCACHE_NOALLOC_BASE;
+        __dsb();
+        __isb();
+        set_sys_clock_hz(PICOFACE_SYS_CLOCK_HZ, false);
+    } else {
+
     qmi_hw->m[0].timing = PICOFACE_QMI_M0_TIMING_SAFE;
     __dsb();
     // The datasheet asks for one more thing here, which we were not doing:
@@ -166,10 +224,12 @@ void pico_init()
 
     const bool clockOk = set_sys_clock_hz(PICOFACE_SYS_CLOCK_HZ, false);
     // The SAFE timing stays in place if the target turned out to be unreachable.
-    qmi_hw->m[0].timing = clockOk ? PICOFACE_QMI_M0_TIMING_TARGET
-                                  : PICOFACE_QMI_M0_TIMING_SAFE;
+    picoface_qmi_timing_effective = clockOk ? PICOFACE_QMI_M0_TIMING_TARGET
+                                            : PICOFACE_QMI_M0_TIMING_SAFE;
+    qmi_hw->m[0].timing = picoface_qmi_timing_effective;
     __dsb();
     __isb();
+    }
 #else
     hw_set_bits(&vreg_and_chip_reset_hw->vreg, VREG_AND_CHIP_RESET_VREG_VSEL_BITS);
     sleep_ms(33);

--- a/core/src/picoface_main.cpp
+++ b/core/src/picoface_main.cpp
@@ -311,8 +311,12 @@ int main(void)
         const uint32_t clkdiv = clkdivRaw ? clkdivRaw : 256u;
         const uint32_t flashMHz = (clock_get_hz(clk_sys) / clkdiv + 500000u) / 1000000u;
         char hw[24];
-        snprintf(hw, sizeof hw, "A%u  %uMHz", (unsigned)rp2350_chip_version(),
-                 (unsigned)flashMHz);
+        // Q or D/S: whether the bootrom got the flash into quad mode. On a
+        // board where it did not, the whole fast-timing path is skipped and
+        // the flash keeps the bootrom's own (much slower) clock -- so this
+        // letter and that number together say why an instrument feels slow.
+        snprintf(hw, sizeof hw, "A%u %c %uMHz", (unsigned)rp2350_chip_version(),
+                 picoface_flash_is_quad ? 'Q' : 'D', (unsigned)flashMHz);
         u8g2_SetFont(&g_u8g2, u8g2_font_5x7_tf);
         u8g2_DrawStr(&g_u8g2, (128 - u8g2_GetStrWidth(&g_u8g2, hw)) / 2, 60, hw);
     }

--- a/core/src/veeprom.cpp
+++ b/core/src/veeprom.cpp
@@ -66,6 +66,7 @@ void veeprom_sim_reset(void) {
 #include "pico/platform.h"
 #include "hardware/structs/qmi.h"
 #include "project_config.h"
+#include "pico_hw.h"
 
 #ifndef FLASH_SECTOR_SIZE
 #define FLASH_SECTOR_SIZE 4096u
@@ -89,7 +90,11 @@ static void __no_inline_not_in_flash_func(flash_write_locked)(int eraseSectorIdx
     }
     flash_range_program(VEEPROM_FLASH_OFFSET + progOff, buf, VEEPROM_RECORD_SIZE);
 #if PICO_RP2350
-    qmi_hw->m[0].timing = PICOFACE_QMI_M0_TIMING_TARGET;  // undo boot2 re-init clobber
+    // Whatever pico_init() decided we are actually running -- not the
+    // compile-time target. On a board where the bootrom did not establish
+    // quad mode those are different, and writing the target here would
+    // undo the boot's care at the first settings save.
+    qmi_hw->m[0].timing = picoface_qmi_timing_effective;  // undo boot2 re-init clobber
     // Returning from this SRAM-resident function is the first instruction fetch
     // to go through the QMI again, so the timing write must have landed by then.
     // __compiler_memory_barrier() only constrains the compiler; __dsb() is what

--- a/instruments/PicoFaceJ6/src/j6_patchstore.cpp
+++ b/instruments/PicoFaceJ6/src/j6_patchstore.cpp
@@ -55,6 +55,7 @@ static bool bank_store(void) { return true; }
 #include "pico/platform.h"
 #include "veeprom.h"
 #include "project_config.h"
+#include "pico_hw.h"
 
 #ifndef FLASH_SECTOR_SIZE
 #define FLASH_SECTOR_SIZE 4096u
@@ -85,7 +86,11 @@ static void __no_inline_not_in_flash_func(bank_write_locked)(const uint8_t* buf)
     flash_range_program(J6_PATCH_FLASH_OFFSET, buf, FLASH_SECTOR_SIZE);
 
 #if PICO_RP2350
-    qmi_hw->m[0].timing = PICOFACE_QMI_M0_TIMING_TARGET;   /* undo boot2 clobber */
+    // Whatever pico_init() decided we are actually running -- not the
+    // compile-time target. On a board where the bootrom did not establish
+    // quad mode those are different, and writing the target here would
+    // undo the boot's care at the first settings save.
+    qmi_hw->m[0].timing = picoface_qmi_timing_effective;   /* undo boot2 clobber */
     /* Returning from this SRAM-resident function is the first fetch to go
      * through the QMI again, so the write must have landed. __dsb orders the
      * APB write against those fetches; a compiler barrier would not. */

--- a/instruments/PicoFaceMD/README.md
+++ b/instruments/PicoFaceMD/README.md
@@ -545,6 +545,69 @@ Two smaller things were corrected in the same place:
   discarded. On an unreachable target it silently leaves `clk_sys` at 150 MHz;
   the aggressive flash timing is now only applied if the switch succeeded.
 
+
+### What the boards actually reported, and the mode we never checked
+
+The experiment above was run. A diagnostic image reads QMI `M0_TIMING`,
+`M0_RFMT` and `M0_RCMD` as the bootrom left them -- captured in `pico_init()`
+before this project touches the flash -- and puts them on the display. On
+RP2350 that is the only way to know: `boot_stage2` is compiled but never runs,
+the bootrom configures the flash, and what it chose was never visible.
+
+| | working A2 board | reporting board |
+|---|---|---|
+| `M0_RCMD` prefix | `EB` (quad I/O) | **`BB` (dual I/O)** |
+| addr / data width | 4 bit | **2 bit** |
+| `DUMMY_LEN` | 4 | **0** |
+| `M0_TIMING` | `0x60007203` | `0x60007023` as reported |
+
+The timing value is almost certainly a transcription slip: the digits were read
+off a screen that could not be photographed and typed by hand, and
+`0x60007023` is one adjacent-digit transposition away from `0x60007203` --
+which is exactly the working board's value. It is treated as such here.
+
+The other two are not slips. `0x00009154` is not a mistyping of `0x000492A8`,
+and the two registers cross-validate: `9154` decodes to precisely the widths
+and turnaround a `BB` dual-I/O read requires. A slip of the pen does not
+accidentally produce a coherent alternative configuration. **The dual mode is
+real.**
+
+That exposes a defect independent of any boot failure. `pico_init()` wrote its
+tuned `M0_TIMING` over whatever the bootrom had established, without ever
+looking at what that was. The tuned value is measured for quad reads with four
+dummy cycles; a dual read with none is a different proposition at the same
+divider -- half the bandwidth per clock, and a turnaround carried entirely by
+the mode byte. We had been overwriting a flash configuration we had never
+looked at.
+
+The fix reads `M0_RCMD` and `M0_RFMT` first and applies the tuned value only
+when the bootrom actually established quad -- prefix `EB` and 4-bit widths.
+Otherwise every field the bootrom chose is kept and only `CLKDIV` is rescaled,
+so the flash keeps the clock it already had across the core-clock change:
+
+| bootrom | flash before | flash after, core at 444 MHz |
+|---|---|---|
+| `CLKDIV=3` @ 150 MHz | 50.0 MHz | 49.3 MHz (`CLKDIV=9`) |
+| without this fix | | 148.0 MHz |
+
+The splash line carries the mode as a `Q` or `D` (`A2 Q 148MHz`), so a board
+running dual is visible in one glance instead of invisible for a fortnight.
+The three post-flash-write restore sites write the value the boot actually
+settled on rather than the compile-time macro, or the first settings save
+would undo the caution.
+
+**This is a correctness fix, not a proven cure.** Two things must be said
+against reading it as the answer to #107. Under the corrected timing value the
+reporting board's bootrom picked the *same* divider as the working one, so the
+flash divider is not what separates them. And the clock ladder does not order
+by flash clock at all: `SAFE`'s 55.5 MHz failed at a 444 MHz core, while `OC`'s
+100 MHz works at a 300 MHz core. No monotone function of flash clock produces
+that; core clock produces it immediately. The prime suspect is therefore the
+core clock, and this fix earns its keep by making the next experiment clean --
+it moves the flash to 49 MHz while leaving the core at 444, which no previous
+build did. The reported chip revision was also `A3`, not the `A4` of the issue
+title, and is hand-transcribed like the rest.
+
 ### Double-tap RESET, and why it used to be disabled
 
 In the standalone repository `pico_bootsel_via_double_reset` was deliberately

--- a/instruments/PicoFaceRD/src/veeprom.cpp
+++ b/instruments/PicoFaceRD/src/veeprom.cpp
@@ -66,6 +66,7 @@ void veeprom_sim_reset(void) {
 #include "pico/platform.h"
 #include "hardware/structs/qmi.h"
 #include "project_config.h"
+#include "pico_hw.h"
 
 #ifndef FLASH_SECTOR_SIZE
 #define FLASH_SECTOR_SIZE 4096u
@@ -89,7 +90,11 @@ static void __no_inline_not_in_flash_func(flash_write_locked)(int eraseSectorIdx
     }
     flash_range_program(VEEPROM_FLASH_OFFSET + progOff, buf, VEEPROM_RECORD_SIZE);
 #if PICO_RP2350
-    qmi_hw->m[0].timing = PICOFACE_QMI_M0_TIMING_TARGET;  // undo boot2 re-init clobber
+    // Whatever pico_init() decided we are actually running -- not the
+    // compile-time target. On a board where the bootrom did not establish
+    // quad mode those are different, and writing the target here would
+    // undo the boot's care at the first settings save.
+    qmi_hw->m[0].timing = picoface_qmi_timing_effective;  // undo boot2 re-init clobber
     // Returning from this SRAM-resident function is the first instruction fetch
     // to go through the QMI again, so the timing write must have landed by then.
     // __compiler_memory_barrier() only constrains the compiler; __dsb() is what


### PR DESCRIPTION
## What this fixes

On RP2350 `boot_stage2` is compiled but never runs — the **bootrom** configures
the flash. `pico_init()` then wrote its tuned `M0_TIMING` over that, without
ever looking at what had been established.

A diagnostic image (PR #128) read the three registers back on two boards, as the
bootrom left them:

| | working A2 board | reporting board (#107) |
|---|---|---|
| `M0_RCMD` prefix | `EB` (quad I/O) | **`BB` (dual I/O)** |
| addr / data width | 4 bit | **2 bit** |
| `DUMMY_LEN` | 4 | **0** |
| `M0_TIMING` | `0x60007203` | `0x60007023` as reported |

Our tuned value is measured for **quad reads with four dummy cycles**. On a
board running a dual read with none it was applied anyway — half the bandwidth
per clock, and a turnaround carried entirely by the mode byte.

## The timing value is treated as a typo

`0x60007023` is one adjacent-digit transposition away from `0x60007203`, which
is exactly the working board's value, and the digits were read off a screen that
could not be photographed and typed by hand. It is almost certainly a slip and is
treated as one here.

The other two are **not** slips, and they cross-validate: `0x00009154` decodes to
precisely the widths and turnaround a `BB` dual-I/O read requires. A slip of the
pen does not accidentally produce a coherent alternative configuration. The dual
mode is real regardless of what the divider actually was.

## The change

Capture `M0_TIMING` / `M0_RFMT` / `M0_RCMD` before anything changes, then:

- **quad established** (prefix `EB`, 4-bit widths) → the tuned timing, exactly as
  before. Every board tested so far is on this path and is bit-for-bit unaffected.
- **anything else** → keep every field the bootrom chose and rescale `CLKDIV`
  only, so the flash keeps the clock it already had across the core-clock change.

| bootrom | flash before | flash after, core at 444 MHz |
|---|---|---|
| `CLKDIV=3` @ 150 MHz | 50.0 MHz | 49.3 MHz (`CLKDIV=9`) |
| *without this fix* | | *148.0 MHz* |

The fix reads the register, not the transcription, so it is immune to the typo
question above — it does the right thing under either reading.

Two supporting changes:

- The splash carries the mode as `Q` or `D` (`A2 Q 148MHz`), so a board running
  dual is visible at a glance instead of invisible for a fortnight.
- The three post-flash-write restore sites (`core/src/veeprom.cpp`,
  `instruments/PicoFaceRD/src/veeprom.cpp`,
  `instruments/PicoFaceJ6/src/j6_patchstore.cpp`) write the value the boot
  actually settled on, not the compile-time macro — otherwise the first settings
  save would undo the caution.

## Verification

Machine code confirms all three registers are read **before** any timing write:

```
ldr r1, [r2, #12]    ; TIMING captured
ldr r0, [r2, #16]    ; RFMT   captured
ldr r3, [r2, #20]    ; RCMD   captured
cmp r3, #235         ; == 0xEB ?
beq ...              ; quad path
```

Full build: 10/10 UF2, 0 errors. Both timing constants still present in the
images; the quad path is unchanged.

## What this does not settle

**This is a correctness fix, not a proven cure for #107.** Under the corrected
timing value the reporting board's bootrom picked the *same* divider as the
working one, so the flash divider is not what separates them. And the clock
ladder does not order by flash clock at all: `SAFE`'s 55.5 MHz failed at a
444 MHz core, while `OC`'s 100 MHz works at a 300 MHz core. No monotone function
of flash clock produces that ordering; core clock produces it immediately.

The prime suspect is therefore the **core clock**. This fix earns its keep by
making the next experiment clean — it moves the flash to 49 MHz while leaving
the core at 444 MHz, which no previous build did.

The reported chip revision was `A3`, not the `A4` of the issue title, and is
hand-transcribed like the rest.

Refs #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)