### PR TITLE
PicoFaceMD: calibrate the engine against the service manual schematics

### DIFF
--- a/instruments/PicoFaceMD/include/moog/moog_defs.h
+++ b/instruments/PicoFaceMD/include/moog/moog_defs.h
@@ -85,9 +85,15 @@
 /* ------------------------------------------------------------------------ */
 /* Keyboard                                                                  */
 /*                                                                           */
-/* The original has 44 keys, F1..C5 (MIDI 29..72). Notes outside that range   */
-/* are folded in by octaves rather than dropped -- a controller with 61 keys  */
-/* should not have dead zones at both ends.                                   */
+/* The original has 44 keys, F1..C5 (MIDI 29..72) -- the service manual gives */
+/* the span as "(LO F) (HI C) 0 TO 3.64V" over a string of 43 resistors       */
+/* (Fig. 9-2, Dwg 1436). The keyboard runs at 1.02 V/oct into a 102K summing  */
+/* resistor, which is 1 V/oct exactly by the time the oscillators see it.     */
+/*                                                                            */
+/* The two constants below record that span; they do not gate anything. Notes */
+/* outside it play where they are asked to, because a MIDI instrument with    */
+/* dead zones at both ends of a 61-key controller would be worse, not more    */
+/* faithful.                                                                  */
 /* ------------------------------------------------------------------------ */
 #define MOOG_KEY_FIRST      29      /* F1 */
 #define MOOG_KEY_LAST       72      /* C5 -- 44 keys */
@@ -107,31 +113,54 @@
 /* further position one octave. LO sits far below 32' -- the manual describes */
 /* it as "sub-audio clicks", and with the osc 3 keyboard switch off it is the */
 /* instrument's only LFO.                                                     */
+/*                                                                            */
+/* How far below is in the schematic rather than the prose: the range switch  */
+/* taps a resistor chain of 1K per octave (2'-4'-8'-16'-32'), and from 32'    */
+/* down to LO sits a single 4.75K (Fig. 9-2). LO is therefore 4.75 octaves    */
+/* under 32' and 6.75 under 8' -- middle C comes out at 2.4 Hz, which is the  */
+/* usable end of an LFO. The -8.0 this used to hold put it at 1.0 Hz, too      */
+/* slow across the whole keyboard.                                            */
 /* ------------------------------------------------------------------------ */
 #define MOOG_RANGE_COUNT    6
-#define MOOG_LO_OCTAVES    (-8.0f)  /* LO, relative to 8' */
+#define MOOG_LO_OCTAVES    (-6.75f) /* LO, relative to 8' (32' - 4.75K/1K) */
 
 /* Waveform switch, six positions. Oscillator 3 substitutes a reverse
  * sawtooth for the sawtooth-triangular of oscillators 1 and 2. */
 #define MOOG_WAVE_COUNT     6
 
-/* Pulse widths of the three rectangular positions. The panel calls them
- * square, wide rectangular and narrow rectangular; the values are the
- * measured duty cycles of the original rather than exact fractions -- the
- * "square" of a Model D is not 50 %, and that asymmetry is audible. */
-#define MOOG_PULSE_SQUARE   0.48f
+/* Pulse widths of the three rectangular positions -- square, wide
+ * rectangular, narrow rectangular.
+ *
+ * The service manual pins all three down. A panel divider of 1.5K / 1K / 7.5K
+ * across -10 V (Dwg 1448) offers three tap voltages, 0 V, -1.5 V and -2.5 V,
+ * and the oscillator board is calibrated against two of them: "0V = RECT" and
+ * "-2.5V = 15 % D/CY" at the PW input (Fig. 9-2). The transfer between them is
+ * linear -- a +/-1.75 V triangle against a threshold halved by a 100K/100K
+ * divider -- so the middle tap lands on 29 %.
+ *
+ * The square really is square: note 4 of Fig. 9-1 has the timing components
+ * "FACTORY SELECTED (IF NECESSARY) TO ACHIEVE 50 % +/-1 % RECT. DUTY CYCLE",
+ * and Fig. 9-3 marks the waveform 50 %. An earlier 0.48 here was asserted to
+ * be a measured asymmetry; it is outside the factory tolerance, and it puts a
+ * second harmonic 24 dB down on the one waveform whose character is having
+ * none. */
+#define MOOG_PULSE_SQUARE   0.50f
 #define MOOG_PULSE_WIDE     0.29f
