### PR TITLE
Flash: measure the timing at boot instead of prescribing it

### DIFF
--- a/core/include/pico_hw.h
+++ b/core/include/pico_hw.h
@@ -77,4 +77,9 @@ extern uint32_t picoface_boot_qmi_rcmd;
 extern bool     picoface_flash_is_quad;
 extern uint32_t picoface_qmi_timing_effective;
 
+// False when no rung of the boot-time ladder reproduced the reference checksum
+// and the bootrom's own rescaled timing had to be taken on trust. Boards that
+// verify -- every one tested so far -- set this true.
+extern bool     picoface_flash_verified;
+
 #endif // __PICO_HW_H__

--- a/core/include/project_config.h
+++ b/core/include/project_config.h
@@ -146,10 +146,10 @@
 // failure".
 #define PICOFACE_QMI_M0_TIMING_SAFE 0x60007208u
 
-// The default. 148 MHz flash at 444 MHz, sampled as early as it goes, and
-// 2.76 ns for a device that may want 6 in the worst case -- which is why the
-// rungs below exist. It has run on every board tested here, and it is the only
-// value that costs nothing.
+// 148 MHz flash at 444 MHz, sampled as early as it goes: 2.76 ns for a device
+// that may want 6 in the worst case, which places the sample point 11 % into
+// the window where the bit is valid. It was the default until RX4 took over
+// -- same speed, same measured cost, and 28 % into that window.
 #define PICOFACE_QMI_M0_TIMING_OC 0x60007303u
 
 // 480 MHz target: CLKDIV=4, RXDELAY=3 -> 120 MHz flash. Used by PicoFaceRD,
@@ -160,11 +160,19 @@
 // thing to try if an RD ever fails to boot.
 #define PICOFACE_QMI_M0_TIMING_RD 0x60007304u
 
-// First rung. Full flash speed with a later sample point: 3.88 ns for the
+// The default. Full flash speed with a later sample point: 3.88 ns for the
 // device against OC's 2.76, and only RXDELAY moves, so there is no reason to
 // expect it to cost anything. Measurement neither confirms nor denies that --
 // its benchmark numbers sit inside OC's own spread. Still under the 10.0 ns
 // worst case: this is more margin, not enough margin.
+//
+// It is the default because the sample point is better placed. A bit is valid
+// from the device's clock-to-output until the next bit replaces it -- at
+// 148 MHz that is 6.00 to 12.76 ns. OC samples at 6.76, which is 11 % into
+// that window and hard against its leading edge; RX4 samples at 7.88, 28 % in.
+// The two were briefly swapped back in favour of OC on a measurement that
+// RXDELAY costs throughput. That measurement was withdrawn (it was noise in a
+// maximum, see README) and this is the default following the retraction.
 #define PICOFACE_QMI_M0_TIMING_RX4 0x60007403u   // CLKDIV=3, RXDELAY=4
 
 // Second rung, and the first value here that satisfies the worst-case sum:
@@ -196,7 +204,7 @@
 #endif
 
 #ifndef PICOFACE_QMI_M0_TIMING_TARGET
-#define PICOFACE_QMI_M0_TIMING_TARGET PICOFACE_QMI_M0_TIMING_OC
+#define PICOFACE_QMI_M0_TIMING_TARGET PICOFACE_QMI_M0_TIMING_RX4
 #endif
 
 

--- a/core/src/pico_hw.cpp
+++ b/core/src/pico_hw.cpp
@@ -111,6 +111,89 @@ uint32_t picoface_boot_qmi_rfmt        = 0;
 uint32_t picoface_boot_qmi_rcmd        = 0;
 bool     picoface_flash_is_quad        = true;   // assumed until pico_init() looks
 uint32_t picoface_qmi_timing_effective = PICOFACE_QMI_M0_TIMING_SAFE;
