### PR TITLE
PicoFaceMD: the shark tooth is a resistor network, not a waveform

### DIFF
--- a/instruments/PicoFaceMD/include/moog/moog_defs.h
+++ b/instruments/PicoFaceMD/include/moog/moog_defs.h
@@ -148,9 +148,31 @@
 #define MOOG_PULSE_WIDE     0.29f
 #define MOOG_PULSE_NARROW   0.15f
 
-/* Break point of the sawtooth-triangular ("shark tooth"): the rising ramp
- * takes this fraction of the cycle, the fall the rest. */
-#define MOOG_TRISAW_BREAK   0.80f
+/* The sawtooth-triangular, the "shark tooth", is not a waveform of its own.
+ * R030 47K and R031 10K are strung between the oscillator's sawtooth and
+ * triangle outputs and the switch taps their junction (Dwg 1448), so position
+ * two carries a resistive mix of the other two:
+ *
+ *     V = (Vsaw/47K + Vtri/10K) / (1/47K + 1/10K)
+ *       = (10*Vsaw + 47*Vtri) / 57
+ *
+ * Two consequences, and both are audible. It is mostly triangle, a sixth of
+ * it sawtooth -- and because that sixth is a sawtooth, the mix carries a real
+ * step at the end of every cycle, 0.35 of full scale. This engine used to
+ * model the shape as a triangle with an off-centre peak, which is continuous
+ * and therefore softer than the original.
+ *
+ * The polarity of the triangle shaper relative to the sawtooth is not legible
+ * on the scan. It does not matter: the two possibilities are time-reverses of
+ * one another, so they carry the same magnitude spectrum.
+ *
+ * Knowingly left out: at the junction the source impedance is 47K||10K, about
+ * 8K, where the sawtooth and triangle positions are driven from followers.
+ * The original's shark tooth is therefore also a little quieter than its
+ * neighbours by an amount that moves with the volume pot -- a couple of dB
+ * that would cost a setting-dependent gain to reproduce. */
+#define MOOG_TRISAW_SAW    (10.0f / 57.0f)   /* 0.1754 */
+#define MOOG_TRISAW_TRI    (47.0f / 57.0f)   /* 0.8246 */
 
 /* Frequency control of oscillators 2 and 3. The panel is marked -7..+7 and
  * the schematic agrees: "7.5V +/-2.5V, +/-5TH(+)" at both controls, a fifth

--- a/instruments/PicoFaceMD/include/moog/moog_osc.h
+++ b/instruments/PicoFaceMD/include/moog/moog_osc.h
@@ -13,12 +13,15 @@
     sawtooth, reverse sawtooth, the three rectangles
         discontinuous in the sample itself -- polyBLEP at every edge
 
-    triangle, sawtooth-triangular
-        continuous, only the slope jumps. Their harmonics fall off at 1/n^2,
-        so the eleventh harmonic of a note at the top of the keyboard is
-        already 40 dB down. Generated directly: a polyBLAMP would cost real
-        cycles to correct something that sits under the noise floor of the
-        original.
+    sawtooth-triangular
+        mostly triangle, but the sixth of it that is sawtooth steps at the end
+        of every cycle, so it takes a polyBLEP scaled to that share
+
+    triangle
+        continuous, only the slope jumps. Its harmonics fall off at 1/n^2, so
+        the eleventh harmonic of a note at the top of the keyboard is already
+        40 dB down. Generated directly: a polyBLAMP would cost real cycles to
+        correct something that sits under the noise floor of the original.
 
   Header-only on purpose. process() is called three times per oversampled
   sample -- at 88.2 kHz that is half a million calls a second, and a function
@@ -130,13 +133,19 @@ public:
                     out = 1.0f - 2.0f * t;
                     out += moogPolyBlep(t, dt);
                 } else {
-                    /* Sawtooth-triangular, the "shark tooth": a long rising
-                     * ramp and a short fall. Continuous, so no correction --
-                     * only the slope steps, not the value. */
-                    out = (t < MOOG_TRISAW_BREAK)
-                            ? (t * (2.0f / MOOG_TRISAW_BREAK) - 1.0f)
-                            : (1.0f - (t - MOOG_TRISAW_BREAK) *
-                                      (2.0f / (1.0f - MOOG_TRISAW_BREAK)));
+                    /* Sawtooth-triangular, the "shark tooth": the resistive
+                     * mix of this oscillator's own sawtooth and triangle that
+                     * the panel taps between R030 and R031 -- see
+                     * MOOG_TRISAW_SAW. Mostly triangle, with enough sawtooth
+                     * in it to rise faster than it falls.
+                     *
+                     * The sawtooth share brings a step with it, so this needs
+                     * the correction after all. Scaled by that share, because
+                     * the step is the sawtooth's own and nothing else here
+                     * jumps. */
+                    out = MOOG_TRISAW_TRI * (1.0f - 4.0f * fabsf(t - 0.5f))
+                        + MOOG_TRISAW_SAW * (2.0f * t - 1.0f);
+                    out -= moogPolyBlep(t, dt) * MOOG_TRISAW_SAW;
                 }
                 break;
 