-#define MOOG_PULSE_NARROW   0.14f
+#define MOOG_PULSE_NARROW   0.15f
 
 /* Break point of the sawtooth-triangular ("shark tooth"): the rising ramp
  * takes this fraction of the cycle, the fall the rest. */
 #define MOOG_TRISAW_BREAK   0.80f
 
-/* Frequency control of oscillators 2 and 3, in semitones. The manual gives
- * the range as "as much as a major sixth"; the panel is marked -7..+7. With
- * the osc 3 keyboard switch off, oscillator 3 widens to six octaves. */
+/* Frequency control of oscillators 2 and 3. The panel is marked -7..+7 and
+ * the schematic agrees: "7.5V +/-2.5V, +/-5TH(+)" at both controls, a fifth
+ * either way (Fig. 9-2).
+ *
+ * With the oscillator 3 keyboard switch off the same control widens out. The
+ * owner's manual rounds that to "a frequency sweep of 6 octaves"; the
+ * schematic is more exact and marks the OSC 3 CONTROL line "+/-2.75 OCT". */
 #define MOOG_FREQ_SEMITONES 7.0f
-#define MOOG_FREQ_OCTAVES   3.0f
+#define MOOG_FREQ_OCTAVES   2.75f
 
 /* Master tune, in semitones either way. */
 #define MOOG_TUNE_SEMITONES 2.5f
@@ -155,6 +184,17 @@
 /* Noise floor of the audio path, well below anything played but enough to
  * keep the output from being mathematically silent between notes. */
 #define MOOG_HISS_LEVEL     4.0e-5f
+
+/* The noise channel of the mixer is not on the same footing as the other
+ * four. Its series resistor into the summing node is R49 12K where the
+ * oscillators and the external input all get 33K (Dwg 1446), so the channel
+ * runs 2.75x hotter; against that, the noise source is specified at -4 dBm
+ * (0.49 V rms, Dwg 1431) where an oscillator delivers 3.5 V p-p (1.01 V rms
+ * on a sawtooth), which is 6.3 dB the other way. What is left is the factor
+ * below -- about 2.5 dB, small, but it is the difference between noise that
+ * sits under a patch and noise that is part of it. Both sources come out of
+ * this engine at the same rms, so it applies as a plain channel gain. */
+#define MOOG_NOISE_MIX_GAIN 1.33f
 
 /* ------------------------------------------------------------------------ */
 /* Ladder filter                                                             */
@@ -180,8 +220,16 @@
  * reach past it. */
 #define MOOG_RESONANCE_MAX    1.06f
 
-/* Amount of Contour at maximum, in octaves of cutoff sweep. */
-#define MOOG_CONTOUR_OCTAVES  6.0f
+/* Amount of Contour at maximum, in octaves of cutoff sweep.
+ *
+ * Derived rather than guessed. The filter contour swings +0.1 V to +4.0 V
+ * (Dwg 1437) and reaches the filter's control node through the 5K Amount pot
+ * and R601 47K (Dwg 1446): 3.9 V / 47K = 83 uA. The same node takes the
+ * keyboard at 1.02 V/oct through 100K, so one octave is 10.2 uA -- and the
+ * contour is worth a little over eight of them. Six octaves, which this held
+ * before, is a third short of what makes the filter envelope of a Model D
+ * sound the way it does. */
+#define MOOG_CONTOUR_OCTAVES  8.1f
 
 /* Keyboard control switches. The manual: switch K "couples a small amount",
  * switch L "a larger amount", and with both on "the filter cutoff frequency
@@ -213,8 +261,14 @@
 
 /* ------------------------------------------------------------------------ */
 /* Glide                                                                     */
+/*                                                                           */
+/* A 5 MOhm audio-taper pot charging C102, 1 uF (Dwg 1436) -- a time constant */
+/* of five seconds at the top of the control. The number below is the time to */
+/* cover 90 % of the interval, which is 2.3 time constants, so 11.5 s. The    */
+/* 3.0 that stood here was roughly four times too fast; the squared panel law */
+/* in moog_voice.cpp stands in for the audio taper of the original pot.       */
 /* ------------------------------------------------------------------------ */
-#define MOOG_GLIDE_MAX_S    3.0f
+#define MOOG_GLIDE_MAX_S   11.5f
 
 /* ------------------------------------------------------------------------ */
 /* Output stage                                                              */