+bool     picoface_flash_verified       = false;  // did the chosen timing prove itself?
+
+#if PICO_RP2350
+// --- Boot-time flash timing self-calibration -------------------------------
+//
+// The timing this project wants is faster than the part is specified for: at
+// 148 MHz the device is given 3.88 ns where a 133 MHz part may ask for 6 in
+// the worst case. It has worked on every board tested, because real silicon at
+// room temperature beats its worst case by a wide margin -- but "works on the
+// boards we own" is not a property one can put in a hardware requirement, and
+// two issues report boards that will not start.
+//
+// So stop asserting it and measure it instead. Checksum a slab of flash at the
+// timing the bootrom itself was using, raise the clock, then walk a ladder from
+// fastest to slowest and keep the first rung that reproduces the checksum. A
+// board that cannot hold 148 MHz lands on 111 or 55 instead of not booting, and
+// a board that can is left exactly where it was -- this must never slow down
+// hardware that already works.
+//
+// Everything from here to the end of the ladder runs from SRAM. That is the
+// part that makes it safe rather than merely clever: while a candidate timing
+// is in force every flash read is suspect, so a wrong one has to corrupt DATA,
+// never the instruction stream. Code in flash would fetch garbage and fault.
+
+// 32 KB of the firmware image itself -- varied data rather than a pattern, and
+// long enough that a marginal sample point shows up as a mismatch rather than
+// getting lucky. Costs about 2 ms per rung at full speed.
+#define PICOFACE_FLASH_PROBE_WORDS (8u * 1024u)
+
+// NOTE on __attribute__((noinline)): pico-sdk's __not_in_flash_func() sets the
+// section and nothing else. Under this file's `#pragma GCC optimize("Ofast")`
+// the compiler happily inlines these three into pico_init(), which lives in
+// flash -- and then the routine that must not execute from flash does exactly
+// that, silently, with no diagnostic. The build looks identical and the design
+// is gone. Keep noinline, and keep the check in the PR that reads the symbol
+// addresses back out of the ELF.
+
+// Read through the no-cache window: a cached second pass would be answered
+// from SRAM and would "verify" any timing at all, including a broken one.
+static __attribute__((noinline)) uint32_t __not_in_flash_func(picoface_flash_probe)(void)
+{
+    const volatile uint32_t *p = (const volatile uint32_t *)XIP_NOCACHE_NOALLOC_BASE;
+    uint32_t h = 2166136261u;                       // FNV-1a over words
+    for (uint32_t i = 0; i < PICOFACE_FLASH_PROBE_WORDS; i++) {
+        h ^= p[i];
+        h *= 16777619u;
+    }
+    return h;
+}
+
+static __attribute__((noinline)) bool __not_in_flash_func(picoface_flash_try)(uint32_t timing, uint32_t ref)
+{
+    qmi_hw->m[0].timing = timing;
+    __dsb();
+    (void)*(volatile uint32_t *)XIP_NOCACHE_NOALLOC_BASE;   // make the divisor take effect
+    __dsb();
+    __isb();
+    return picoface_flash_probe() == ref;
+}
+
+// Rungs arrive as arguments, not as a table: a flash-resident array would have
+// to be read while a candidate timing is in force, which is the one thing this
+// routine may not do. The literals are materialised by the caller, before any
+// of them is applied.
+static __attribute__((noinline)) uint32_t __not_in_flash_func(picoface_flash_autotune)(uint32_t ref,
+                                                             uint32_t fast,
+                                                             uint32_t mid,
+                                                             uint32_t slow,
+                                                             uint32_t fallback,
+                                                             bool *verified)
+{
+    *verified = true;
+    if (picoface_flash_try(fast, ref)) return fast;
+    if (picoface_flash_try(mid,  ref)) return mid;
+    if (picoface_flash_try(slow, ref)) return slow;
+    *verified = false;
+    // Nothing verified. The bootrom's own configuration, rescaled to hold the
+    // flash clock it chose, is the most trustworthy thing left; apply it and
+    // take it either way, because there is nothing below it to fall to.
+    (void)picoface_flash_try(fallback, ref);
+    return fallback;
+}
+#endif
 
 void pico_init()
 {
@@ -169,35 +252,32 @@ void pico_init()
     picoface_flash_is_quad =
         ((picoface_boot_qmi_rcmd & 0xFFu) == 0xEBu) && (bootDataWidth == 2u);
 
-    if (!picoface_flash_is_quad) {
-        // Keep the flash where the bootrom put it. CLKDIV is a divider of
-        // clk_sys, so raising the clock raises the flash with it unless the
-        // divider grows to match -- scale it, keep every other field the
-        // bootrom chose (RXDELAY, cooldown, deselect), and never write the
-        // compile-time target at all.
-        //
-        // The result is slow: preserving a bootrom that chose CLKDIV=35 gives
-        // a few MHz of XIP, and the sample-reading instruments will be far
-        // from usable. That is the point. A board that boots and shows its
-        // flash clock on the splash can be diagnosed; a dead one cannot.
-        uint32_t bootDiv = picoface_boot_qmi_timing & QMI_M0_TIMING_CLKDIV_BITS;
-        if (bootDiv == 0u) bootDiv = 256u;                 // 0 encodes 256
-        const uint32_t clkNow = clock_get_hz(clk_sys);
-        // ceil(target * bootDiv / clkNow), clamped into the 1..255 the field holds
-        uint64_t want = ((uint64_t)PICOFACE_SYS_CLOCK_HZ * bootDiv + clkNow - 1u) / clkNow;
-        if (want < 1u)   want = 1u;
-        if (want > 255u) want = 255u;
-        picoface_qmi_timing_effective =
-            (picoface_boot_qmi_timing & ~QMI_M0_TIMING_CLKDIV_BITS) | (uint32_t)want;
-        qmi_hw->m[0].timing = picoface_qmi_timing_effective;
-        __dsb();
-        (void)*(volatile uint32_t *)XIP_NOCACHE_NOALLOC_BASE;
-        __dsb();
-        __isb();
-        set_sys_clock_hz(PICOFACE_SYS_CLOCK_HZ, false);
-    } else {
+    // The reference: a checksum of a slab of flash taken at the timing the
+    // bootrom itself was using. The chip booted and is executing from flash
+    // with it, which makes it the one configuration known to be correct here.
+    const uint32_t flashRef = picoface_flash_probe();
 
-    qmi_hw->m[0].timing = PICOFACE_QMI_M0_TIMING_SAFE;
+    // The last resort, computed while the old clock still stands: the bootrom's
+    // own timing with CLKDIV scaled so the flash keeps the clock it chose
+    // across the jump. Every other field it picked is preserved -- RXDELAY,
+    // cooldown, deselect -- because none of them was chosen by us.
+    uint32_t bootDiv = picoface_boot_qmi_timing & QMI_M0_TIMING_CLKDIV_BITS;
+    if (bootDiv == 0u) bootDiv = 256u;                 // 0 encodes 256
+    const uint32_t clkNow = clock_get_hz(clk_sys);
+    // ceil(target * bootDiv / clkNow), clamped into the 1..255 the field holds
+    uint64_t want = ((uint64_t)PICOFACE_SYS_CLOCK_HZ * bootDiv + clkNow - 1u) / clkNow;
+    if (want < 1u)   want = 1u;
+    if (want > 255u) want = 255u;
+    const uint32_t scaledBoot =
+        (picoface_boot_qmi_timing & ~QMI_M0_TIMING_CLKDIV_BITS) | (uint32_t)want;
+
+    // Slack across the clock switch. A board the bootrom put in quad gets SAFE,
+    // which is what has always been used here and is known to survive the jump;
+    // anything else gets its own bootrom's settings rescaled, because SAFE's
+    // other fields were never chosen with that flash in mind.
+    const uint32_t slack = picoface_flash_is_quad ? PICOFACE_QMI_M0_TIMING_SAFE
+                                                  : scaledBoot;
+    qmi_hw->m[0].timing = slack;
     __dsb();
     // The datasheet asks for one more thing here, which we were not doing:
     //
@@ -207,7 +287,6 @@ void pico_init()
     //    Mx_TIMING write to ensure the SCK divisor change is in effect _before_
     //    the system clock is changed."
     //
-    // That is exactly this write: CLKDIV goes 4 -> 8 ahead of the clk_sys jump.
     // The barriers order the APB write, but they do not make the QMI run a
     // transaction, and until it does the new divisor need not be in effect. The
     // only flash access that followed was the instruction fetch of the code
@@ -222,14 +301,31 @@ void pico_init()
     __dsb();
     __isb();
 
+    // set_sys_clock_hz() is called with required=false: on an unreachable
+    // target it returns false and silently leaves clk_sys at its default.
+    // 444 MHz is reachable via the PLL (VCO 1332 / 3), but if that ever changes
+    // we must not tighten the flash timing for a clock the part never got to.
     const bool clockOk = set_sys_clock_hz(PICOFACE_SYS_CLOCK_HZ, false);
-    // The SAFE timing stays in place if the target turned out to be unreachable.
-    picoface_qmi_timing_effective = clockOk ? PICOFACE_QMI_M0_TIMING_TARGET
-                                            : PICOFACE_QMI_M0_TIMING_SAFE;
+
+    if (!clockOk) {
+        // clk_sys never moved, so the slack timing is already the right one and
+        // nothing faster may be applied. The symptom is loud rather than
+        // subtle: the synth runs at 150 MHz and the load percentage on the
+        // status line goes through the roof.
+        picoface_qmi_timing_effective = slack;
+        picoface_flash_verified       = false;
+    } else {
+        picoface_qmi_timing_effective =
+            picoface_flash_autotune(flashRef,
+                                    PICOFACE_QMI_M0_TIMING_TARGET,
+                                    PICOFACE_QMI_M0_TIMING_CD4,
+                                    PICOFACE_QMI_M0_TIMING_SAFE,
+                                    scaledBoot,
+                                    &picoface_flash_verified);
+    }
     qmi_hw->m[0].timing = picoface_qmi_timing_effective;
     __dsb();
     __isb();
-    }
 #else
     hw_set_bits(&vreg_and_chip_reset_hw->vreg, VREG_AND_CHIP_RESET_VREG_VSEL_BITS);
     sleep_ms(33);

--- a/instruments/PicoFaceMD/README.md
+++ b/instruments/PicoFaceMD/README.md
@@ -411,14 +411,15 @@ the requirement is 10.0 ns, and at 444 MHz:
 | `RX4` | 3 | 4 | 148.0 MHz | 7.88 ns | 3.88 ns |
 | `OC` | 3 | 3 | 148.0 MHz | 6.76 ns | **2.76 ns** |
 
-`OC` was the default and leaves 2.76 ns where the part asks for 6. It has run on
-every board tested here, because real pads and a real flash at room temperature
-are far better than their worst-case numbers -- but that is exactly the profile
-of a setting that works on one board and not the next, and two issues report
-boards that will not boot.
+`OC` was the default for a while and leaves 2.76 ns where the part asks for 6.
+It has run on every board tested here, because real pads and a real flash at
+room temperature are far better than their worst-case numbers -- but that is
+exactly the profile of a setting that works on one board and not the next, and
+two issues report boards that will not boot. `RX4` is the default now, and the
+ladder is walked at boot rather than handed out by e-mail; both are below.
 
-**`OC` is the default, and getting there took three tries and a lesson about
-the measuring instrument.** The arithmetic alone made `CD4` look right, and it
+**Getting to a default took three tries and a lesson about the measuring
+instrument.** The arithmetic alone made `CD4` look right, and it
 was the default briefly. Then the cost was measured on the D5 -- the most
 XIP-bound of the ten, because it reads its PCM from flash. Boot benchmark,
 four voices:
@@ -445,12 +446,19 @@ nothing measured here separates them.
 `CD4`'s cost does stand: 59 against 51–53 is six to eight points, well outside
 the spread, and about **1.3 voices** before the governor starts trimming tails.
 
-Which leaves whether to buy any margin at all, and the honest answer is *not
-yet*: two boards are reported not to boot and neither reporter has tested a
-thing, so nothing here is known to help. `OC` is the default because it is the
-configuration that runs on every board actually tested and the one nothing has
-argued against. The others are the rungs to hand somebody whose board does not
-boot.
+Which leaves which rung to ship. **`RX4` is the default**, and it is a free
+change: same 148 MHz, and its benchmark numbers sit inside `OC`'s own spread, so
+nothing measured separates them on cost. What separates them is where in the
+valid window the sample point lands. A bit is good from the device's
+clock-to-output until the next bit replaces it -- at 148 MHz, 6.00 to 12.76 ns.
+`OC` samples at 6.76, which is 11 % in and hard against the leading edge; `RX4`
+samples at 7.88, 28 % in. Free margin is worth taking.
+
+There is some history in that sentence. `RX4` was briefly the default, then
+reverted to `OC` on a measurement that RXDELAY costs about five percent of
+throughput. That measurement was withdrawn one PR later -- it was noise in a
+maximum -- but the default never followed the retraction, and stayed on `OC` for
+a reason that no longer existed.
 
 `CD4` itself was wrong when it was added: `RXDELAY=4` gives 9.01 ns, a nanosecond
 short. It had been chosen against the part's 133 MHz rating rather than against
@@ -607,6 +615,78 @@ core clock, and this fix earns its keep by making the next experiment clean --
 it moves the flash to 49 MHz while leaving the core at 444, which no previous
 build did. The reported chip revision was also `A3`, not the `A4` of the issue
 title, and is hand-transcribed like the rest.
+
+
+### Measuring the flash instead of prescribing it
+
+Everything above is an argument about which single timing to ship, and every
+version of that argument has the same hole in it: the right value is a property
+of the board, and the boards are not ours. Waveshare changes flash suppliers
+between production runs; the same part number, bought twice, need not carry the
+same die. The honest hardware requirement for a fixed 148 MHz would read *"a
+QSPI flash that beats its own datasheet by more than a factor of two"*, and
+nobody can shop for that.
+
+Two things are worth separating before the fix, because the dual-mode finding
+above invites the wrong conclusion:
+
+- **Dual is not slower to sample than quad.** Same pins, same clock, same
+  clock-to-output; a 133 MHz part is rated 133 MHz either way. The budget table
+  applies unchanged. **A dual flash can be clocked exactly as high as a quad
+  one** -- what dual costs is *bandwidth*, two bits per clock instead of four.
+- **Dual is usually not a property of the chip either.** Practically every 16 MB
+  SPI NOR supports quad I/O. Coming up in dual normally means the bootrom could
+  not *confirm* quad, because the quad-enable bit sits in a different
+  status-register bit per manufacturer. It is a probe outcome, not something
+  printed on the package -- which is the second reason a hardware requirement
+  would not have helped.
+
+So the timing is measured at boot instead of asserted. Checksum 32 KB of flash
+at the timing the bootrom itself was running -- the chip booted with it, so it
+is the one configuration known good -- raise the clock, then walk the ladder
+fastest-first and keep the first rung that reproduces the checksum:
+
+| rung | SCK | outcome |
+|---|---|---|
+| `RX4` | 148 MHz | kept if it verifies; every board tested lands here |
+| `CD4` | 111 MHz | first fallback, the first value inside the worst-case sum |
+| `SAFE` | 55.5 MHz | second fallback |
+| bootrom's own, `CLKDIV` rescaled | whatever it chose | last resort, taken on trust |
+
+**This must never slow down hardware that already works, and it does not:** a
+board that verifies at `RX4` is left exactly where it was. The ladder only
+rescues boards that would otherwise not start, which is the entire point.
+
+The part that makes it safe rather than merely clever is that the probe, the
+per-rung retry and the ladder all execute **from SRAM**. While a candidate
+timing is in force every flash read is suspect, so a wrong one must corrupt
+*data*, never the instruction stream -- code in flash would fetch garbage and
+fault instead of returning a mismatch. Two details fall out of that and both
+are checked in the built ELF rather than assumed:
+
+- `__not_in_flash_func()` sets the section and **nothing else**. Under this
+  file's `#pragma GCC optimize("Ofast")` the compiler inlined all three routines
+  into `pico_init()`, which lives in flash -- the design was silently gone and
+  the build looked identical. They carry an explicit `noinline` now, and the
+  first version of this section was written against an ELF in which the symbols
+  did not exist at all.
+- The rung constants reach the routine as arguments rather than as a table. A
+  flash-resident array would have to be read while a candidate timing is in
+  force, which is the one thing this code may not do. In the built image the
+  literal pool sits inside the RAM function (`60007403`, `60007504`, `60007208`
+  at `0x200002a8`), every `bl` targets a RAM address, and the probe reads
+  through `0x14000000` -- the no-cache window, because a cached second pass
+  would be answered from SRAM and would "verify" a broken timing.
+
+Cost is about 5 ms at boot on a quad board and under 100 ms on a slow dual one,
+against a splash screen that is held for two seconds.
+
+**What it does not cover:** the check runs at boot temperature, and timing
+margin shrinks as the die warms. A rung that verifies cold could in principle
+fail hot. Taking the rung *below* the fastest that verifies would cover it and
+was rejected -- it would cost every working board 1.3 voices to insure against
+something not yet observed. If a board is ever reported to fail after warming
+up, that is the knob.
 
 ### Double-tap RESET, and why it used to be disabled
 


### PR DESCRIPTION
Answers a question that came out of #107 and #122: *do we need a hardware
requirement — a quad flash?*

**No, and a requirement would not have helped anyway.**

- **Dual is not slower to sample than quad.** Same pins, same clock, same
  clock-to-output; a 133 MHz part is rated 133 MHz either way. A dual flash can
  be clocked exactly as high. What dual costs is *bandwidth* — two bits per
  clock instead of four. (This corrects a sentence in #128, which said a dual
  read at the same divider was "a different proposition". Signal-wise it is not.)
- **Dual is usually not a property of the chip either.** Practically every 16 MB
  SPI NOR supports quad I/O; coming up in dual normally means the bootrom could
  not *confirm* quad, because the quad-enable bit sits in a different
  status-register bit per manufacturer. It is a probe outcome, not something
  printed on the package.

The honest requirement for a fixed 148 MHz would read *"a QSPI flash that beats
its own datasheet by more than a factor of two"*. Nobody can shop for that. So
this stops asserting the timing and measures it.

## 1. RX4 becomes the default

Same 148 MHz, and its benchmark numbers sit inside `OC`'s own spread — nothing
measured separates them on cost. What separates them is where the sample point
lands. A bit is valid from clock-to-output until the next bit replaces it; at
148 MHz that is 6.00–12.76 ns:

| | SCK | samples at | into the window |
|---|---|---|---|
| `OC` (old default) | 148 MHz | 6.76 ns | **11 %** |
| `RX4` (new default) | 148 MHz | 7.88 ns | 28 % |

`RX4` was briefly the default already and was reverted in #126 on a measurement
that RXDELAY costs ~5 % of throughput. That measurement was **withdrawn** in
#127 — it was noise in a maximum — but the default never followed the
retraction and stayed on `OC` for a reason that no longer existed.

## 2. The ladder is walked at boot

Checksum 32 KB of flash at the timing the bootrom itself was running — the chip
booted with it, so it is the one configuration known good — raise the clock,
then keep the first rung that reproduces the checksum:

| rung | SCK (444 MHz core) | budget |
|---|---|---|
| `RX4` | 148.0 MHz | 7.88 ns |
| `CD4` | 111.0 MHz | 10.14 ns |
| `SAFE` | 55.5 MHz | 11.26 ns |
| bootrom's own, `CLKDIV` rescaled | whatever it chose | last resort, taken on trust |

RD keeps its own ladder at 480 MHz (`RD` 120 MHz → `CD4` 120 MHz with more
RXDELAY → `SAFE` 60 MHz), which is monotone in budget too.

**This must never slow down hardware that already works, and it does not:** a
board that verifies at the top rung is left exactly where it was. The ladder
only rescues boards that would otherwise not start.

## Why it is safe, and how that was checked

The probe, the per-rung retry and the ladder all execute **from SRAM**. While a
candidate timing is in force every flash read is suspect, so a wrong one must
corrupt *data*, never the instruction stream — code in flash would fetch garbage
and fault instead of returning a mismatch.

Two traps, both found by reading the built ELF rather than trusting the source:

- **`__not_in_flash_func()` sets the section and nothing else.** Under this
  file's `#pragma GCC optimize("Ofast")` the compiler inlined all three routines
  into `pico_init()`, which lives in flash. The design was silently gone and the
  build looked identical — the symbols did not exist in the image at all. They
  carry an explicit `noinline` now.
- **The rung constants are arguments, not a table.** A flash-resident array
  would have to be read while a candidate timing is in force, which is the one
  thing this code may not do.

Verified in **all ten images**: the three routines at RAM addresses, and in the
disassembly every `bl` targets RAM, the literal pool sits inside the RAM
function (`60007403` / `60007504` / `60007208` at `0x200002a8`), and the probe
reads through `0x14000000` — the **no-cache** window, since a cached second pass
would be answered from SRAM and would "verify" any timing at all.

```
20000260 <picoface_flash_autotune>:
  20000270:  bl  2000022c <picoface_flash_try>   ; RAM -> RAM, no veneer
  200002a8:  .word 0x60007403                    ; rung literal, in RAM
```

Cost is about 5 ms at boot on a quad board, under 100 ms on a slow dual one,
against a splash held for two seconds. Full build 10/10, 0 errors.

## What it does not cover

The check runs at **boot temperature**, and timing margin shrinks as the die
warms — a rung that verifies cold could in principle fail hot. Taking the rung
*below* the fastest that verifies would cover that and was rejected: it would
cost every working board ~1.3 voices to insure against something not yet
observed. If a board is ever reported to fail after warming up, that is the knob.

Refs #107, #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)