### PR TITLE
Flash: no upward ladder on a board the bootrom left in dual

### DIFF
--- a/core/src/pico_hw.cpp
+++ b/core/src/pico_hw.cpp
@@ -314,6 +314,25 @@ void pico_init()
         // status line goes through the roof.
         picoface_qmi_timing_effective = slack;
         picoface_flash_verified       = false;
+    } else if (!picoface_flash_is_quad) {
+        // The bootrom could not establish quad on this flash. Do NOT probe
+        // upward here.
+        //
+        // The upward ladder rests on an assumption that hardware has now
+        // refuted: that a too-fast timing returns bad data, so the checksum
+        // mismatches and the next rung gets a turn. On a board in issue #107 it
+        // does not -- it takes the chip down, and the ladder never reaches its
+        // second rung. Two 444 MHz images differing only in their FIRST rung
+        // decide it: with a slow one the board boots, with RX4 it is dead.
+        // A faulting XIP read is not confined to data either; the fault handler
+        // itself lives in flash, which is exactly what is broken at that moment.
+        //
+        // So on these boards keep what the bootrom chose, rescaled to hold its
+        // clock. That is slow and it boots, which beats fast and dead. The
+        // ladder stays for boards the bootrom put in quad, where every rung-one
+        // verification so far has succeeded and no bad timing is ever applied.
+        picoface_qmi_timing_effective = scaledBoot;
+        picoface_flash_verified       = false;
     } else {
         picoface_qmi_timing_effective =
             picoface_flash_autotune(flashRef,

--- a/core/src/picoface_main.cpp
+++ b/core/src/picoface_main.cpp
@@ -309,8 +309,10 @@ int main(void)
         // CLKDIV encodes the SCK period in system clock cycles; 0 means 256.
         const uint32_t clkdivRaw = qmi_hw->m[0].timing & QMI_M0_TIMING_CLKDIV_BITS;
         const uint32_t clkdiv = clkdivRaw ? clkdivRaw : 256u;
-        const uint32_t flashMHz = (clock_get_hz(clk_sys) / clkdiv + 500000u) / 1000000u;
-        char hw[24];
+        const uint32_t sysHz    = clock_get_hz(clk_sys);
+        const uint32_t coreMHz  = (sysHz + 500000u) / 1000000u;
+        const uint32_t flashMHz = (sysHz / clkdiv + 500000u) / 1000000u;
+        char hw[32];
         // Q or D/S: whether the bootrom got the flash into quad mode. On a
         // board where it did not, the whole fast-timing path is skipped and
         // the flash keeps the bootrom's own (much slower) clock -- so this
@@ -320,9 +322,14 @@ int main(void)
         // without it an A/B of two timings is unreadable at the device.
         const uint32_t rxdelay =
             (qmi_hw->m[0].timing & QMI_M0_TIMING_RXDELAY_BITS) >> QMI_M0_TIMING_RXDELAY_LSB;
-        snprintf(hw, sizeof hw, "A%u %c %uMHz r%u", (unsigned)rp2350_chip_version(),
-                 picoface_flash_is_quad ? 'Q' : 'D', (unsigned)flashMHz,
-                 (unsigned)rxdelay);
+        // The core clock leads: it is what set_sys_clock_hz() may silently have
+        // failed to reach (the flash figure is derived from it and would then
+        // be misread as a flash problem), and it is the parameter the #107
+        // board is suspected on. Reading "core/flash" also makes a set of
+        // images that differ only in clock target tellable apart at the device.
+        snprintf(hw, sizeof hw, "A%u %c %u/%u r%u", (unsigned)rp2350_chip_version(),
+                 picoface_flash_is_quad ? 'Q' : 'D', (unsigned)coreMHz,
+                 (unsigned)flashMHz, (unsigned)rxdelay);
         u8g2_SetFont(&g_u8g2, u8g2_font_5x7_tf);
         u8g2_DrawStr(&g_u8g2, (128 - u8g2_GetStrWidth(&g_u8g2, hw)) / 2, 60, hw);
     }

--- a/instruments/PicoFaceMD/README.md
+++ b/instruments/PicoFaceMD/README.md
@@ -658,8 +658,13 @@ fastest-first and keep the first rung that reproduces the checksum:
 | bootrom's own, `CLKDIV` rescaled | whatever it chose | last resort, taken on trust |
 
 **This must never slow down hardware that already works, and it does not:** a
-board that verifies at `RX4` is left exactly where it was. The ladder only
-rescues boards that would otherwise not start, which is the entire point.
+board that verifies at `RX4` is left exactly where it was.
+
+**What it cannot do is rescue a board that would otherwise not start** -- which
+was the entire point, and which the next section shows to be false on the one
+board it was tried on. The ladder is kept for what it does prove: that the
+timing a quad board runs at has reproduced a checksum of the flash at least
+once.
 
 The part that makes it safe rather than merely clever is that the probe, the
 per-rung retry and the ladder all execute **from SRAM**. While a candidate
@@ -692,6 +697,74 @@ was rejected -- it would cost every working board 1.3 voices to insure against
 something not yet observed. If a board is ever reported to fail after warming
 up, that is the knob.
 
+
+
+### The ladder cannot rescue a board, and what does
+
+The premise of the ladder is one sentence in the code: a too-fast timing
+corrupts *data*, so the checksum mismatches and the next rung gets a turn. It
+was written as if established. It is not. A 16 MB board with an A4-marked chip
+-- the same class as issue #107, and in hand this time -- settled it with two
+444 MHz images that differ only in their **first** rung:
+
+| image, all at 444 MHz core | first rung | result |
+|---|---|---|
+| shipping `v1.12.0` | `RX4`, 148 MHz | **does not boot** |
+| `SAFE` first | 56 MHz | boots, `444/56` |
+| no ladder, bootrom's own clock | 49 MHz | boots, `444/49 r2` |
+
+And from the core-clock ladder run on the same board: at a 420 MHz core, `RX4`
+*verified* -- 140 MHz flash, `420/140 r4`, running. So the flash on this board
+is good to 140 MHz, dead at 148, and the ladder that was supposed to notice the
+difference and step down never got the chance. Applying the fast rung is not a
+failed read. It takes the chip down.
+
+The likely mechanism, stated as such: both `EB` and `BB` reads carry mode bits
+(the `M7-M0` byte) that tell the part whether the *next* transaction will skip
+the command byte. A read garbled by a too-fast clock can leave those bits in a
+state the QMI did not intend, after which the part and the controller disagree
+about what every following transaction means -- at any speed. Then the next
+rungs fail too, and the return into flash-resident code is the hang. Nothing
+about "data, never instructions" survives that; the fault handler lives in flash
+as well.
+
+This also made `v1.12.0` a regression I introduced. PR #128 on its own -- a
+board the bootrom left in dual keeps the bootrom's clock, and nothing is probed
+-- would have booted both boards known to fail. PR #129 put a fast first rung
+in front of that on every board.
+
+**The fix is #128's rule again, in front of the ladder:** if the bootrom did
+not establish quad, apply its own timing with `CLKDIV` rescaled to hold its
+clock across the jump, and probe nothing. On the board above that is
+`0x60007203` from the bootrom, `0x60007209` in force -- the diagnostic image
+printed both -- and a working instrument at 444 MHz core with 49 MHz flash.
+Quad boards keep the ladder, where every first-rung verification so far has
+succeeded and no fast timing has ever been applied to a board that could not
+take it.
+
+**The cost is real and should be said plainly.** 49 MHz is about a third of what
+this particular board demonstrably handles, and at two bits per clock it is
+about a sixth of a quad board's XIP bandwidth. The MD does not care; the D5,
+which reads its PCM from flash, will. Slow and booting beats fast and dead, but
+it is not the end of the story. The way to get such a board its 140 MHz back is
+a ladder that probes *upward* from the known-good value and **re-synchronises
+the flash after a failed rung** -- the bootrom exposes the exit-from-XIP and
+reset sequences for exactly that -- before trying the next. That needs the
+board in hand to test, and it now is.
+
+Two loose ends from the same session. The `A4` question turned inside out:
+Raspberry Pi's PCN 28 describes A4 as *"some small user-invisible changes to the
+boot ROM"* -- a bootrom revision on A3 silicon, which is why a chip marked
+`RP2350A0A4` reports `A3` in `CHIP_ID`, and why the datasheet's "no hardware
+changes" was true and beside the point. The reporter's suspicion was right in
+substance. The same PCN says the A4 bootrom runs its early boot path four times
+faster (clk_sys about 48 MHz instead of 12), which is a plausible reason the A4
+boards seen here come up in dual where A2 boards come up in quad; that is a
+lead, not a finding. And one reading from this board, `444/56 r4`, cannot be
+produced by any path in the code -- `CLKDIV=8` exists only as `SAFE`, whose
+`RXDELAY` is 2, and the diagnostic confirmed the bootrom's own `RXDELAY` is 2 as
+well. It is most likely `444/56 r2` read off a 5x7 font; nothing above depends
+on it.
 
 ### A benchmark that cannot be compared across builds
 


### PR DESCRIPTION
**`v1.12.0` does not boot on the boards #107 is about, and that is a regression I introduced in #129. This fixes it, and it is confirmed on hardware.**

## What the board said

A 16 MB board with an A4-marked chip — same class as the reporter's, in hand this time. Two 444 MHz images differing **only in their first ladder rung**:

| image, 444 MHz core | first rung | result |
|---|---|---|
| shipping `v1.12.0` | `RX4`, 148 MHz | **does not boot** |
| `SAFE` first | 56 MHz | boots, `444/56` |
| **this PR**: no ladder, bootrom's clock | 49 MHz | boots, `444/49 r2` |

And from the core-clock ladder on the same board: at a **420 MHz core, `RX4` verified** — 140 MHz flash, running. So the flash is good to 140 MHz and dead at 148, and the ladder that was built to notice exactly that never got its second rung.

**The core clock is exonerated.** I had it as the prime suspect for two rounds; the 444/56 image running at full core speed refutes it.

## Why the ladder cannot rescue anyone

Its premise was one sentence in the code: *a too-fast timing corrupts data, so the checksum mismatches and the next rung gets a turn.* Written as if established. It is not: applying the fast rung takes the chip down. The likely mechanism is the continuous-read mode bits (`M7–M0`) that both `EB` and `BB` reads carry — a read garbled by a too-fast clock can leave the part and the controller disagreeing about what every following transaction means, at any speed. Then the later rungs fail too, and the return into flash-resident code is the hang. "Data, never instructions" does not survive that; the fault handler lives in flash as well.

So the ladder helps only where it is not needed (every quad board verifies at rung one) and kills the board where it would be. #128 on its own — *dual keeps the bootrom's clock, nothing probed* — would have booted both boards known to fail.

## The fix

#128's rule goes back in front of the ladder: **if the bootrom did not establish quad, apply its own timing with `CLKDIV` rescaled to hold its clock across the jump, and probe nothing.** Quad boards keep the ladder unchanged.

Confirmed with a diagnostic image that prints both registers:

```
60007203 > 60007209      bootrom CLKDIV=3 RXDELAY=2  ->  CLKDIV=9 at 444 MHz
A3 D 444/49 r2           and the instrument runs
```

Full build 10/10, 0 errors; the three RAM-resident routines verified at RAM addresses in all ten images.

## The cost, plainly

49 MHz is about a third of what this board demonstrably handles, and at two bits per clock about a sixth of a quad board's XIP bandwidth. The MD does not care. **The D5, which reads its PCM from flash, will** — it should boot and the governor should trim voices, but it will not be the D5 a quad board gets. Slow and booting beats fast and dead; it is not the end of the story. The way back to 140 MHz is a ladder that probes *upward* from the known-good value and **re-synchronises the flash after a failed rung** (the bootrom exposes the exit-from-XIP and reset sequences for that) before trying the next. With the board in hand, that is now testable. Separate PR.

## Also in this PR

- The splash leads with the core clock: `A3 D 444/49 r2` — core / flash / RXDELAY, all from live registers. It is what made the core-clock ladder and this A/B readable at the device.
- README: the false claim that the ladder "lands on 111 or 55 instead of not booting" is corrected, the evidence above is written down, and two loose ends are recorded.

## Two loose ends, recorded rather than resolved

- **A4 turned inside out.** Raspberry Pi's PCN 28 describes A4 as *"some small user-invisible changes to the boot ROM"* — a bootrom revision on A3 silicon. That is why a chip marked `RP2350A0A4` reports `A3` in `CHIP_ID`, and why the datasheet's "no hardware changes" was true and beside the point. **The reporter's suspicion was right in substance.** The same PCN says the A4 bootrom runs its early boot path four times faster (clk_sys ≈ 48 MHz instead of 12), a plausible reason the A4 boards seen here come up in dual where A2 boards come up in quad. A lead, not a finding.
- One reading, `444/56 r4`, cannot be produced by any code path (`CLKDIV=8` exists only as `SAFE`, whose `RXDELAY` is 2, and the diagnostic confirmed the bootrom's `RXDELAY` is 2 too). Most likely `r2` read off a 5×7 font. Nothing depends on it.

**Recommend a `v1.12.1` release on merge** — `v1.12.0` is worse than `v1.11.1` on these boards.

Refs #107, #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)