### PR TITLE
Flash: set the quad-enable bit ourselves, and restore the read mode after every flash write

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,10 +162,13 @@ The artifacts are then in `build/<instrument>.uf2`.
 Pico-2-format RP2350A board. `-DPICOFACE_BOARD=rp2350b_plus_w` builds for the
 Waveshare RP2350B-Plus-W: it selects an RP2350B board profile (48 GPIOs, 16 MB),
 puts I2S on GP40/41/42, and re-bases PIO0 to GPIO 16-47 before the I2S program
-is loaded, because an RP2350 PIO addresses either GPIO 0-31 or 16-47. It also
-tops the flash timing ladder one rung lower (111 MHz instead of 148; RD 96
-instead of 120): the reference board's Puya P25Q128H verifies 111 MHz in quad
-and hangs at 148, and a rung that hangs cannot be stepped down from. A board
+is loaded, because an RP2350 PIO addresses either GPIO 0-31 or 16-47. The firmware
+also puts such a board's flash into quad by itself when the bootrom left it in
+dual -- the Puya P25Q128H on the reference board ships with its quad-enable bit
+clear, and the bootrom never sets one -- and then tops the flash timing ladder
+one rung lower (111 MHz instead of 148; RD 96 instead of 120): that part
+verifies 111 MHz in quad and hangs at 148, and a rung that hangs cannot be
+stepped down from. See the PicoFaceMD README, *The bit the bootrom never sets*. A board
 with a faster flash can ask for the full rung with
 `-DPICOFACE_QMI_M0_TIMING_TARGET=PICOFACE_QMI_M0_TIMING_RX4`. The released UF2s
 are the default variant; the RP2350B build is one cmake flag away and produces

--- a/core/include/pico_hw.h
+++ b/core/include/pico_hw.h
@@ -82,4 +82,15 @@ extern uint32_t picoface_qmi_timing_effective;
 // verify -- every one tested so far -- set this true.
 extern bool     picoface_flash_verified;
 
+// Flash identification and the quad story. picoface_flash_jedec holds the
+// 0x9F answer (manufacturer, type, capacity). picoface_flash_quad_by_us is
+// true when the bootrom left the flash in dual and pico_init() set the part's
+// quad-enable bit and switched it to EBh itself; such boards run the
+// CAUTIOUS rung. picoface_flash_after_write() must be called after every
+// flash program/erase: the SDK re-enters XIP in 03h serial there, and the
+// timing alone does not bring the mode back.
+extern uint32_t picoface_flash_jedec;
+extern bool     picoface_flash_quad_by_us;
+void picoface_flash_after_write(void);
+
 #endif // __PICO_HW_H__

--- a/core/include/project_config.h
+++ b/core/include/project_config.h
@@ -209,6 +209,17 @@
 #define PICOFACE_SYS_CLOCK_HZ 444000000
 #endif
 
+// The rung for a board whose flash WE had to put into quad (the bootrom found
+// it in dual). The only such part measured -- a Puya P25Q128H -- verifies
+// 111 MHz in quad and hangs at 148, and a rung that hangs cannot be stepped
+// down from. So such boards top out here rather than at the full rung, at
+// either core clock. A board that turns out faster can override TARGET.
+#if PICOFACE_SYS_CLOCK_HZ == 480000000
+#define PICOFACE_QMI_M0_TIMING_CAUTIOUS PICOFACE_QMI_M0_TIMING_RD_CAP
+#else
+#define PICOFACE_QMI_M0_TIMING_CAUTIOUS PICOFACE_QMI_M0_TIMING_CD4
+#endif
+
 #ifndef PICOFACE_QMI_M0_TIMING_TARGET
 #if defined(WAVESHARE_RP2350B_PLUS_W)
 // The rp2350b_plus_w variant tops out one rung lower. Its reference board

--- a/core/src/pico_hw.cpp
+++ b/core/src/pico_hw.cpp
@@ -22,6 +22,8 @@
 #else
 #include <hardware/structs/qmi.h>
 #include <hardware/structs/xip.h>
