### PR TITLE
Board variant: Waveshare RP2350B-Plus-W (I2S on GP40/41/42), and the PIO pin-mask fix it uncovered

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,8 +51,29 @@ endif()
 if(NOT DEFINED PICO_PLATFORM)
     set(PICO_PLATFORM "rp2350-arm-s")
 endif()
-if(NOT DEFINED PICO_BOARD)
-    set(PICO_BOARD "sparkfun_promicro_rp2350")
+# --- Board variant -----------------------------------------------------------
+# PICOFACE_BOARD selects the physical board the firmware is built for.
+#   pico             (default) any Pico-2-format RP2350A board: I2S on GP26/27/28
+#   rp2350b_plus_w   Waveshare RP2350B-Plus-W: an RP2350B whose Pico header carries
+#                    GP40/41/42 where a Pico has GP26/27/28. A Pico-Audio HAT on it
+#                    is driven from GP40/41/42, and PIO0 has to be re-based to
+#                    GPIO 16..47 to reach them (RP2350 PIO addresses 0-31 or 16-47).
+set(PICOFACE_BOARD "pico" CACHE STRING "Board variant: pico | rp2350b_plus_w")
+if(PICOFACE_BOARD STREQUAL "rp2350b_plus_w")
+    set(PICO_BOARD "waveshare_rp2350b_plus_w")
+    list(APPEND PICO_BOARD_HEADER_DIRS ${CMAKE_CURRENT_SOURCE_DIR}/boards)
+    set(PICOFACE_I2S_DATA_PIN 40)
+    set(PICOFACE_I2S_CLOCK_PIN_BASE 41)
+    set(PICOFACE_PIO_GPIO_BASE 16)
+elseif(PICOFACE_BOARD STREQUAL "pico")
+    if(NOT DEFINED PICO_BOARD)
+        set(PICO_BOARD "sparkfun_promicro_rp2350")
+    endif()
+    set(PICOFACE_I2S_DATA_PIN 26)
+    set(PICOFACE_I2S_CLOCK_PIN_BASE 27)
+    set(PICOFACE_PIO_GPIO_BASE 0)
+else()
+    message(FATAL_ERROR "PICOFACE_BOARD must be 'pico' or 'rp2350b_plus_w' (got '${PICOFACE_BOARD}')")
 endif()
 
 include(cmake/pico_sdk_import.cmake)

--- a/README.md
+++ b/README.md
@@ -50,6 +50,16 @@ needs on a small board.
 The pin map is the same for every instrument and lives in
 [core/include/project_config.h](core/include/project_config.h).
 
