### PR TITLE
PicoFaceMD: the modulation mix gets its own noise colour, as SW14 gives it

### DIFF
--- a/instruments/PicoFaceMD/include/moog/moog_defs.h
+++ b/instruments/PicoFaceMD/include/moog/moog_defs.h
@@ -185,6 +185,28 @@
  * keep the output from being mathematically silent between notes. */
 #define MOOG_HISS_LEVEL     4.0e-5f
 
+/* Noise source: three outputs, not two.
+ *
+ * The noise board (Dwg 1431) is a chain -- generator, then a "-3db/OCTAVE
+ * FILTER" giving pink, then a "100 Hz LOWPASS FILTER" giving a third output
+ * the drawing calls red. All three are specified at -4 dBm, so each stage
+ * makes back the level its filter takes out.
+ *
+ * The panel switch SW14 is double-pole and moves both taps at once: the audio
+ * mixer gets white or pink, and the modulation mix gets pink or red -- always
+ * one stage darker than what is being heard. The modulation mix amplifier
+ * (Dwg 1444) has its noise input labelled "PINK OR RED NOISE", which is what
+ * gives that away. It matters: red is what makes noise pointed at the filter
+ * a slow random wander rather than a fizz.
+ *
+ * The order of the low-pass is not legible on the scan, but the network
+ * carries two capacitors, so it is modelled with two poles at the corner the
+ * drawing names. The gain is measured rather than derived -- it is what puts
+ * red at the same rms as white, which is what -4 dBm on all three outputs
+ * says the original does. */
+#define MOOG_RED_HZ        100.0f
+#define MOOG_RED_GAIN       2.07f   /* measured: puts red at the rms of white */
+
 /* The noise channel of the mixer is not on the same footing as the other
  * four. Its series resistor into the summing node is R49 12K where the
  * oscillators and the external input all get 33K (Dwg 1446), so the channel

--- a/instruments/PicoFaceMD/include/moog/moog_dsp.h
+++ b/instruments/PicoFaceMD/include/moog/moog_dsp.h
@@ -196,12 +196,29 @@ struct MoogBiquadLP {
 /* four instructions. The white output is the raw generator; the pink one is  */
 /* Paul Kellet's three-pole economy filter, which tracks a true -3 dB/octave  */
 /* slope to within a tenth of a dB across the audio band.                     */
