### PR TITLE
PicoFaceMD: retune the six presets that use oscillator 3 as an LFO

### DIFF
--- a/instruments/PicoFaceMD/src/moog/moog_presets.cpp
+++ b/instruments/PicoFaceMD/src/moog/moog_presets.cpp
@@ -164,7 +164,7 @@ const MoogProgram moogPrograms[MOOG_NPROGRAMS] = {
  * little so the preset shows what it does. */
 { "Whistle", {
     CTL(0.15f, ON, 0.00f, 0.167f, ON, OFF),
-    OSCS(F4, W_TRI,  F4, 0.500f, W_TRI,  LO, 0.550f, W_TRI),
+    OSCS(F4, W_TRI,  F4, 0.500f, W_TRI,  LO, 0.327f, W_TRI),
     MIX(0.80f, ON, 0.00f, OFF, 0.00f, OFF, 0.00f, OFF, WHITE, 0.00f, OFF),
     MODF(0.70f, 0.30f, 0.15f, OFF, ON, ON,
          0.15f, 0.40f, 0.80f,  0.18f, 0.40f, 0.92f, ON),
@@ -193,7 +193,7 @@ const MoogProgram moogPrograms[MOOG_NPROGRAMS] = {
  * wheel already past halfway. */
 { "Wobble Bass", {
     CTL(0.16f, OFF, 0.00f, 0.742f, OFF, OFF),
-    OSCS(F16, W_SAW,  F16, 0.520f, W_SAW,  LO, 0.420f, W_TRI),
+    OSCS(F16, W_SAW,  F16, 0.520f, W_SAW,  LO, 0.185f, W_TRI),
     MIX(0.85f, ON, 0.70f, ON, 0.00f, OFF, 0.00f, OFF, WHITE, 0.00f, OFF),
     MODF(0.22f, 0.70f, 0.20f, ON, ON, OFF,
          0.02f, 0.40f, 0.50f,  0.02f, 0.45f, 0.95f, ON),
@@ -202,7 +202,7 @@ const MoogProgram moogPrograms[MOOG_NPROGRAMS] = {
 
 { "Vibrato Lead", {
     CTL(0.20f, ON, 0.00f, 0.205f, ON, OFF),
-    OSCS(F8, W_SAW,  F8, 0.530f, W_ALT,  LO, 0.500f, W_TRI),
+    OSCS(F8, W_SAW,  F8, 0.530f, W_ALT,  LO, 0.273f, W_TRI),
     MIX(0.80f, ON, 0.70f, ON, 0.00f, OFF, 0.00f, OFF, WHITE, 0.00f, OFF),
     MODF(0.48f, 0.45f, 0.35f, OFF, ON, ON,
          0.10f, 0.40f, 0.55f,  0.06f, 0.45f, 0.90f, ON),
@@ -231,7 +231,7 @@ const MoogProgram moogPrograms[MOOG_NPROGRAMS] = {
  * filter: the modulation mix turned all the way over. */
 { "Wind", {
     CTL(0.30f, OFF, 1.00f, 0.592f, OFF, OFF),
-    OSCS(F8, W_TRI,  F8, 0.500f, W_TRI,  LO, 0.350f, W_TRI),
+    OSCS(F8, W_TRI,  F8, 0.500f, W_TRI,  LO, 0.109f, W_TRI),
     MIX(0.00f, OFF, 0.00f, OFF, 0.00f, OFF, 0.90f, ON, PINK, 0.00f, OFF),
     MODF(0.35f, 0.55f, 0.25f, ON, OFF, OFF,
          0.55f, 0.60f, 0.70f,  0.50f, 0.60f, 0.90f, ON),
@@ -297,7 +297,7 @@ const MoogProgram moogPrograms[MOOG_NPROGRAMS] = {
 
 { "Space Drone", {
     CTL(0.40f, OFF, 0.30f, 0.490f, ON, OFF),
-    OSCS(F16, W_SAW,  F8, 0.545f, W_ALT,  LO, 0.300f, W_TRI),
+    OSCS(F16, W_SAW,  F8, 0.545f, W_ALT,  LO, 0.055f, W_TRI),
     MIX(0.70f, ON, 0.65f, ON, 0.00f, OFF, 0.15f, ON, PINK, 0.00f, OFF),
     MODF(0.35f, 0.60f, 0.30f, ON, ON, OFF,
          0.70f, 0.70f, 0.60f,  0.60f, 0.75f, 0.90f, ON),
@@ -364,17 +364,24 @@ const MoogProgram moogPrograms[MOOG_NPROGRAMS] = {
  * Two things the sheet does not give a number for:
  *
  *   The oscillator 3 frequency. It only says the range switch is on LO, which
- *   spans 0.13..8.2 Hz here. 0.882 puts it at 4.96 Hz, a normal vibrato rate.
+ *   spans 0.36..16.3 Hz here. 0.689 puts it at 5.00 Hz, a normal vibrato rate.
+ *
+ *   That value used to be 0.882. It moved when the LO range was corrected
+ *   against the schematic -- LO turned out to sit 6.75 octaves under 8', not
+ *   the 8.0 this engine had assumed, so every setting of this control came
+ *   out 1.25 octaves fast and the vibrato here ran at 10.4 Hz. Five other
+ *   presets that use oscillator 3 as an LFO moved with it. The rate is what
+ *   was authored; only the knob position that reaches it has changed.
  *
  *   The modulation wheel. On the instrument this is played, not set -- you
  *   bring the vibrato in by hand on the long notes, and it is not on for the
  *   whole piece. A preset has to pick something, and this ships at 0.020,
- *   which is about +/-7 cents: a shimmer that is there without the note
- *   sounding as though it were sobbing. Raise it with CC 1 or on the CTL MOD
- *   page for as much wail as the part wants.
+ *   which is about +/-10 cents from oscillator 3: a shimmer that is there
+ *   without the note sounding as though it were sobbing. Raise it with CC 1
+ *   or on the CTL MOD page for as much wail as the part wants.
  *
- *   It shipped at 0.050 first, giving +/-18 cents of 5 Hz vibrato on every
- *   note, which is a lot on a sustained lead. Note that the Modulation Mix
+ *   It shipped at 0.050 first, which is +/-26 cents of 5 Hz vibrato on every
+ *   note, and that is a lot on a sustained lead. Note that the Modulation Mix
  *   is not what makes that dirty: measured at equal depth, oscillator 3
  *   smears the spectrum to 20 dB harmonic-to-rest while the noise source
  *   only reaches 46 dB. Turn Mod Mix to 0 for a clean sine vibrato, but
@@ -391,7 +398,7 @@ const MoogProgram moogPrograms[MOOG_NPROGRAMS] = {
  */
 { "Shine On", {
     CTL(0.10f, OFF, 0.50f, 0.141f, ON, OFF),
-    OSCS(F8, W_SAW,  F8, 0.5029f, W_SAW,  LO, 0.882f, W_TRI),
+    OSCS(F8, W_SAW,  F8, 0.5029f, W_SAW,  LO, 0.689f, W_TRI),
     MIX(0.80f, ON, 0.80f, ON, 0.00f, OFF, 0.00f, OFF, WHITE, 0.35f, ON),
     MODF(0.385f, 0.35f, 0.35f, OFF, ON, OFF,
          0.133f, 0.392f, 0.85f,  0.100f, 0.434f, 1.00f, ON),


### PR DESCRIPTION
Fallout from [#136](https://github.com/Michi71/PicoVintageSynthCollection/pull/136),
reported from hardware: *"Patch 25 Shine On klingt hinten heraus verzerrt."*

Correcting the LO range against the schematic moved it 1.25 octaves up, and
that silently retuned every preset that parks oscillator 3 down there and
points it at the pitch or the filter. Their frequency controls were set against
the old, wrong LO, so all six came out fast:

| # | preset | rate was | became | osc 3 freq |
|---|---|---|---|---|
| 7 | Whistle | 1.26 Hz | 2.94 | 0.550 → **0.327** |
| 10 | Wobble Bass | 0.73 | 1.79 | 0.420 → **0.185** |
| 11 | Vibrato Lead | 1.02 | 2.43 | 0.500 → **0.273** |
| 14 | Wind | 0.55 | 1.37 | 0.350 → **0.109** |
| 21 | Space Drone | 0.44 | 1.13 | 0.300 → **0.055** |
| 25 | Shine On | 5.00 | **10.43** | 0.882 → **0.689** |

Shine On gives it away because it was already the fastest of them. A 10.4 Hz
vibrato is a nervous buzz where the patch is named for a slow sing, and on two
saws through a resonant filter with the feedback path up, that reads as
roughness rather than as vibrato.

**The engine is not at fault and is not touched here.** The rates are what was
authored; only the knob positions that reach them have changed.

## It is not clipping

Worth stating, because several constants moved at once in #136 and a level
problem was the obvious first suspect. On a legato phrase through Shine On,
with the effects out of the way so the colouring stage can be inverted:

| | before #136 | after |
|---|---|---|
| peak | 0.493 | 0.507 |
| level reaching the colouring stage | 0.948 | 0.997 |
| samples driven past 1.0 | 0.00 % | **0.00 %** |

Reverting `MOOG_CONTOUR_OCTAVES` alone reproduces the old figures exactly, so
those four tenths of a dB are the contour and nothing else, and nothing is
clipping.

## Verification

All six rates rendered from the engine and checked against the same rendering
of the pre-#136 build — they land back within a hundredth of a hertz, bar Space
Drone at 0.45 against 0.44, which is the third decimal of the panel value. On
Shine On the peak pitch excursion is back to the 16.7 cents it had. No preset
produces non-finite output; the loudest peaks at 0.583. Firmware links at RAM
53.66 %.

Two comments in the Shine On block quoted numbers this invalidates and are
corrected with it: the span of the frequency control on LO (0.13..8.2 Hz was
the old law, 0.36..16.3 Hz is the real one) and the wheel depth in cents, which
grew when the modulation depth was corrected in the same pass.

## Still open, deliberately

Shine On's **Mod Mix sits at 5.0**, so half its vibrato is noise. That was
inaudible while the noise reaching the modulation mix was white; under
[#137](https://github.com/Michi71/PicoVintageSynthCollection/pull/137) it is
pink, which carries the same rms in far larger low-frequency excursions and
drags the pitch around by up to ±27 cents. Whether that share should come down
is a decision about the patch rather than about the engine, so it is left
alone here.

This branch is off `main` and does **not** carry #137, so the two can merge in
either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
