### PR TITLE
project_config: the cautious flash rung can be overridden per build

### DIFF
--- a/core/include/project_config.h
+++ b/core/include/project_config.h
@@ -214,11 +214,13 @@
 // 111 MHz in quad and hangs at 148, and a rung that hangs cannot be stepped
 // down from. So such boards top out here rather than at the full rung, at
 // either core clock. A board that turns out faster can override TARGET.
+#ifndef PICOFACE_QMI_M0_TIMING_CAUTIOUS
 #if PICOFACE_SYS_CLOCK_HZ == 480000000
 #define PICOFACE_QMI_M0_TIMING_CAUTIOUS PICOFACE_QMI_M0_TIMING_RD_CAP
 #else
 #define PICOFACE_QMI_M0_TIMING_CAUTIOUS PICOFACE_QMI_M0_TIMING_CD4
 #endif
+#endif   // overridable, e.g. -DPICOFACE_QMI_M0_TIMING_CAUTIOUS=PICOFACE_QMI_M0_TIMING_SAFE for a flash slower than the reference part
 
 #ifndef PICOFACE_QMI_M0_TIMING_TARGET
 #if defined(WAVESHARE_RP2350B_PLUS_W)


### PR DESCRIPTION
One-line guard: `PICOFACE_QMI_M0_TIMING_CAUTIOUS` (the rung a board runs when the firmware had to enable quad itself) can now be set from the build, e.g. `-DPICOFACE_QMI_M0_TIMING_CAUTIOUS=PICOFACE_QMI_M0_TIMING_SAFE` for a flash slower than the reference Puya. Needed to hand the #107 reporter — whose flash was good to 100 MHz and dead at 116 in dual — an image that cannot hang on its first rung. No change to any default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)