+/*                                                                           */
+/* red() is the third output of the original's noise board, the one only the  */
+/* modulation mix ever sees -- see MOOG_RED_HZ. It is fed from pink, because  */
+/* the stages of that board are cascaded.                                     */
 /* ------------------------------------------------------------------------ */
 struct MoogNoise {
     uint32_t state = 0x1234567u;
     float b0 = 0.0f, b1 = 0.0f, b2 = 0.0f;
+    float r0 = 0.0f, r1 = 0.0f;
+    /* Default is the corner at the oversampled rate this normally runs at,
+     * so an instance nobody configures still behaves. */
+    float redK = 2.0f * (float) M_PI * MOOG_RED_HZ /
+                 ((float) SAMPLING_RATE * MOOG_OVERSAMPLE);
 
     void seed(uint32_t s) { state = s ? s : 0x1234567u; }
+
+    /* Only red depends on the rate; the pink coefficients below are the
+     * published ones and are left as they are. */
+    void setRate(float sr)
+    {
+        const float w = 2.0f * (float) M_PI * MOOG_RED_HZ / sr;
+        redK = w / (1.0f + w);
+    }
 
     float white()
     {
@@ -218,6 +235,14 @@ struct MoogNoise {
         b1 = 0.96300f * b1 + w * 0.2965164f;
         b2 = 0.57000f * b2 + w * 1.0526913f;
         return (b0 + b1 + b2 + w * 0.1848f) * 0.32f;
+    }
+
+    /* Takes the pink output, as the third stage of the board does. */
+    float red(float p)
+    {
+        r0 += (p - r0) * redK;
+        r1 += (r0 - r1) * redK;
+        return r1 * MOOG_RED_GAIN;
     }
 };
 

--- a/instruments/PicoFaceMD/src/moog/moog_voice.cpp
+++ b/instruments/PicoFaceMD/src/moog/moog_voice.cpp
@@ -27,6 +27,7 @@ void MoogVoice::init(float sampleRate)
     osc3_.init(osSr_, 0xC2B2AE35u, true);
 
     noise_.seed(0x1F123BB5u);
+    noise_.setRate(osSr_);          /* the render loop clocks it oversampled */
     hiss_.seed(0x27D4EB2Fu);
 
     ladder_.init(osSr_);
@@ -558,17 +559,29 @@ void MoogVoice::process(float* out, int frames)
             const float s2 = osc2_.process();
             const float s3 = osc3_.process();
 
+            /* All three stages of the noise board are clocked every sample,
+             * whichever way the switch is thrown -- they are filters with
+             * state, and letting one idle would make the panel switch fade in
+             * rather than change over. */
             const float w  = noise_.white();
-            const float nz = pinkNoise_ ? noise_.pink(w) : w;
+            const float pk = noise_.pink(w);
+            const float rd = noise_.red(pk);
+
+            /* SW14 is double-pole: the mixer hears white or pink, and the
+             * modulation mix is handed the next stage down either way. The
+             * panel legend names what is heard, which is why it says White
+             * and Pink and never mentions red at all. */
+            const float audioNz = pinkNoise_ ? pk : w;
+            const float modNz   = pinkNoise_ ? rd : pk;
 
             /* Oscillator 3 and the noise source feed the modulation mix
              * whether or not the mixer switches let them be heard. */
-            lastMod_ = moogLerp(s3, nz, modMix_) * modWheel_;
+            lastMod_ = moogLerp(s3, modNz, modMix_) * modWheel_;
 
             float mix = s1 * mixGain_[0]
                       + s2 * mixGain_[1]
                       + s3 * mixGain_[2]
-                      + nz * mixGain_[3]
+                      + audioNz * mixGain_[3]
                       + feedback_ * fbGain_;
 
             mix += hiss_.white() * MOOG_HISS_LEVEL;


### PR DESCRIPTION
The last of the three design divergences from the service manual that
[#136](https://github.com/Michi71/PicoVintageSynthCollection/pull/136)
deliberately left alone.

## What the board actually does

The noise board of a Model D has **three** outputs, not two. Dwg 1431 shows
them cascaded:

```
generator ──▶ "-3db/OCTAVE FILTER" ──▶ "100 Hz LOWPASS FILTER"
    │                  │                        │
  WHITE (5)         PINK (6)                 RED (2)          all at -4 dBm
```

Every stage makes back the level its filter takes out, which is why all three
carry the same specified level.

**SW14 is double-pole** and moves two taps at once. The audio mixer gets white
or pink — that is what the panel legend names, because that is what is heard —
and the modulation mix gets **pink or red**, always one stage darker. The give-
away is the modulation mix amplifier: Dwg 1444 labels its noise input
*"PINK OR RED NOISE"*, never white.

This engine had one tap. Whatever the panel selected went to both destinations,
so noise pointed at the filter came out a fizz where the original gives a slow
random wander. That is a different effect, not a different amount of the same
one — red is the whole point of the routing.

## Change

`MoogNoise::red()` is fed from pink, as the board feeds it: two poles at the
corner the drawing names. The order is not legible on the scan, but the network
carries two capacitors, so two it is. The gain is **measured rather than
derived** — 2.07 puts red at the same rms as white, which is what −4 dBm on all
three outputs says the original does.

All three stages are now clocked every sample whichever way the switch is
thrown. They are filters with state, and letting one idle would make the panel
switch fade in rather than change over. Pink already had that problem: it was
only stepped when pink was selected.

## Verification

Against the running engine:

```
noise brightness (rms of 1st difference)   white 1.4144  pink 0.6009  red 0.0033
red rms / white rms                        1.0023   (want 1.0000)
modulation tap    switch moves it by +1.8 dB; with osc 3 as the source 0e+00
```

Red is 180× darker than pink, which is what a 100 Hz low-pass does to it, while
all three sit within 0.02 dB of the same level.

The routing itself is shown by difference against a control rendering, with the
noise kept **out of the audio mixer** so that nothing but the modulation mix can
carry it: moving the switch changes the output by 1.8 dB rms, and with
oscillator 3 selected as the modulation source instead it changes it by
**exactly zero**. So the switch reaches the modulation mix, and it reaches
nothing else.

Every check from #136 still passes and no preset produces non-finite output.
Firmware links at RAM 53.68 %.

## What to listen for

Noise → filter with the panel on **Pink**. Before this it fizzed; it should now
be a slow random drift of the cutoff. On **White** the modulation is pink, which
is roughly what the whole control used to sound like, so that position will have
changed much less.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