+#include <hardware/flash.h>          // flash_do_cmd: JEDEC id, status registers, QE bit
+#include <pico/bootrom.h>            // rom_flash_select_xip_read_mode, rom_flash_flush_cache
 #endif
 
 
@@ -195,6 +197,139 @@ static __attribute__((noinline)) uint32_t __not_in_flash_func(picoface_flash_aut
 }
 #endif
 
+// --- Quad enable: the bit the bootrom never sets -------------------------------
+//
+// The RP2350 bootrom does not know any flash vendor's quad-enable bit. It tries
+// EBh quad, BBh dual, 0Bh and 03h at divisors 3/6/12/24 and boots in the first
+// mode that yields a valid image (datasheet 5.2.7). A part whose QE bit is
+// clear answers EBh with garbage, so the bootrom settles on dual and the board
+// runs at half the bandwidth -- for no reason in the silicon. The datasheet
+// puts any further setup on the image itself. This is that setup: identify the
+// part, set QE once and non-volatile (the write is guarded on the bit being
+// clear, so it happens once per board), switch to EBh, and believe it only if
+// a checksum of the flash reproduces the one taken in the bootrom's own mode.
+//
+// Everything here runs from SRAM: each step changes how flash is read, and the
+// code doing it must not itself be fetched from flash meanwhile. flash_do_cmd()
+// leaves XIP in the bootrom's generic 03h serial mode afterwards, which is why
+// every mode below is set explicitly and the reference is taken beforehand.
+uint32_t picoface_flash_jedec      = 0;
+bool     picoface_flash_quad_by_us = false;
+#if PICO_RP2350
+static __attribute__((noinline)) void __not_in_flash_func(picoface_xip_settle)(void)
+{
+    rom_flash_flush_cache();
+    __dsb();
+    (void)*(volatile uint32_t *)XIP_NOCACHE_NOALLOC_BASE;
+    __dsb();
+    __isb();
+}
+
+// Where the quad-enable bit lives, by JEDEC manufacturer byte. reg 2: status
+// register 2, read 35h, written 31h (or 01h with two bytes on older parts).
+// reg 1: status register 1 bit 6, read 05h, written 01h. Vendors not listed
+// are left alone -- Micron/ST (20h) in particular use a different scheme and
+// share the byte with XMC, so neither is touched.
+struct QeSpec { uint8_t mfr; uint8_t reg; uint8_t bit; };
+static const QeSpec kQeTable[] = {
+    {0x85, 2, 0x02},   // Puya      (P25Q128H on the Waveshare RP2350B-Plus-W)
+    {0xEF, 2, 0x02},   // Winbond
+    {0xC8, 2, 0x02},   // GigaDevice
+    {0x5E, 2, 0x02},   // Zbit
+    {0x0B, 2, 0x02},   // XTX
+    {0x68, 2, 0x02},   // Boya
+    {0xA1, 2, 0x02},   // Fudan
+    {0xC2, 1, 0x40},   // Macronix
+    {0x9D, 1, 0x40},   // ISSI
+    {0x1C, 1, 0x40},   // EON
+};
+
+static __attribute__((noinline)) uint8_t __not_in_flash_func(picoface_flash_rd)(uint8_t cmd)
+{
+    uint8_t tx[2] = {cmd, 0}, rx[2] = {0, 0};
+    flash_do_cmd(tx, rx, 2);
+    return rx[1];
+}
+static __attribute__((noinline)) void __not_in_flash_func(picoface_flash_wait_wip)(void)
+{
+    for (int i = 0; i < 200000; ++i) {                 // bounded: a status write takes ~ms
+        if ((picoface_flash_rd(0x05) & 0x01u) == 0u) return;
+    }
+}
+
+// Returns true when the flash now reads correctly in EBh quad.
+static __attribute__((noinline)) bool __not_in_flash_func(picoface_flash_enable_quad)(uint32_t ref)
+{
+    uint8_t tx[4] = {0x9F, 0, 0, 0}, rx[4] = {0, 0, 0, 0};
+    flash_do_cmd(tx, rx, 4);
+    picoface_flash_jedec = ((uint32_t)rx[1] << 16) | ((uint32_t)rx[2] << 8) | rx[3];
+
+    const QeSpec *spec = NULL;
+    for (unsigned i = 0; i < sizeof kQeTable / sizeof kQeTable[0]; ++i) {
+        if (kQeTable[i].mfr == rx[1]) { spec = &kQeTable[i]; break; }
+    }
+    if (spec) {
+        const uint8_t rdcmd = spec->reg == 2 ? 0x35 : 0x05;
+        uint8_t cur = picoface_flash_rd(rdcmd);
+        if ((cur & spec->bit) == 0u) {
+            // Once, non-volatile: the bootrom then finds quad by itself on
+            // every later boot and this code no longer runs on this board.
+            // Other bits (block protection etc.) are written back as read.
+            uint8_t wren[1] = {0x06};
+            if (spec->reg == 2) {
+                uint8_t wr[2] = {0x31, (uint8_t)(cur | spec->bit)};
+                flash_do_cmd(wren, NULL, 1); flash_do_cmd(wr, NULL, 2); picoface_flash_wait_wip();
+                cur = picoface_flash_rd(0x35);
+                if ((cur & spec->bit) == 0u) {         // older parts: 01h takes SR1 and SR2 together
+                    const uint8_t sr1 = picoface_flash_rd(0x05);
+                    uint8_t wr2[3] = {0x01, sr1, (uint8_t)(cur | spec->bit)};
+                    flash_do_cmd(wren, NULL, 1); flash_do_cmd(wr2, NULL, 3); picoface_flash_wait_wip();
+                    cur = picoface_flash_rd(0x35);
+                }
+            } else {
+                uint8_t wr[2] = {0x01, (uint8_t)(cur | spec->bit)};
+                flash_do_cmd(wren, NULL, 1); flash_do_cmd(wr, NULL, 2); picoface_flash_wait_wip();
+                cur = picoface_flash_rd(0x05);
+            }
+        }
+        if ((cur & spec->bit) != 0u) {
+            rom_flash_select_xip_read_mode(BOOTROM_XIP_MODE_EBH_QUAD, 3);
+            picoface_xip_settle();
+            if (picoface_flash_probe() == ref) return true;
+        }
+    }
+    // No quad: put the bootrom's dual back, and prove it, before touching anything else.
+    rom_flash_select_xip_read_mode(BOOTROM_XIP_MODE_BBH_DUAL, 3);
+    picoface_xip_settle();
+    if (picoface_flash_probe() == ref) return false;
+    rom_flash_select_xip_read_mode(BOOTROM_XIP_MODE_03H_SERIAL, 3);
+    picoface_xip_settle();
+    return false;
+}
+#endif
+
+// After a flash program/erase. The SDK's flash_range_program/erase re-enter XIP
+// through rom_flash_enter_cmd_xip(), which is "a standard 03h serial read
+// command ... CLKDIV 12" -- not the mode the bootrom found, and not ours.
+// Restoring the timing alone, as the three write sites did, left every board
+// on serial 03h at the fast divider until the next reboot: one bit per clock,
+// a quarter of quad's bandwidth, after the first settings save. So: the mode
+// first, then the timing pico_init() settled on. RAM-resident, like its callers.
+void __attribute__((noinline)) __not_in_flash_func(picoface_flash_after_write)(void)
+{
+#if PICO_RP2350
+    rom_flash_select_xip_read_mode(picoface_flash_is_quad ? BOOTROM_XIP_MODE_EBH_QUAD
+                                                          : BOOTROM_XIP_MODE_BBH_DUAL, 3);
+    rom_flash_flush_cache();
+    __dsb();
+    qmi_hw->m[0].timing = picoface_qmi_timing_effective;
+    __dsb();
+    (void)*(volatile uint32_t *)XIP_NOCACHE_NOALLOC_BASE;
+    __dsb();
+    __isb();
+#endif
+}
+
 void pico_init()
 {
     // FPU flush-to-zero + default-NaN for THIS core (see pico_hw.h for the
@@ -251,6 +386,19 @@ void pico_init()
         (picoface_boot_qmi_rfmt & QMI_M0_RFMT_DATA_WIDTH_BITS) >> QMI_M0_RFMT_DATA_WIDTH_LSB;
     picoface_flash_is_quad =
         ((picoface_boot_qmi_rcmd & 0xFFu) == 0xEBu) && (bootDataWidth == 2u);
+
+    if (!picoface_flash_is_quad) {
+        // The bootrom settled on something slower than quad. Take a checksum in
+        // that mode as the truth, try to get quad ourselves, and re-read the
+        // registers so everything below sees the result.
+        const uint32_t ref0 = picoface_flash_probe();
+        picoface_flash_quad_by_us = picoface_flash_enable_quad(ref0);
+        picoface_boot_qmi_timing = qmi_hw->m[0].timing;
+        picoface_boot_qmi_rfmt   = qmi_hw->m[0].rfmt;
+        picoface_boot_qmi_rcmd   = qmi_hw->m[0].rcmd;
+        const uint32_t w2 = (picoface_boot_qmi_rfmt & QMI_M0_RFMT_DATA_WIDTH_BITS) >> QMI_M0_RFMT_DATA_WIDTH_LSB;
+        picoface_flash_is_quad = ((picoface_boot_qmi_rcmd & 0xFFu) == 0xEBu) && (w2 == 2u);
+    }
 
     // The reference: a checksum of a slab of flash taken at the timing the
     // bootrom itself was using. The chip booted and is executing from flash
@@ -336,7 +484,8 @@ void pico_init()
     } else {
         picoface_qmi_timing_effective =
             picoface_flash_autotune(flashRef,
-                                    PICOFACE_QMI_M0_TIMING_TARGET,
+                                    picoface_flash_quad_by_us ? PICOFACE_QMI_M0_TIMING_CAUTIOUS
+                                                              : PICOFACE_QMI_M0_TIMING_TARGET,
                                     PICOFACE_QMI_M0_TIMING_CD4,
                                     PICOFACE_QMI_M0_TIMING_SAFE,
                                     scaledBoot,

--- a/core/src/veeprom.cpp
+++ b/core/src/veeprom.cpp
@@ -94,7 +94,7 @@ static void __no_inline_not_in_flash_func(flash_write_locked)(int eraseSectorIdx
     // compile-time target. On a board where the bootrom did not establish
     // quad mode those are different, and writing the target here would
     // undo the boot's care at the first settings save.
-    qmi_hw->m[0].timing = picoface_qmi_timing_effective;  // undo boot2 re-init clobber
+    picoface_flash_after_write();   // mode AND timing: the SDK left 03h serial here
     // Returning from this SRAM-resident function is the first instruction fetch
     // to go through the QMI again, so the timing write must have landed by then.
     // __compiler_memory_barrier() only constrains the compiler; __dsb() is what

--- a/instruments/PicoFaceJ6/src/j6_patchstore.cpp
+++ b/instruments/PicoFaceJ6/src/j6_patchstore.cpp
@@ -90,7 +90,7 @@ static void __no_inline_not_in_flash_func(bank_write_locked)(const uint8_t* buf)
     // compile-time target. On a board where the bootrom did not establish
     // quad mode those are different, and writing the target here would
     // undo the boot's care at the first settings save.
-    qmi_hw->m[0].timing = picoface_qmi_timing_effective;   /* undo boot2 clobber */
+    picoface_flash_after_write();   // mode AND timing: the SDK left 03h serial here
     /* Returning from this SRAM-resident function is the first fetch to go
      * through the QMI again, so the write must have landed. __dsb orders the
      * APB write against those fetches; a compiler barrier would not. */

--- a/instruments/PicoFaceMD/README.md
+++ b/instruments/PicoFaceMD/README.md
@@ -699,6 +699,52 @@ up, that is the knob.
 
 
 
+### The bit the bootrom never sets, and the mode it leaves behind
+
+Two more things came out of the RP2350B-Plus-W, and both reach further than
+that board.
+
+**Why a flash boots in dual.** The board's part is a Puya P25Q128H (JEDEC
+`85 20 18`), not the Winbond in Waveshare's schematic, and its quad-enable bit
+was clear from the factory. The RP2350 bootrom never sets that bit for any
+vendor. Datasheet 5.2.7: it tries *EBh quad, BBh dual, 0Bh, 03h* at divisors
+3/6/12/24 and boots in the first mode that yields a valid image. A part with QE
+clear answers EBh with garbage, so the bootrom settles on dual -- half the
+bandwidth, for nothing in the silicon -- and the datasheet puts "any further
+setup" on the image itself. A board whose flash ships with QE set (the Winbond
+on the A2 reference board) never shows the problem, which is why it looked
+like a stepping difference for two weeks.
+
+`pico_init()` now does that setup when the bootrom left something slower than
+quad: read the JEDEC id, look the vendor up (Puya, Winbond, GigaDevice, Zbit,
+XTX, Boya, Fudan: status register 2 bit 1; Macronix, ISSI, EON: status
+register 1 bit 6; Micron/XMC share a manufacturer byte and are left alone), set
+the bit **once, non-volatile**, if it is clear, select EBh through the bootrom
+API, and believe it only if a 32 KB checksum of the flash reproduces the one
+taken in the bootrom's own mode. Otherwise dual is put back and proven the same
+way. From then on the bootrom finds quad by itself and this code no longer
+runs on that board. Measured on the D5: boot benchmark **154 in dual at 49 MHz,
+62 in quad at 111 MHz**; the A2 reference reads 51-57.
+
+A board where *we* had to do this runs the cautious rung -- `CD4` at 444 MHz,
+`RD_CAP` at 480 -- because the only such part measured verifies 111 MHz and
+hangs at 148, and a rung that hangs cannot be stepped down from. Everything
+runs from SRAM; `flash_do_cmd()` leaves XIP in 03h serial afterwards, which is
+why every mode is set explicitly and the reference is taken first.
+
+**The mode after a flash write.** This one reached every board. The SDK's
+`flash_range_program()` and `flash_range_erase()` re-enter XIP through
+`rom_flash_enter_cmd_xip()`, documented as *"a standard 03h serial read
+command ... CLKDIV is set to 12"* -- not the mode the bootrom found, and not
+ours. The three write sites (`core/src/veeprom.cpp`, the RD's `veeprom.cpp`,
+the J6's `j6_patchstore.cpp`) restored the **timing** alone, which put every
+board on serial 03h at the fast divider from the first settings save until the
+next reboot: one bit per clock, a quarter of quad's bandwidth, and 03h itself
+is a command most parts rate to about 50 MHz. `picoface_flash_after_write()`
+now restores the mode and then the timing, from RAM, at all three sites. The
+visible symptom on a D5 is the load figure rising after a settings save and
+falling back after a reboot.
+
 ### The "A4 board" that had no sound was a different board
 
 A footnote to everything above, because it would otherwise read as one story.

--- a/instruments/PicoFaceRD/src/veeprom.cpp
+++ b/instruments/PicoFaceRD/src/veeprom.cpp
@@ -94,7 +94,7 @@ static void __no_inline_not_in_flash_func(flash_write_locked)(int eraseSectorIdx
     // compile-time target. On a board where the bootrom did not establish
     // quad mode those are different, and writing the target here would
     // undo the boot's care at the first settings save.
-    qmi_hw->m[0].timing = picoface_qmi_timing_effective;  // undo boot2 re-init clobber
+    picoface_flash_after_write();   // mode AND timing: the SDK left 03h serial here
     // Returning from this SRAM-resident function is the first instruction fetch
     // to go through the QMI again, so the timing write must have landed by then.
     // __compiler_memory_barrier() only constrains the compiler; __dsb() is what


### PR DESCRIPTION
Two findings from the RP2350B-Plus-W that reach further than that board. Both confirmed on hardware.

## 1. The bit the bootrom never sets

The board's flash is a **Puya P25Q128H** (JEDEC `85 20 18`, not the Winbond in Waveshare's schematic) with its quad-enable bit **clear from the factory**. The RP2350 bootrom never sets that bit for any vendor — datasheet 5.2.7: it tries *EBh quad → BBh dual → 0Bh → 03h* at divisors 3/6/12/24 and boots in the first mode that yields a valid image. A part with QE clear answers EBh with garbage, so the bootrom settles on **dual** — half the bandwidth, for nothing in the silicon. A flash that ships with QE set (the Winbond on the A2 reference board) never shows it, which is why this looked like a stepping difference for two weeks. The datasheet puts "any further setup" on the image itself.

`pico_init()` now does that setup when the bootrom left something slower than quad:

- read the JEDEC id; look the vendor up — **Puya, Winbond, GigaDevice, Zbit, XTX, Boya, Fudan: SR2 bit 1; Macronix, ISSI, EON: SR1 bit 6**; Micron/XMC share a manufacturer byte and are left alone
- set the bit **once, non-volatile**, only if it is clear (other bits written back as read)
- select EBh through the bootrom API and believe it only if a 32 KB checksum reproduces the one taken in the bootrom's own mode; otherwise put dual back and prove that the same way
- from then on the bootrom finds quad by itself and this code no longer runs on that board

A board where *we* had to do this runs the **cautious rung** (`CD4` at 444 MHz, `RD_CAP` at 480): the only such part measured verifies 111 MHz and hangs at 148, and a rung that hangs cannot be stepped down from.

Everything runs from SRAM. `flash_do_cmd()` leaves XIP in 03h serial afterwards, which is why every mode is set explicitly and the reference checksum is taken first.

**On the board:** QE cleared with a diagnostic, power-cycled, this image flashed → `A3 D` from the bootrom, then **`A3 Q 444/111 r5`** from the firmware. Earlier measurements on the same board: D5 boot benchmark **154 in dual at 49 MHz → 62 in quad at 111 MHz** (A2 reference: 51–57).

## 2. The mode left behind after every flash write — this one reached every board

The SDK's `flash_range_program()`/`flash_range_erase()` re-enter XIP through `rom_flash_enter_cmd_xip()`, documented as *"a standard 03h serial read command … CLKDIV is set to 12"* — not the mode the bootrom found, and not ours. The three write sites (`core/src/veeprom.cpp`, RD's `veeprom.cpp`, J6's `j6_patchstore.cpp`) restored the **timing** alone. Net effect: **every board ran on serial 03h at the fast divider from its first settings save until the next reboot** — one bit per clock, a quarter of quad's bandwidth, in a command most parts rate to about 50 MHz.

`picoface_flash_after_write()` (RAM-resident) now restores the mode and then the timing at all three sites. Visible symptom before the fix: a D5's load figure rising after a settings save and falling back after a reboot.

## What changes for the boards already in use

Boards the bootrom puts in quad by itself — every one tested before this week — take none of the enable path. They gain the after-write fix only. Ladder literals read back from the ELFs: default D5 `SAFE / RX4 / CD4` selected at runtime, RD `SAFE / RD / RD_CAP`; the variant unchanged from #133.

## Verification

- Hardware, all confirmed on the boards:
  - **B board (RP2350B-Plus-W, Puya):** QE cleared with a diagnostic, power-cycled, this image flashed → bootrom lands on dual, firmware ends at **`A3 Q 444/111 r5`**; **sound; D5 boot benchmark B62** (154 before, in dual at 49 MHz). Power-cycled again → still `Q`: the bit held, the bootrom finds quad by itself now. **MD: sound.**
  - **A2 board (Winbond, quad from the bootrom):** D5 load **P10 idle, P59 with keys held — identical before and after a settings save.** The after-write path restores mode and timing without disturbing a board that never needed the enable.
- Both variants build all ten instruments, 0 errors. All new routines at RAM addresses; the after-write helper is called from all three write sites (`bl` in each ELF).
- READMEs: top-level *Which RP2350 board*, and a new section in the MD README, *The bit the bootrom never sets, and the mode it leaves behind*.

Refs #107 — a board whose bootrom lands on dual now gets quad from the firmware; whether the reporter's board is such a case is the open question there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