### PR DESCRIPTION
Second of the two design divergences left open by
[#136](https://github.com/Michi71/PicoVintageSynthCollection/pull/136).

Position two of the waveform switch is not an output of the oscillator at all.
R030 47K and R031 10K are strung between that oscillator's sawtooth and triangle
outputs, and the switch taps their junction (Dwg 1448):

```
#1 SAW IN ──┬── R030 47K ──┬── R031 10K ──┬── #1 TRIANGLE IN
            │              │              │
        contact 3      contact 2      contact 1
         (sawtooth)   (shark tooth)   (triangle)
```

so the mixer receives

```
V = (Vsaw/47K + Vtri/10K) / (1/47K + 1/10K) = (10·Vsaw + 47·Vtri) / 57
```

— ten fifty-sevenths sawtooth, forty-seven fifty-sevenths triangle.

This engine had it as a triangle with its peak moved to 0.8 of the cycle. That
was invented: a plausible-looking shape, and **continuous**, where the real one
carries a step of 0.35 full scale at the end of every cycle because a sixth of
it is a sawtooth.

## The difference is not subtle

Projected onto the harmonic series at 110 Hz:

| | h2 | h3 | h4 | rms |
|---|---|---|---|---|
| old (0.8 break) | −7.9 dB | −14.9 | −24.1 | 0.577 |
| **new (the network)** | **−21.7 dB** | **−18.2** | −27.6 | 0.487 |

The old shape was strongly asymmetric and rang with even harmonics; the real
one is mostly triangle with a sawtooth edge. Level drops 1.5 dB, since the mix
no longer reaches full scale in both directions (min −0.995, max +0.825).

Both figures check out analytically, which is the reason to trust them: only
the sawtooth share carries even harmonics, so h2 should be
`0.1754 · 0.3183 / 0.6779` = −21.7 dB, and h3 the two shares in quadrature at
−18.2 dB. Measured −21.7 and −18.2.

## The step needs a polyBLEP

The old continuous shape did not. The correction is scaled by the sawtooth
share, because the step is the sawtooth's own and nothing else in the mix jumps.
That was derived rather than tuned, so it was worth checking — at B6, energy
sitting off the harmonic series:

```
no correction         -29.3 dB
full sawtooth scale   -16.9 dB     (an over-correction, worse than none)
scaled by the share   -45.5 dB     <- what ships
```

## Knowingly left out

At that junction the source impedance is 47K‖10K, about 8K, where the sawtooth
and triangle positions are driven from followers. The original's shark tooth is
therefore quieter than its neighbours by a further couple of dB — an amount that
moves with the volume pot, and would cost a setting-dependent gain to reproduce.

The polarity of the triangle shaper relative to the sawtooth is not legible on
the scan. It does not matter: the two possibilities are time-reverses of one
another and carry the same magnitude spectrum.

## What to listen for

Two presets use the position, both on oscillator 2: **11 Vibrato Lead** and
**21 Space Drone**. Their oscillator 2 loses its even harmonics and 1.5 dB,
which is audible and is the point — it should read as hollower and softer,
closer to a triangle with an edge on it than to the reedy thing it was.

Whole check suite passes, no preset produces non-finite output, loudest peaks at
0.583. Firmware links at RAM 53.68 %.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