--- a/instruments/PicoFaceMD/include/moog/moog_voice.h
+++ b/instruments/PicoFaceMD/include/moog/moog_voice.h
@@ -48,12 +48,22 @@
 #include "moog_ladder.h"
 #include "moog_env.h"
 
-/* Depth of the modulation mix at a fully raised mod wheel. Neither the
- * manual nor the schematic puts a number on these; they are set so that the
- * wheel gives a usable vibrato over its first third and a full-blooded
- * effect at the top. */
-#define MOOG_OSC_MOD_OCTAVES  0.60f
-#define MOOG_FILT_MOD_OCTAVES 3.00f
+/* Depth of the modulation mix at a fully raised mod wheel.
+ *
+ * The schematic does put a number on these, contrary to what stood here
+ * before. Fig. 9-2 marks the modulation bus "1.75 P-P MAX", and both
+ * destinations are ordinary summing resistors against a node where the
+ * keyboard's 1.02 V/oct through 102K is one octave:
+ *
+ *   oscillators   R5  100K  ->  1.75 V p-p = 1.75 oct p-p = +/-0.875 oct
+ *   filter        R52  33K  ->  5.3 oct p-p                = +/-2.65 oct
+ *
+ * That makes a fully raised wheel worth ten and a half semitones on the
+ * oscillators, not the seven the earlier 0.60 gave -- the dive bombs the
+ * instrument is known for need the whole of it. The wheel's own taper is
+ * dealt with separately, in the squared panel law in applyParameter(). */
+#define MOOG_OSC_MOD_OCTAVES  0.875f
+#define MOOG_FILT_MOD_OCTAVES 2.65f
 
 class MoogVoice
 {

--- a/instruments/PicoFaceMD/src/moog/moog_voice.cpp
+++ b/instruments/PicoFaceMD/src/moog/moog_voice.cpp
@@ -211,7 +211,9 @@ void MoogVoice::applyParameter(int id)
     case MOOG_OSC3_FREQ:
         /* "You will also observe that Oscillator 3's FREQUENCY control has a
          * much wider range when switch (B) is off ... a frequency sweep of 6
-         * octaves rather than one octave." */
+         * octaves rather than one octave." The schematic states the same
+         * thing to the decimal place: "+/-2.75 OCT" on the OSC 3 CONTROL
+         * line, so 5.5 octaves of sweep rather than the rounded 6. */
         oscFine_[2] = (v * 2.0f - 1.0f) *
                       (osc3Kbd_ ? MOOG_FREQ_SEMITONES
                                 : MOOG_FREQ_OCTAVES * 12.0f);
@@ -228,7 +230,10 @@ void MoogVoice::applyParameter(int id)
         mixGain_[2] = moogParamOn(p_[MOOG_OSC3_ON]) ? p_[MOOG_OSC3_VOL] : 0.0f;
         break;
     case MOOG_NOISE_VOL: case MOOG_NOISE_ON:
-        mixGain_[3] = moogParamOn(p_[MOOG_NOISE_ON]) ? p_[MOOG_NOISE_VOL] : 0.0f;
+        /* Scaled against the oscillators as the mixer of the original scales
+         * it -- see MOOG_NOISE_MIX_GAIN. */
+        mixGain_[3] = moogParamOn(p_[MOOG_NOISE_ON])
+                        ? p_[MOOG_NOISE_VOL] * MOOG_NOISE_MIX_GAIN : 0.0f;
         break;
     case MOOG_NOISE_COLOR:
         pinkNoise_ = (moogParamStep(v, 2) == 1);
@@ -590,13 +595,18 @@ void MoogVoice::process(float* out, int frames)
         y = dcOut_.process(y);
         y = toneLp_.process(y);
         y = moogSoftClip(y * 1.10f);
-        y *= volume_;
 
+        /* The tuning tone is injected into the second amplifier stage of the
+         * original (Dwg 1445), which sits ahead of the main volume control --
+         * so the volume knob rides it along with everything else. It stays
+         * clear of the filter and of the loudness contour, as it does there. */
         if (a440On_) {
             a440Phase_ += a440Inc_;
             if (a440Phase_ >= 1.0f) a440Phase_ -= 1.0f;
             y += sinf(a440Phase_ * twoPi) * MOOG_A440_LEVEL;
         }
+
+        y *= volume_;
 
         out[i] = y;
     }


### PR DESCRIPTION
The Minimoog Model D service manual carries no theory-of-operation or
specification text at all — it is Section 7 (parts lists) and Section 9
(schematics) plus the original R. A. Moog drawings 1429–1449. Everything here
is therefore read off the circuit rather than off prose.