+**Which RP2350 board.** The default build assumes a Pico-2-format board with an
+RP2350**A** -- Pico 2, Waveshare RP2350-Plus and the like -- where I2S sits on
+GP26/27/28 at header pins 31/32/34. The Waveshare **RP2350B-Plus-W** has the
+same header but carries **GP40/41/42** at those three positions (the RP2350B's
+ADC0-2 take the Pico's ADC spots; GP26-28 are only on the pads underneath), so
+a default image on it drives the I2S lines into thin air: display, MIDI and
+encoders work, only the sound is missing, and every counter reads healthy. It
+is a build-time choice, not a wiring one -- see *Building* for
+`-DPICOFACE_BOARD=rp2350b_plus_w`.
+
 **If the screen stays dark.** The panel is on I2C at 1 MHz with only the chip's
 internal pull-ups. That is above what an SH1106 datasheet promises (400 kHz) and
 it is what the reference board runs, because the display push is paced in half
@@ -147,6 +157,19 @@ cmake --build build
 ```
 
 The artifacts are then in `build/<instrument>.uf2`.
+
+**Board variant.** `-DPICOFACE_BOARD=pico` (the default) builds for any
+Pico-2-format RP2350A board. `-DPICOFACE_BOARD=rp2350b_plus_w` builds for the
+Waveshare RP2350B-Plus-W: it selects an RP2350B board profile (48 GPIOs, 16 MB),
+puts I2S on GP40/41/42, and re-bases PIO0 to GPIO 16-47 before the I2S program
+is loaded, because an RP2350 PIO addresses either GPIO 0-31 or 16-47. The
+released UF2s are the default variant; the RP2350B build is one cmake flag
+away and produces the same ten images.
+
+```bash
+cmake -S . -B build-b -G Ninja -DCMAKE_BUILD_TYPE=Release -DPICOFACE_BOARD=rp2350b_plus_w
+cmake --build build-b
+```
 
 **The splash screen names the build.** Every instrument shows a version taken
 from `git describe`, not a number typed into its `instrument.cmake`: on a

--- a/boards/waveshare_rp2350b_plus_w.h
+++ b/boards/waveshare_rp2350b_plus_w.h
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Michi71
+//
+// Waveshare RP2350B-Plus-W: an RP2350B (QFN-80, 48 GPIOs) on a Pico-format
+// board with 16 MB flash and Radio Module 2. Pico-compatible 40-pin header,
+// with one consequence that matters for this project: the header positions
+// where a Pico carries GP26/GP27/GP28 (pins 31/32/34) carry GP40/GP41/GP42
+// here, so the RP2350B's ADC0-2 keep the Pico's ADC positions. GP26-GP28 exist
+// only on the castellated pads underneath. A Pico-Audio HAT on this board is
+// therefore driven from GP40/41/42, which is what the rp2350b_plus_w build
+// variant selects. Everything else this project uses (MIDI GP4/5, display
+// GP2/3, encoders GP6-15) sits where a Pico has it.
+//
+// Modelled on the SDK's sparkfun_promicro_rp2350.h / solderparty_rp2350_stamp_xl.h.
+
+#ifndef _BOARDS_WAVESHARE_RP2350B_PLUS_W_H
+#define _BOARDS_WAVESHARE_RP2350B_PLUS_W_H
+
+// For board detection
+#define WAVESHARE_RP2350B_PLUS_W
+
+// --- RP2350 VARIANT ---
+#define PICO_RP2350A 0      // 1 for RP2350A, 0 for RP2350B (48 GPIOs -> PIO GPIO base available)
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 0
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 1
+#endif
+
+// no PICO_DEFAULT_LED_PIN (the on-board LEDs are not on a GPIO this project owns)
+// no PICO_DEFAULT_WS2812_PIN
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 4
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 5
+#endif
+
+// --- SPI ---
+#ifndef PICO_DEFAULT_SPI
+#define PICO_DEFAULT_SPI 0
+#endif
+#ifndef PICO_DEFAULT_SPI_SCK_PIN
+#define PICO_DEFAULT_SPI_SCK_PIN 18
+#endif
+#ifndef PICO_DEFAULT_SPI_TX_PIN
+#define PICO_DEFAULT_SPI_TX_PIN 19
+#endif
+#ifndef PICO_DEFAULT_SPI_RX_PIN
+#define PICO_DEFAULT_SPI_RX_PIN 16
+#endif
+#ifndef PICO_DEFAULT_SPI_CSN_PIN
+#define PICO_DEFAULT_SPI_CSN_PIN 17
+#endif
+
+// --- FLASH ---
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+pico_board_cmake_set_default(PICO_FLASH_SIZE_BYTES, (16 * 1024 * 1024))
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (16 * 1024 * 1024)
+#endif
+
+pico_board_cmake_set_default(PICO_RP2350_A2_SUPPORTED, 1)
+#ifndef PICO_RP2350_A2_SUPPORTED
+#define PICO_RP2350_A2_SUPPORTED 1
+#endif
+
+#endif

--- a/cmake/PicoFaceInstrument.cmake
+++ b/cmake/PicoFaceInstrument.cmake
@@ -179,8 +179,8 @@ function(picoface_add_instrument)
     # --- compile definitions -----------------------------------------------------
     set(_defines
         USE_AUDIO_I2S=1
-        PICO_AUDIO_I2S_DATA_PIN=26
-        PICO_AUDIO_I2S_CLOCK_PIN_BASE=27
+        # I2S pins and PIO GPIO base are PUBLIC definitions of the Audio target
+        # (lib/audio/CMakeLists.txt), so every instrument sees the same values.
     )
     # PICO_USE_SW_SPIN_LOCKS and the enlarged stacks are deliberately NOT set
     # here. In the original repositories they were per-instrument: YC, J6, MD

--- a/hardware/README.md
+++ b/hardware/README.md
@@ -260,7 +260,14 @@ Still needed:
 - **The pin map matches the firmware**, checked pad by pad against
   `core/include/project_config.h`: MIDI on GP4/GP5 → pins 6/7, display on GP2/GP3
   → pins 4/5, I2S on GP26/27/28 → pins 31/32/34, the three encoders on
-  GP6-GP8/GP10-GP15, stdio on GP0/GP1 → pins 1/2. Ground lands on 3, 8, 13, 18,
+  GP6-GP8/GP10-GP15, stdio on GP0/GP1 → pins 1/2.
+  **This map assumes a Pico-format RP2350A board.** The Waveshare
+  RP2350B-Plus-W keeps every one of these positions *except* pins 31/32/34,
+  which carry GP40/41/42 there (the RP2350B's ADC0-2 take the Pico's ADC
+  positions; GP26-28 are only on the pads underneath). A firmware built for a
+  Pico drives GP26-28 into thin air on that board -- display, MIDI and
+  encoders work, only the sound is missing. Build it with
+  `-DPICOFACE_BOARD=rp2350b_plus_w` instead; see the top-level README. Ground lands on 3, 8, 13, 18,
   23, 28 and 38, and AGND on 33 — which the datasheet allows to be tied to
   digital ground when the ADC is not used, and it is not.
 - **RUN is on pin 30** of the Pico format, so the RUN switch works.

--- a/instruments/PicoFaceMD/README.md
+++ b/instruments/PicoFaceMD/README.md
@@ -699,6 +699,22 @@ up, that is the knob.
 
 
 
+### The "A4 board" that had no sound was a different board
+
+A footnote to everything above, because it would otherwise read as one story.
+The 16 MB A4-marked board used for the flash work turned out to be a Waveshare
+**RP2350B-Plus-W** -- an RP2350B in Pico format. Its flash findings stand: the
+dual-I/O bootrom configuration, the fatal fast rung, the 49 MHz fallback. But it
+also made no sound with any instrument, and that had nothing to do with the
+flash: on that board the header positions where a Pico carries GP26/27/28
+carry GP40/41/42, so the I2S lines were driven into thin air while every
+firmware counter read healthy. A pin probe settled it (the chip was toggling
+BCK/LRCK on 27/28 the whole time), and a board variant fixed it -- with two
+more traps on the way that are recorded in the commit history: the audio
+library did not receive the instrument's pin defines, and the PIO init built
+its pin-direction mask as a 32-bit shift, undefined for pin 40. See the
+top-level README, *Which RP2350 board*.
+
 ### The ladder cannot rescue a board, and what does
 
 The premise of the ladder is one sentence in the code: a too-fast timing

--- a/lib/audio/CMakeLists.txt
+++ b/lib/audio/CMakeLists.txt
@@ -11,4 +11,19 @@ target_include_directories(Audio PUBLIC
 
 pico_generate_pio_header(Audio ${CMAKE_CURRENT_LIST_DIR}/piosrc/audio_i2s.pio)
 
+# The I2S pins and the PIO GPIO base come from the board variant selected in
+# the top-level CMakeLists (PICOFACE_BOARD). They must reach THIS target: the
+# library is compiled once, separately from the instruments, and a define put
+# only on the instrument targets never arrives here -- the header defaults
+# (26/27) then silently win, which is exactly how a board variant fails to
+# take effect while looking correct everywhere else.
+if(NOT DEFINED PICOFACE_I2S_DATA_PIN OR NOT DEFINED PICOFACE_I2S_CLOCK_PIN_BASE OR NOT DEFINED PICOFACE_PIO_GPIO_BASE)
+    message(FATAL_ERROR "lib/audio: PICOFACE_I2S_DATA_PIN / PICOFACE_I2S_CLOCK_PIN_BASE / PICOFACE_PIO_GPIO_BASE must be set by the board variant before add_subdirectory(lib/audio)")
+endif()
+target_compile_definitions(Audio PUBLIC
+    PICO_AUDIO_I2S_DATA_PIN=${PICOFACE_I2S_DATA_PIN}
+    PICO_AUDIO_I2S_CLOCK_PIN_BASE=${PICOFACE_I2S_CLOCK_PIN_BASE}
+    PICOFACE_PIO_GPIO_BASE=${PICOFACE_PIO_GPIO_BASE}
+)
+
 target_link_libraries(Audio pico_stdlib pico_util_buffer pico_multicore hardware_pio hardware_dma)

--- a/lib/audio/include/audio_i2s.h
+++ b/lib/audio/include/audio_i2s.h
@@ -114,13 +114,17 @@ extern "C" {
 #ifndef PICO_AUDIO_I2S_DATA_PIN
 //#warning PICO_AUDIO_I2S_DATA_PIN should be defined when using AUDIO_I2S
 //#define PICO_AUDIO_I2S_DATA_PIN 18
+#ifndef PICO_AUDIO_I2S_DATA_PIN
 #define PICO_AUDIO_I2S_DATA_PIN 26
+#endif
 #endif
 
 #ifndef PICO_AUDIO_I2S_CLOCK_PIN_BASE
 //#warning PICO_AUDIO_I2S_CLOCK_PIN_BASE should be defined when using AUDIO_I2S
 //#define PICO_AUDIO_I2S_CLOCK_PIN_BASE 16
+#ifndef PICO_AUDIO_I2S_CLOCK_PIN_BASE
 #define PICO_AUDIO_I2S_CLOCK_PIN_BASE 27
+#endif
 #endif
 
 // todo this needs to come from a build config

--- a/lib/audio/piosrc/audio_i2s.pio
+++ b/lib/audio/piosrc/audio_i2s.pio
@@ -62,8 +62,15 @@ static inline void audio_i2s_program_init(PIO pio, uint sm, uint offset, uint da
 
     pio_sm_init(pio, sm, offset, &sm_config);
 
-    uint pin_mask = (1u << data_pin) | (3u << clock_pin_base);
-    pio_sm_set_pindirs_with_mask(pio, sm, pin_mask, pin_mask);
+    // 64-bit masks: on RP2350 the pins may sit above 31 (an RP2350B board
+    // variant drives I2S from GP40-42). A 32-bit mask shifted by 40 is
+    // undefined behaviour -- on ARM the shift wraps modulo 32, the mask lands
+    // on pins 8-10 and the SDK's parameter check rejects it silently in a
+    // release build, so the pins never become outputs and the DAC hears
+    // nothing while every other check reads correct. The 64-bit call takes
+    // absolute GPIO numbers and works for pins below 32 exactly as before.
+    const uint64_t pin_mask = (1ull << data_pin) | (3ull << clock_pin_base);
+    pio_sm_set_pindirs_with_mask64(pio, sm, pin_mask, pin_mask);
     pio_sm_set_pins(pio, sm, 0); // clear pins
 
     // set resolution to ISR (use as config value)

--- a/lib/audio/src/audio_subsystem.cpp
+++ b/lib/audio/src/audio_subsystem.cpp
@@ -1,3 +1,4 @@
+#include "hardware/pio.h"
 #include "audio_subsystem.h"
 
 // This library is intentionally independent of the instrument configuration
@@ -36,6 +37,16 @@ audio_buffer_pool_t *init_audio(uint32_t sample_freq, uint buffer_count)
         .dma_channel = 0,
         .pio_sm = 0};
 
+#if defined(PICOFACE_PIO_GPIO_BASE) && (PICOFACE_PIO_GPIO_BASE != 0)
+    // The I2S pins sit above GPIO 31 on this board variant. An RP2350 PIO
+    // addresses either GPIO 0-31 or 16-47; re-base this PIO before its first
+    // program is added -- the SDK refuses the call once instruction memory is
+    // in use. Loud on failure: a silent no-op here is a silent instrument.
+    if (pio_set_gpio_base(__CONCAT(pio, PICO_AUDIO_I2S_PIO), PICOFACE_PIO_GPIO_BASE) != PICO_OK)
+    {
+        panic("PicoAudio: cannot set PIO GPIO base %d\n", PICOFACE_PIO_GPIO_BASE);
+    }
+#endif
     output_format = audio_i2s_setup(&s_audio_format, &s_audio_format, &config);
     if (!output_format)
     {


### PR DESCRIPTION
Closes the "boots, everything works, no sound" case on the Waveshare **RP2350B-Plus-W** — confirmed on hardware with the images from this branch.

## What it was

An RP2350**B** in Pico format. Its 40-pin header carries **GP40/41/42** where a Pico has GP26/27/28 (pins 31/32/34): the RP2350B's ADC0–2 take the Pico's ADC positions, and GP26–28 exist only on the pads underneath. A Pico-Audio HAT on this board is therefore wired to GP40/41/42, and a default image drives the I2S lines into thin air. Display, MIDI and encoders sit where a Pico has them, so everything else worked and every firmware counter read healthy.

The diagnostic path that got there is worth keeping: notes reached the engine (`dr 0`), the engine rendered six voices for three keys (`tv6`), the engine's own output peak was alive, a fixed test tone was inaudible, and a pin probe showed the chip **toggling BCK/LRCK on 27/28 the whole time** — so the loss was off-chip, and the board's pinout image said where.

## The variant

`-DPICOFACE_BOARD=rp2350b_plus_w`:

- a board header with `PICO_RP2350A 0` (48 GPIOs — which is what compiles the PIO GPIO-base support in at all), 16 MB flash, A2 supported
- I2S on **GP40/41/42**
- PIO0 re-based to GPIO 16–47 before the I2S program is loaded (an RP2350 PIO addresses 0–31 or 16–47), loudly if that fails

The default `pico` variant is unchanged: 26/27, base 0, re-base code compiled out — verified in the images (MD carries the `(26,27)` config bytes and no `(40,41)`; the variant the reverse).

## Two traps on the way, both fixed here

1. **The audio library never saw the pin defines.** It is compiled once, separately from the instruments; a define on the instrument targets does not reach it, and `audio_i2s.h` defined the pins unconditionally so even one that arrived would have been overridden. The first variant image looked right in every check that did not read the library's own compile line. Pins and base are now PUBLIC definitions of the `Audio` target, sourced from the board variant; the header values are defaults.

2. **The PIO init built its pin-direction mask as a 32-bit shift** — `(1u << 40)` is undefined, wraps to pins 8–10 on ARM, and the SDK's parameter check rejects it silently in a release build. Base set, program loaded, pins owned by PIO0, **no edge ever left the chip** (`rc0 gb16 pio24 f666 e0/0` on the board). `pio_sm_set_pindirs_with_mask64` takes absolute GPIO numbers and behaves identically below 32.

## Verification

- Hardware: v3 image → **sound** on the RP2350B-Plus-W (D5 and MD).
- Both variants build all ten instruments, 0 errors; every image carries the 64-bit pin-direction call and none the old one.
- READMEs: *Which RP2350 board* and the `PICOFACE_BOARD` flag in the top-level README; the pin-map caveat in `hardware/README.md`; a footnote in the MD README separating this board's no-sound from its flash findings.

Not related to the flash timing work; the flash findings from the same board stand on their own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)