### PR TITLE
rp2350b_plus_w: top flash rung CD4 (111 MHz), RD 96 MHz -- the reference flash hangs at 148

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,9 +162,14 @@ The artifacts are then in `build/<instrument>.uf2`.
 Pico-2-format RP2350A board. `-DPICOFACE_BOARD=rp2350b_plus_w` builds for the
 Waveshare RP2350B-Plus-W: it selects an RP2350B board profile (48 GPIOs, 16 MB),
 puts I2S on GP40/41/42, and re-bases PIO0 to GPIO 16-47 before the I2S program
-is loaded, because an RP2350 PIO addresses either GPIO 0-31 or 16-47. The
-released UF2s are the default variant; the RP2350B build is one cmake flag
-away and produces the same ten images.
+is loaded, because an RP2350 PIO addresses either GPIO 0-31 or 16-47. It also
+tops the flash timing ladder one rung lower (111 MHz instead of 148; RD 96
+instead of 120): the reference board's Puya P25Q128H verifies 111 MHz in quad
+and hangs at 148, and a rung that hangs cannot be stepped down from. A board
+with a faster flash can ask for the full rung with
+`-DPICOFACE_QMI_M0_TIMING_TARGET=PICOFACE_QMI_M0_TIMING_RX4`. The released UF2s
+are the default variant; the RP2350B build is one cmake flag away and produces
+the same ten images.
 
 ```bash
 cmake -S . -B build-b -G Ninja -DCMAKE_BUILD_TYPE=Release -DPICOFACE_BOARD=rp2350b_plus_w

--- a/core/include/project_config.h
+++ b/core/include/project_config.h
@@ -204,7 +204,16 @@
 #endif
 
 #ifndef PICOFACE_QMI_M0_TIMING_TARGET
+#if defined(WAVESHARE_RP2350B_PLUS_W)
+// The rp2350b_plus_w variant tops out one rung lower. Its reference board
+// carries a Puya P25Q128H that verifies 111 MHz in quad and hangs at 148 --
+// in quad exactly as it did in dual -- and the ladder cannot step down from
+// a rung that hangs. CD4 is the fastest timing proven on that part; a board
+// with a faster flash can still ask for RX4 with -DPICOFACE_QMI_M0_TIMING_TARGET.
+#define PICOFACE_QMI_M0_TIMING_TARGET PICOFACE_QMI_M0_TIMING_CD4
+#else
 #define PICOFACE_QMI_M0_TIMING_TARGET PICOFACE_QMI_M0_TIMING_RX4
+#endif
 #endif
 
 

--- a/core/include/project_config.h
+++ b/core/include/project_config.h
@@ -160,6 +160,12 @@
 // thing to try if an RD ever fails to boot.
 #define PICOFACE_QMI_M0_TIMING_RD 0x60007304u
 
+// RD on the rp2350b_plus_w variant: CLKDIV=5, RXDELAY=5 -> 96 MHz flash at
+// 480 MHz, 10.42 ns for the device. The variant's reference flash (Puya
+// P25Q128H) is proven at 111 MHz and hangs at 148; RD's own 120 MHz rung sits
+// in the unproven gap, and a rung that hangs cannot be stepped down from.
+#define PICOFACE_QMI_M0_TIMING_RD_CAP 0x60007505u   // CLKDIV=5, RXDELAY=5
+
 // The default. Full flash speed with a later sample point: 3.88 ns for the
 // device against OC's 2.76, and only RXDELAY moves, so there is no reason to
 // expect it to cost anything. Measurement neither confirms nor denies that --

--- a/instruments/PicoFaceRD/instrument.cmake
+++ b/instruments/PicoFaceRD/instrument.cmake
@@ -136,6 +136,15 @@ if(NOT _rd_pk_rc EQUAL 0)
 endif()
 message(STATUS "PicoFaceRD: ${_rd_pk_out}")
 
+# RD's flash rung follows the board variant: its 120 MHz rung is unproven on
+# the rp2350b_plus_w reference flash (111 MHz verified, 148 fatal), so that
+# variant gets the 96 MHz cap instead. See core/include/project_config.h.
+if(PICOFACE_BOARD STREQUAL "rp2350b_plus_w")
+    set(_rd_qmi_target PICOFACE_QMI_M0_TIMING_RD_CAP)
+else()
+    set(_rd_qmi_target PICOFACE_QMI_M0_TIMING_RD)
+endif()
+
 picoface_add_instrument(
     NAME PicoFaceRD
     PROGRAM_NAME "PicoFaceRD"
@@ -187,7 +196,7 @@ picoface_add_instrument(
         TARGET_RP2350=1
         RD_CLOCK_504=1
         PICOFACE_SYS_CLOCK_HZ=480000000
-        PICOFACE_QMI_M0_TIMING_TARGET=PICOFACE_QMI_M0_TIMING_RD
+        PICOFACE_QMI_M0_TIMING_TARGET=${_rd_qmi_target}
     # Which slice of the sixteen patches this build carries.
         RD_PATCH_BASE=${_rd_patch_base}
         RD_PATCH_COUNT=${_rd_patch_count}


### PR DESCRIPTION
Follow-up to #132, after the flash on the reference RP2350B-Plus-W turned out to be capable of quad.

## What happened

The board's flash is a **Puya P25Q128H** (JEDEC `85 20 18`), not the Winbond in Waveshare's schematic. Its quad-enable bit was clear, so the bootrom — which never sets QE, it only tries `EBh → BBh → 0Bh → 03h` per divisor until an image reads (datasheet 5.2.7) — landed on dual. A diagnostic set the bit; from then on the bootrom finds quad by itself, and the board takes the quad path with the full ladder.

That ladder tries `RX4` (148 MHz) first, and **148 MHz hangs this part in quad exactly as it did in dual** — no checksum, no splash, no USB. #131 only guarded boards the bootrom left in dual; a quad board that cannot take the top rung was unprotected, and the v1.12.2 variant image no longer boots on this board at all.

## The change

- **`rp2350b_plus_w` tops its ladder at `CD4` (111 MHz, RXDELAY 5)** — the fastest timing verified on this part. Chosen in `project_config.h` via the board header's `WAVESHARE_RP2350B_PLUS_W`; the default variant keeps `RX4`. A board with a faster flash can still ask for `RX4` with `-DPICOFACE_QMI_M0_TIMING_TARGET=PICOFACE_QMI_M0_TIMING_RX4`.
- **RD on this variant gets a 96 MHz rung** (`_RD_CAP`, CLKDIV 5, RXDELAY 5, 10.4 ns) instead of its 120 MHz one, which sits in the unproven gap between 111 and 148.
- README: the cap and why.

## Verified on the board

`A3 Q 444/111 r5`, boots, **B62** on the D5 (was 154 in dual at 49 MHz; the A2 reference board reads 51–57), sound. Both variants build all ten instruments; ladders read back from every ELF: variant `SAFE, CD4` (RD: `SAFE, CD4, RD_CAP`), default unchanged `SAFE, RX4, CD4` (RD: `SAFE, RD, CD4`).

## What this does not do yet

It does not enable quad on such a board by itself — that took a diagnostic image. The next step is a boot-time quad enable for known vendors (Puya/Winbond/GigaDevice: SR2 bit 1; Macronix/ISSI: SR1 bit 6), one-time and non-volatile, verified by checksum, with the rule that a board where *we* had to enable quad gets the CD4 top rung. Separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)