The schematics make that straightforward. The keyboard runs at 1.02 V/oct into
a 102K summing resistor (Fig. 9-2), so **10 µA is one octave** at any summing
node in the instrument, and every other branch converts against that.

## Corrected

| | before | after | source |
|---|---|---|---|
| Square / narrow duty | 0.48 / 0.14 | **0.50 / 0.15** | Fig. 9-1 note 4, Fig. 9-2 |
| LO relative to 8' | −8.0 oct | **−6.75 oct** | 4.75K step in the 1K/oct chain |
| Amount of Contour | 6.0 oct | **8.1 oct** | 3.9 V through R601 47K vs 10.2 µA/oct |
| Mod → oscillators | ±0.60 oct | **±0.875 oct** | "1.75 P-P MAX" through R5 100K |
| Mod → filter | ±3.00 oct | **±2.65 oct** | "1.75 P-P MAX" through R52 33K |
| Glide (90 % time) | 3.0 s | **11.5 s** | 5 MΩ on C102 1 µF = τ 5 s |
| Osc 3 sweep, kbd off | ±3.0 oct | **±2.75 oct** | "±2.75 OCT" on the control line |
| Noise mixer channel | ×1.0 | **×1.33** | R49 12K vs 33K, less the −4 dBm source |
| A-440 | behind Volume | **ahead of Volume** | Dwg 1445, injected into VCA 2 |

Two of these are worth spelling out.

**The square really is square.** Note 4 of Fig. 9-1 has the oscillator timing
parts *"FACTORY SELECTED (IF NECESSARY) TO ACHIEVE 50 % ±1 % RECT. DUTY
CYCLE"*, and Fig. 9-2 marks the PW input *"0V = RECT"* / *"−2.5V = 15 % D/CY"*.
The 0.48 that stood here asserted a measured asymmetry outside the factory
tolerance, and it put a second harmonic 24 dB down on the one waveform whose
character is having none. The wide position needed no change: the panel
divider's middle tap sits at −1.5 V, which the linear comparator law maps to
exactly 29 %.

**The modulation depths were in the schematic all along.** The header claimed
that neither the manual nor the schematic put a number on them. Fig. 9-2 marks
the modulation bus "1.75 P-P MAX", which makes a fully raised wheel worth ten
and a half semitones on the oscillators rather than the seven it was giving.

Also corrects the keyboard comment: `MOOG_KEY_FIRST`/`MOOG_KEY_LAST` record the
44-key F..C span the manual gives (*"(LO F) (HI C) 0 TO 3.64V"*, 43 resistors)
but gate nothing, and the octave folding the comment promised was never
implemented. Notes outside the span keep playing where they are asked to.

## Deliberately not changed

Three further divergences from the schematic are design decisions rather than
wrong numbers, and are left alone:

- the pulse outputs are level-compensated here, where the original's three
  rectangles all come out at 3.5 V p-p and the narrow one really is quieter;
- the shark tooth is modelled as a broken triangle, where the original mixes
  17.5 % sawtooth into it through R030/R031 (Dwg 1448) and therefore carries a
  real step discontinuity;
- the modulation mix is fed the same noise colour as the audio path, where
  SW14 is double-pole and hands it *"PINK OR RED NOISE"* (Dwg 1444) — red being
  a 100 Hz low-passed noise, which is what makes "noise → filter" on a Model D
  a slow random wander rather than a fizz.

## Verification

An offline harness driving the engine directly:

```
range switch      8'  4186.01 Hz    LO  38.891 Hz
LO below 8'       6.7500 oct  (want 6.7500)
square duty       50.05 %
contour ½ travel  3.957 oct   (want 4.050 — the ladder's tuning polynomial
                               accounts for the remainder)
cutoff panel 0.2  62.73 Hz self-oscillation against a nominal 64, which also
                  confirms the 16 Hz / ten-octave cutoff span already present
glide 90 %        11.50 s
NaN sweep         0 of all presets
```

Firmware links clean, RAM 53.66 %, FLASH 0.60 %.

## What to listen for on hardware

**Contour 6 → 8.1 octaves** changes every patch with a filter envelope: the
same knob position now opens considerably further, which is the point — it is
what the classic Model D filter attack depends on. **Glide 3 → 11.5 s** makes
the upper half of that control usable for the first time. Both are real
changes in sound, not cosmetics, so they want a listen before this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
