### PR TITLE
PicoFaceMD: couple the rectangles, and stop compensating their level

### DIFF
--- a/instruments/PicoFaceMD/include/moog/moog_osc.h
+++ b/instruments/PicoFaceMD/include/moog/moog_osc.h
@@ -168,11 +168,31 @@ public:
                 if (t2 < 0.0f) t2 += 1.0f;
                 out -= moogPolyBlep(t2, dt);
 
-                /* A narrow pulse has a much smaller mean square than a
-                 * square wave. Without this the waveform switch would double
-                 * as a volume control. */
-                out *= (wave_ == MOOG_W_SQUARE) ? 1.0f
-                     : (wave_ == MOOG_W_WIDE)   ? 1.15f : 1.45f;
+                /* Coupled, as the 10 uF between the waveform switch and the
+                 * mixer's audio node couples it (Fig. 9-2). Without this the
+                 * rectangle arrives at the ladder sitting on its own duty
+                 * cycle -- -0.42 for the wide one, -0.70 for the narrow --
+                 * and biases the saturating input stage, which squashes one
+                 * half of the wave against the other. The original's filter
+                 * never sees that offset.
+                 *
+                 * It is also what makes the three positions differ in level
+                 * at all. The comparator output is a logic swing and knows
+                 * nothing about duty cycle: all three leave the oscillator
+                 * board at the same 3.5 V peak to peak (Fig. 9-2 pin 20B,
+                 * "0 / -3.5V"; Fig. 9-3 puts the triangle and sawtooth at
+                 * +/-1.75 V, the same span). Uncoupled they would all carry
+                 * the same mean square. Coupled, the mean square goes as
+                 * 4*w*(1-w), so 29 % lands 0.8 dB under the square and 15 %
+                 * lands 2.9 dB under it, and the peak turns asymmetric --
+                 * a narrow pulse reaches +1.7 against -0.3, exactly as
+                 * 2.975 V against -0.525 V on the instrument.
+                 *
+                 * So on a Model D the waveform switch really is a little bit
+                 * of a volume control. This engine used to make that back
+                 * with a gain per position, which is convenient and is not
+                 * what the instrument does. */
+                out -= 2.0f * w - 1.0f;
                 break;
             }
         }


### PR DESCRIPTION
The last of the three design divergences left open by
[#136](https://github.com/Michi71/PicoVintageSynthCollection/pull/136).

> Stacked on [#139](https://github.com/Michi71/PicoVintageSynthCollection/pull/139)
> and based on it, so the diff stays readable. GitHub will retarget this to
> `main` when #139 merges.

## What setting out to remove a gain turned up

The job was meant to be deleting the per-position gain on the three rectangles.
It turned up the reason it was there.

A **10 µF capacitor sits between the waveform switch and the mixer's audio
node**, which Fig. 9-2 marks `+2VDC`. The oscillator is coupled into the mixer.
This engine was not coupling it, so a rectangle arrived at the ladder sitting on
its own duty cycle:

```
square 50 %   mean +0.000     <- only this one was centred
wide   29 %   mean -0.420
narrow 15 %   mean -0.700
```

That offset biases the saturating input stage of the ladder, squashing one half
of the wave against the other. The original's filter never sees it.

## The coupling is what creates the level difference

The comparator output is a logic swing and knows nothing about duty cycle: all
three rectangles leave the oscillator board at the same 3.5 V peak to peak
(Fig. 9-2 pin 20B `0 / -3.5V`; Fig. 9-3 puts the triangle and sawtooth at
±1.75 V, the same span). **Uncoupled, they all carry the same mean square** —
which is what this engine had. So the per-position gain was not restoring a
balance the instrument has. It was inventing one, on top of a waveform that was
wrong in a different way.

Coupled, the mean square goes as `4·w·(1−w)`. Measured after the change:

| | p-p | mean | rms | vs square | peaks |
|---|---|---|---|---|---|
| square 50 % | 2.000 | +0.000 | 1.000 | — | +1.00 / −1.00 |
| wide 29 % | 2.000 | +0.000 | 0.906 | −0.85 dB *(formula: −0.84)* | +1.42 / −0.58 |
| narrow 15 % | 2.000 | +0.000 | 0.713 | −2.94 dB *(formula: −2.92)* | +1.70 / −0.30 |

Peak to peak stays constant, as on the board, and the peaks turn asymmetric —
+1.70 against −0.30 on the narrow one is 2.975 V against −0.525 V on the
instrument. So the waveform switch on a Model D really is a little bit of a
volume control, and now it is here too.

## Removing the bias repairs two presets

Rendered dry with two notes held:

| # | preset | was | now |
|---|---|---|---|
| 16 | Clav | −39.8 dBFS | **−29.6** |
| 5 | Funk Bass | −22.2 | **−18.2** |
| 9 | Hard Lead | −13.0 | −12.6 |
| 18 | Growl Bass | −12.0 | −11.9 |
| 22 | Trumpet | −13.4 | −13.9 |

Everything else moves by less than a twentieth of a dB. This is a repair rather
than a regression: **Clav sat eight decibels below the next quietest preset in
the whole bank** and now sits alongside Bell at the bottom of a sensible spread.
It was being crushed by an offset that should never have reached the filter.

Nothing clips — the loudest peak across the bank is 0.583 — and no preset
produces non-finite output. Whole check suite passes. Firmware links at RAM
53.68 %.

## What to listen for

**16 Clav** and **5 Funk Bass**, which should be louder and cleaner rather than
just louder. Then any narrow-pulse patch against a square one on the same
oscillator: the switch now steps down in level as you go from square to narrow,
which it did not before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
