### PR TITLE
PicoFaceJ6: the service manual's numbers, and all 56 factory patches

### DIFF
--- a/instruments/PicoFaceJ6/include/juno/juno_defs.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_defs.h
@@ -272,21 +272,35 @@
 /* At the top of the slider that is 2.786 s of silence and a further second   */
 /* of fade, which again overshoots the specified 1.5 s.                        */
 /* ------------------------------------------------------------------------ */
+/* The specifications page says 20 Hz; the factory adjustment is more exact
+ * and sets the top of the slider to a 45 ms period, which Fig. 29 of the
+ * service notes labels 22 Hz. */
 #define JUNO_LFO_HZ_MIN      0.3f
-#define JUNO_LFO_HZ_MAX     20.0f
+#define JUNO_LFO_HZ_MAX     22.0f
 #define JUNO_LFO_DELAY_MAX_S 2.786f
 #define JUNO_LFO_FADE_MAX_S  1.000f
 /*
  * Pitch modulation at full DCO LFO depth, in semitones.
  *
- * One, not seven. Seven was a guess and it was badly wrong: "Piano I" has the
- * DCO LFO slider at 0.4, which at seven semitones is a wobble of nearly three
- * semitones -- a ghost, not a piano. junox settles it by construction, since
- * its oscillator applies 2^(freqMod/12) with freqMod running to 1, so the
- * slider is worth exactly one semitone at the top. That also reads correctly
- * for the panel: this is a vibrato control, not a siren.
+ * The service notes settle this outright. Describing the master oscillator
+ * (TR58-TR62), which carries the common bender, LFO and tune voltages, they
+ * give its variable range per input:
+ *
+ *     BENDER  +/-700 cents
+ *     LFO     +/-300 cents
+ *     TUNE    +/- 50 cents
+ *
+ * and check the arithmetic themselves -- "when these voltages are summed
+ * together, the maximum shiftable range is +/-1050 cents". So a fully raised
+ * DCO LFO slider is worth three semitones.
+ *
+ * This held 1.0 before, taken from junox by construction rather than from any
+ * measurement, and it made the factory patches too timid to hear: at 1.0 the
+ * fifteen that use the slider get between 10 and 40 cents of vibrato, where
+ * a violin or an oboe wants three or four times that. Seven, which it held
+ * before that, was a guess and was too much.
  */
-#define JUNO_LFO_DCO_SEMIS   1.0f
+#define JUNO_LFO_DCO_SEMIS   3.0f
 
 /* ------------------------------------------------------------------------ */
 /* Chorus -- 2x MN3009 BBD, MN3101 clocks                                    */
@@ -347,14 +361,36 @@
 #define JUNO_DC_BLOCK_HZ     12.0f
 #define JUNO_HISS_LEVEL       3.0e-5f
 
-/* Pitch bender: the Juno-60 bender is a lever, and its range is set by a
- * panel control rather than fixed. Two semitones is what a MIDI controller
- * expects, so that is the default. */
-#define JUNO_BEND_MAX_SEMITONES 12.0f
+/* Pitch bender: the Juno-60 bender is a lever, and its depth is set by the
+ * Bend Sens (DCO) control on the bender panel rather than being fixed. That
+ * control's own maximum is seven semitones -- the master oscillator takes
+ * +/-700 cents from the bender (service notes, master oscillator), and the
+ * bender adjustment proves it twice over: with the lever hard left an E5
+ * must read 442 Hz, and with it hard right a D4 must read 442 Hz, each a
+ * fifth away from A4.
+ *
+ * This offered twelve before, which the instrument cannot reach. Two remains
+ * the default, since that is what a MIDI controller expects and it is well
+ * inside the range. */
+#define JUNO_BEND_MAX_SEMITONES 7.0f
 
 /* ------------------------------------------------------------------------ */
 /* Tuning                                                                    */
 /* ------------------------------------------------------------------------ */
+/*
+ * A deliberate departure, recorded here rather than left to look like an
+ * oversight: a Juno-60 is tuned to A = 442 Hz, not 440.
+ *
+ * The service notes say so four times over -- the master oscillator
+ * adjustment ("hold down A4 key and adjust L1 for 442 Hz"), both halves of
+ * the bender adjustment, the key designation figure, and the frequency table
+ * in the DCB section, which lists A4 at 442.0 Hz.
+ *
+ * 440 is kept because this instrument is played alongside others through
+ * MIDI, where being two hertz sharp is a fault rather than a period detail.
+ * Anyone who wants the original pitch has it on the panel: the rear Tune
+ * control spans +/-50 cents and 442 is 7.85 cents up.
+ */
 #define JUNO_A4_HZ          440.0f
 #define JUNO_NOTE0_HZ       8.1757989157f
 

--- a/instruments/PicoFaceJ6/include/juno/juno_defs.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_defs.h
@@ -44,9 +44,9 @@
 #include <stdint.h>
 #include <stddef.h>
 
-/* ------------------------------------------------------------------------ */
-/* Host/target switch (same approach as the rest of the family)              */
-/* ------------------------------------------------------------------------ */
+/* ------------------------------------------------------------------------   */
+/* Host/target switch (same approach as the rest of the family)               */
+/* ------------------------------------------------------------------------   */
 #ifdef JUNO_HOST_BUILD
 #ifndef PICO_AUDIO_I2S_BUFFERS_PER_CHANNEL
 #define PICO_AUDIO_I2S_BUFFERS_PER_CHANNEL 3
@@ -64,48 +64,48 @@
 
 #define JUNO_BLOCK          I2S_BUFFER_WORDS
 
-/* ------------------------------------------------------------------------ */
-/* Oversampling                                                              */
-/*                                                                           */
+/* ------------------------------------------------------------------------   */
+/* Oversampling                                                               */
+/*                                                                            */
 /* Six voices cost six times what one does, so this matters far more here     */
 /* than it did for the Model D, and it is the one number worth getting right   */
 /* before anything else.                                                      */
-/*                                                                           */
+/*                                                                            */
 /* Measured on this engine, scaled against the load PicoFaceMD reports on the  */
 /* device (its dry engine is 0.185 % of one host core and P21 on the RP2350):  */
-/*                                                                           */
+/*                                                                            */
 /*     1x   fixed P8, P6.2 per voice, chorus P2   -> six voices P48            */
 /*     2x   fixed P10, P10 per voice, chorus P2   -> six voices P72            */
-/*                                                                           */
+/*                                                                            */
 /* A prototype written before the engine predicted P42 and P59. It was too     */
 /* optimistic by 13 points at 2x, so the earlier conclusion that one core is   */
 /* comfortable at 2x does not survive its own measurement: P72 leaves only a   */
 /* quarter of the core for USB, MIDI and pushing the display out.              */
-/*                                                                           */
+/*                                                                            */
 /* Aliasing, one voice, sawtooth, filter wide open and no resonance -- the     */
 /* only configuration that can be measured honestly, since a resonant peak     */
 /* below the fundamental is not at a harmonic and swamps the figure:           */
-/*                                                                           */
+/*                                                                            */
 /*     1x  -45.2 dB     2x  -55.4 dB     4x  -53.7 dB                          */
-/*                                                                           */
+/*                                                                            */
 /* So 2x buys 10 dB and 4x buys nothing, the same shape of result as the       */
 /* Model D. 1x is the default because it fits one core with room to spare;     */
 /* going to 2x means either living at P72 or splitting the voices over both    */
 /* cores the way PicoFaceRD does.                                             */
-/* ------------------------------------------------------------------------ */
+/* ------------------------------------------------------------------------   */
 #ifndef JUNO_OVERSAMPLE
 #define JUNO_OVERSAMPLE 1
 #endif
 
 #define JUNO_DECIMATE_HZ 15000.0f
 
-/* ------------------------------------------------------------------------ */
-/* Polyphony                                                                 */
-/*                                                                           */
+/* ------------------------------------------------------------------------   */
+/* Polyphony                                                                  */
+/*                                                                            */
 /* Six, fixed. The instrument has six voice cards -- the schematic shows six  */
 /* IR3109 filters (IC2, 5, 8, 11, 14, 17) and six BA662 amplifiers -- and     */
 /* what happens on the seventh note is part of how a Juno plays.              */
-/* ------------------------------------------------------------------------ */
+/* ------------------------------------------------------------------------   */
 #define JUNO_VOICES         6
 
 /* 61 keys, 5 octaves (specifications page). Notes outside that are accepted
@@ -115,21 +115,21 @@
 #define JUNO_KEY_LAST       96      /* C7 -- 61 keys */
 #define JUNO_CENTER_NOTE    60      /* C4, reference for key follow */
 
-/* ------------------------------------------------------------------------ */
-/* DCO                                                                       */
-/*                                                                           */
+/* ------------------------------------------------------------------------   */
+/* DCO                                                                        */
+/*                                                                            */
 /* One per voice. The signal path is analogue but the timing comes from a     */
 /* digital clock, which is why a Juno stays in tune in a way a VCO does not.  */
 /* There is therefore no oscillator drift to model -- the opposite of the     */
 /* Model D, where the drift was most of the character.                        */
-/*                                                                           */
+/*                                                                            */
 /* junox reproduces the digital clock as round(sampleRate / frequency), which */
 /* quantises the period to whole audio samples. That is not what the          */
 /* instrument does: its counter runs in the megahertz, so its quantisation    */
 /* sits far below one audio sample. At 44.1 kHz junox's approach would put    */
 /* the top octave tens of cents out. A float accumulator is used here, which  */
 /* is both more accurate and cheaper.                                         */
-/* ------------------------------------------------------------------------ */
+/* ------------------------------------------------------------------------   */
 #define JUNO_RANGE_COUNT    3       /* 16' / 8' / 4' */
 
 /* Pulse width. The panel control runs from a square to a narrow pulse;
@@ -137,7 +137,7 @@
 #define JUNO_PW_MIN         0.50f
 #define JUNO_PW_MAX         0.95f
 
-/* Sub-oscillator: a square one octave below the DCO. */
+/* Sub-oscillator: a square one octave below the DCO.                         */
 #define JUNO_SUB_OCTAVES   (-1.0f)
 
 /* Noise. A note on the AR80017A filter clone says the noise source is
@@ -145,26 +145,26 @@
  * generator bolted to the side. */
 #define JUNO_NOISE_LP_HZ    5000.0f
 
-/* Master tune, specifications page: +/- 50 cents. */
+/* Master tune, specifications page: +/- 50 cents.                            */
 #define JUNO_TUNE_CENTS     50.0f
 
-/* ------------------------------------------------------------------------ */
-/* VCF -- IR3109                                                             */
-/*                                                                           */
+/* ------------------------------------------------------------------------   */
+/* VCF -- IR3109                                                              */
+/*                                                                            */
 /* Four OTA integrator sections in series inside a feedback loop, with a      */
 /* BA662 setting the amount of feedback. Structurally the same class as the    */
 /* transistor ladder of the Model D: four one-poles and one saturating stage. */
 /* Not a diode ladder, which is what junox models it as.                      */
-/*                                                                           */
+/*                                                                            */
 /* The audible difference from a Moog ladder is the bass. A transistor ladder */
 /* loses low end as the resonance comes up because the feedback is taken from */
 /* inside the ladder; an OTA cascade with a separate feedback amplifier does  */
 /* not. That is the gComp term below, and it is set high for exactly this     */
 /* reason -- a Juno with the resonance up is never thin.                      */
-/*                                                                           */
+/*                                                                            */
 /* Specifications page: RESONANCE (0 - Self Oscillation), KEY FOLLOW          */
 /* (0 - 100%).                                                                */
-/* ------------------------------------------------------------------------ */
+/* ------------------------------------------------------------------------   */
 #define JUNO_CUTOFF_MIN_HZ     20.0f
 #define JUNO_CUTOFF_MAX_HZ  18000.0f
 
@@ -219,56 +219,64 @@
 
 #define JUNO_LFO_VCF_OCTAVES    3.0f
 
-/* ------------------------------------------------------------------------ */
-/* HPF                                                                       */
-/*                                                                           */
+/* ------------------------------------------------------------------------   */
+/* HPF                                                                        */
+/*                                                                            */
 /* One for all six voices, after the sum (service notes, block diagram). A    */
 /* HD14051B switches between three capacitors (0.022 / 0.01 / 0.0047 uF) and  */
 /* a bypass, so the control has exactly four positions and no values in       */
 /* between.                                                                   */
-/*                                                                           */
+/*                                                                            */
 /* Corner frequencies from the Juno60 measurements, worked out from the       */
 /* component values as F = 1/(2*pi*R*C). junox uses 0 / 250 / 520 / 1220 Hz   */
 /* instead and says in a comment that it kept them because they sound good,   */
 /* not because they are right; these are the ones that follow from the parts. */
 /* 6 dB per octave -- a single pole.                                          */
-/* ------------------------------------------------------------------------ */
+/* ------------------------------------------------------------------------   */
 #define JUNO_HPF_POSITIONS  4
 #define JUNO_HPF_HZ_1       154.0f
 #define JUNO_HPF_HZ_2       339.0f
 #define JUNO_HPF_HZ_3       720.0f
 
-/* ------------------------------------------------------------------------ */
-/* Envelope -- IR3201                                                        */
-/*                                                                           */
+/* ------------------------------------------------------------------------   */
+/* Envelope -- IR3201                                                         */
+/*                                                                            */
 /* Times, from the specifications page:                                       */
 /*     ATTACK  1 ms .. 3 s                                                    */
 /*     DECAY   2 ms .. 12 s                                                   */
 /*     RELEASE 2 ms .. 12 s                                                   */
-/*                                                                           */
+/*                                                                            */
 /* Measured off a real instrument (Juno60), which does not agree:             */
 /*     ATTACK  slider 0/2.5/5/7.5/10 -> 0.001 / 0.03 / 0.24 / 0.65 / 3.25 s   */
 /*     DECAY   slider 0/2.5/5/7.5/10 -> 0.002 / 0.096 / 0.984 / 4.449 /       */
 /*             19.783 s                                                       */
-/*                                                                           */
-/* The measurement wins -- 19.8 s where the sheet says 12 is a big gap, but   */
-/* the sheet also says the diagrams in the manual are not meant to be exact,  */
-/* and a measurement off the actual hardware beats a round number in a table. */
-/*                                                                           */
+/*                                                                            */
+/* Where the two disagree the factory adjustment wins, and for the            */
+/* attack there is one: procedure 10 has the technician set ENV TIME          */
+/* VR6 for a three-second attack, with Fig. 38 drawing the curve              */
+/* against T = 3s. That is what the instrument is set to; 3.25 s is           */
+/* where one particular forty-year-old example has drifted to.                */
+/*                                                                            */
+/* The decay has no adjustment of its own -- the same VR6 sets the            */
+/* whole timing network and the decay pot scales it -- so the                 */
+/* measurement stands there. Strictly, calibrating the attack down by         */
+/* 8 % would carry the decay with it through that shared trimmer;             */
+/* left alone rather than derived, because nothing measures it.               */
+/*                                                                            */
 /* Two things about the shape matter more than the numbers:                    */
-/*                                                                           */
+/*                                                                            */
 /*   The decay duration does not depend on the sustain level. Measured with   */
 /*   sustain at 0 and at 5, the times came out the same (19.78 s and 17.11 s  */
 /*   at the top of the slider). That rules out the RC-charging-towards-target */
 /*   model used in PicoFaceMD, where the time to reach sustain shortens as    */
 /*   sustain rises. Segments here have a fixed duration.                       */
-/*                                                                           */
+/*                                                                            */
 /*   The slopes are curved, and junox interpolates them linearly. Measured    */
 /*   attack at slider 10 reaches 0.224 after half a second of a 3.25 s rise,  */
 /*   where a straight line would be at 0.154. Juno60 fits (1-e^-x)/0.632.     */
-/* ------------------------------------------------------------------------ */
+/* ------------------------------------------------------------------------   */
 #define JUNO_ATTACK_MIN_S    0.001f
-#define JUNO_ATTACK_MAX_S    3.250f
+#define JUNO_ATTACK_MAX_S    3.000f   /* adjustment 10: ENV TIME VR6 */
 #define JUNO_ATTACK_CURVE    0.5f     /* exponent of the slider mapping      */
 #define JUNO_ATTACK_SHAPE    0.632f   /* 1 - 1/e; normalises (1-e^-x)        */
 
@@ -288,23 +296,29 @@
 #define JUNO_GATE_ATTACK_S   0.003f
 #define JUNO_GATE_RELEASE_S  0.006f
 
-/* ------------------------------------------------------------------------ */
-/* LFO                                                                       */
-/*                                                                           */
+/* ------------------------------------------------------------------------   */
+/* LFO                                                                        */
+/*                                                                            */
 /* Specifications page: RATE 0.3 .. 20 Hz, DELAY TIME 0 .. 1.5 s.             */
 /* Triangle. junox's rate mapping reproduces the range and puts the middle of */
 /* the slider at 3.5 Hz, which is used here.                                  */
-/*                                                                           */
+/*                                                                            */
 /* Delay: measured (Juno60) as two things at once -- silence, then a ramp in. */
-/* At the top of the slider that is 2.786 s of silence and a further second   */
-/* of fade, which again overshoots the specified 1.5 s.                        */
-/* ------------------------------------------------------------------------ */
+/* The length of the silence has a factory adjustment, and two                */
+/* published figures agree with it: procedure 7-4 sets DELAY TIME VR4         */
+/* so that the modulation disappears on a key press and "2 seconds            */
+/* later, begins to reappear" (Fig. 31), and the owner's manual               */
+/* specifications say DELAY TIME 0 ~ 2s. Only the service notes' own          */
+/* specifications page dissents, at 1.5 s. 2.786 s stood here from a          */
+/* measurement off one instrument. The fade that follows the silence          */
+/* has no published figure at all, so that stays measured.                    */
+/* ------------------------------------------------------------------------   */
 /* The specifications page says 20 Hz; the factory adjustment is more exact
  * and sets the top of the slider to a 45 ms period, which Fig. 29 of the
  * service notes labels 22 Hz. */
 #define JUNO_LFO_HZ_MIN      0.3f
 #define JUNO_LFO_HZ_MAX     22.0f
-#define JUNO_LFO_DELAY_MAX_S 2.786f
+#define JUNO_LFO_DELAY_MAX_S 2.000f   /* adjustment 7-4 */
 #define JUNO_LFO_FADE_MAX_S  1.000f
 /*
  * Pitch modulation at full DCO LFO depth, in semitones.
@@ -329,26 +343,26 @@
  */
 #define JUNO_LFO_DCO_SEMIS   3.0f
 
-/* ------------------------------------------------------------------------ */
-/* Chorus -- 2x MN3009 BBD, MN3101 clocks                                    */
-/*                                                                           */
+/* ------------------------------------------------------------------------   */
+/* Chorus -- 2x MN3009 BBD, MN3101 clocks                                     */
+/*                                                                            */
 /* One triangle LFO driving two bucket-brigade lines, one per channel, with   */
 /* the right-hand modulation inverted so the two are half a cycle apart.      */
-/*                                                                           */
+/*                                                                            */
 /* Rates measured off the instrument (Juno60), which also showed that the     */
 /* service notes have a typo: they label the third setting 1 Hz where it is   */
 /* really 9.75 Hz. Without that correction the I+II setting would have been   */
 /* built ten times too slow.                                                  */
-/*                                                                           */
+/*                                                                            */
 /* An MN3009 has 256 stages, so its delay is 256/(2*fclk). The measured       */
 /* 1.66 .. 5.35 ms therefore puts the clock between about 77 kHz and 24 kHz.  */
 /* At the long end the line's own Nyquist limit is down at 12 kHz, so the     */
 /* top comes and goes with the modulation. That is the chip, not a fault, and */
 /* it is modelled with a low-pass that follows the delay.                      */
-/*                                                                           */
+/*                                                                            */
 /* I+II is mono: both lines get the same modulation, so what comes out is a   */
 /* vibrato rather than a chorus. The manual calls it Leslie-like.             */
-/* ------------------------------------------------------------------------ */
+/* ------------------------------------------------------------------------   */
 #define JUNO_CHORUS_MIN_MS    1.66f
 #define JUNO_CHORUS_MAX_MS    5.35f
 #define JUNO_CHORUS_I_HZ      0.513f
@@ -358,18 +372,18 @@
 #define JUNO_BBD_STAGES       256.0f
 #define JUNO_BBD_INPUT_LP_HZ  7000.0f  /* the 12 dB low-pass ahead of the BBD */
 
-/* ------------------------------------------------------------------------ */
-/* Arpeggiator                                                               */
-/*                                                                           */
+/* ------------------------------------------------------------------------   */
+/* Arpeggiator                                                                */
+/*                                                                            */
 /* Specifications page: ARPEGGIO RATE 1.5 .. 50 Hz. Panel Board A carries the */
 /* on/off switch, a MODE switch (up, up and down, down) and a RANGE switch    */
 /* (one, two or three octaves); the rear panel has an ARPEGGIO CLOCK input,   */
 /* which this does not have a socket for.                                     */
-/*                                                                           */
+/*                                                                            */
 /* Not part of a patch -- the switches live in the CPU's switch matrix, not   */
 /* in the patch memory, so changing sound mid-performance leaves the arpeggio */
 /* running.                                                                   */
-/* ------------------------------------------------------------------------ */
+/* ------------------------------------------------------------------------   */
 #define JUNO_ARP_HZ_MIN      1.5f
 #define JUNO_ARP_HZ_MAX     50.0f
 #define JUNO_ARP_MODES        3
@@ -382,9 +396,9 @@
  * note sliding about. */
 #define JUNO_ARP_GATE         0.55f
 
-/* ------------------------------------------------------------------------ */
-/* Output stage                                                              */
-/* ------------------------------------------------------------------------ */
+/* ------------------------------------------------------------------------   */
+/* Output stage                                                               */
+/* ------------------------------------------------------------------------   */
 #define JUNO_DC_BLOCK_HZ     12.0f
 #define JUNO_HISS_LEVEL       3.0e-5f
 
@@ -406,9 +420,9 @@
  * inside the range. */
 #define JUNO_BEND_MAX_SEMITONES 7.0f
 
-/* ------------------------------------------------------------------------ */
-/* Tuning                                                                    */
-/* ------------------------------------------------------------------------ */
+/* ------------------------------------------------------------------------   */
+/* Tuning                                                                     */
+/* ------------------------------------------------------------------------   */
 /*
  * A deliberate departure, recorded here rather than left to look like an
  * oversight: a Juno-60 is tuned to A = 442 Hz, not 440.

--- a/instruments/PicoFaceJ6/include/juno/juno_defs.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_defs.h
@@ -167,6 +167,33 @@
 /* ------------------------------------------------------------------------ */
 #define JUNO_CUTOFF_MIN_HZ     20.0f
 #define JUNO_CUTOFF_MAX_HZ  18000.0f
+
+/*
+ * Ceiling on the cutoff the filter itself will accept, as a fraction of the
+ * rate it runs at: one radian per sample, 1/2pi.
+ *
+ * This is not a nicety. The Huovilainen fits in juno_filter.h are good to
+ * about one radian per sample and no further, and past that the resonance fit
+ * does not merely lose accuracy -- it crosses zero at wc = 1.085 and goes
+ * negative, which turns the feedback around the loop from negative into
+ * positive. What comes out is not a filtered note but a thump at whatever
+ * rate the loop settles into.
+ *
+ * The panel only reaches JUNO_CUTOFF_MAX_HZ, but everything else adds octaves
+ * on top of it -- the contour up to ten of them, key follow, the LFO -- so the
+ * filter is asked for far more than the panel in ordinary playing. Organ 1 at
+ * F4 asks for 9.2 kHz, which at 44.1 kHz is wc = 1.31 and well into the broken
+ * region. That patch, and four others, went silent above the middle of the
+ * keyboard until this was here.
+ *
+ * At the rate this engine runs the filter, one radian per sample is 7.0 kHz.
+ * That is a real ceiling on how far the filter opens, and it is the price of
+ * running the filter at the sample rate rather than oversampled the way
+ * PicoFaceMD does; the alternative costs six voices' worth of CPU that this
+ * instrument does not have. The Moog ladder carries the identical clamp for
+ * the identical reason.
+ */
+#define JUNO_FILTER_WC_MAX_OVER_2PI 0.15915f
 #define JUNO_RESONANCE_MAX      1.06f   /* self-oscillates a little above 1 */
 #define JUNO_VCF_GCOMP          0.85f   /* Moog ladder uses 0.5; see above  */
 

--- a/instruments/PicoFaceJ6/include/juno/juno_defs.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_defs.h
@@ -361,6 +361,11 @@
 #define JUNO_DC_BLOCK_HZ     12.0f
 #define JUNO_HISS_LEVEL       3.0e-5f
 
+/* Noise inside each voice's filter loop, which is what lets the resonance
+ * self-oscillate from silence the way an IR3109 does on its own transistor
+ * noise -- see the note in juno_voice.h. Bank 7 has no other sound source. */
+#define JUNO_VCF_NOISE_FLOOR  2.0e-4f
+
 /* Pitch bender: the Juno-60 bender is a lever, and its depth is set by the
  * Bend Sens (DCO) control on the bender panel rather than being fixed. That
  * control's own maximum is seven semitones -- the master oscillator takes

--- a/instruments/PicoFaceJ6/include/juno/juno_filter.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_filter.h
@@ -60,7 +60,9 @@ public:
      */
     void setCutoff(float hz)
     {
-        hz = junoClamp(hz, 5.0f, sr_ * 0.49f);
+        /* Not Nyquist -- the fits below break long before that. See
+         * JUNO_FILTER_WC_MAX_OVER_2PI. */
+        hz = junoClamp(hz, 5.0f, sr_ * JUNO_FILTER_WC_MAX_OVER_2PI);
         wc_ = 2.0f * (float) M_PI * hz / sr_;
 
         const float w2 = wc_ * wc_;

--- a/instruments/PicoFaceJ6/include/juno/juno_presets.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_presets.h
@@ -5,9 +5,12 @@
   juno_presets.h -- the patch list
 
   A Juno-60 stores 56 patches of its own, eight per bank across seven banks.
-  The factory set is not in the service notes; these 48 come from the patch
-  table of junox (GPL v3), which uses the same parameters and supplied the
-  names.
+  All 56 are here, transcribed from the chart on pages 25 to 28 of the owner's
+  manual, which prints every slider and switch of every factory patch. The
+  chorus column of that chart sits at the page edge and is the one part of it
+  this scan cannot resolve; it is taken instead from the LED graphics of the
+  Juno-60 Patch Book (Sunshine Jones, 2021), which redraws the same data
+  legibly and agrees with the chart everywhere the chart can be read.
 
   Selecting a patch writes every parameter, so a patch is a starting point and
   never a layer: turn a control afterwards and only that control moves.
@@ -18,7 +21,7 @@
 
 #include "juno_params.h"
 
-#define JUNO_NPROGRAMS 48
+#define JUNO_NPROGRAMS 56
 
 struct JunoProgram {
     char  name[16];

--- a/instruments/PicoFaceJ6/include/juno/juno_voice.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_voice.h
@@ -62,6 +62,8 @@ public:
         osSr_ = sampleRate * (float) JUNO_OVERSAMPLE;
         dco_.init(osSr_, seed);
         vcf_.init(osSr_);
+        /* Its own seed, so six voices do not hiss in lockstep. */
+        hiss_.seed(seed ^ 0x9E3779B9u);
         env_.init(sampleRate);
         note_   = JUNO_CENTER_NOTE;
         active_ = false;
@@ -178,9 +180,18 @@ public:
             ? junoExp2Fast(lfo * p.dcoLfo * (JUNO_LFO_DCO_SEMIS / 12.0f))
             : 1.0f;
 
+        /* The voice card has a noise floor of its own, and it matters: an
+         * IR3109 turned up to self-oscillation sings on its own transistor
+         * noise. A digital filter fed exactly zero stays at exactly zero
+         * however high the resonance, so without this the eight patches of
+         * bank 7 -- which the owner's manual describes as having "VCF self-
+         * oscillation" for a sound source and which carry no waveform at all
+         * -- are silent. It sits inside the loop, where the original's is.
+         * Far too quiet to hear on a patch that has an oscillator. */
         float out = 0.0f;
         for (int os = 0; os < JUNO_OVERSAMPLE; ++os)
-            out = vcf_.process(dco_.process(pitchMul) * 0.4f);
+            out = vcf_.process(dco_.process(pitchMul) * 0.4f
+                               + hiss_.white() * JUNO_VCF_NOISE_FLOOR);
 
         return out * e;
     }
@@ -189,6 +200,7 @@ private:
     JunoDco    dco_;
     JunoFilter vcf_;
     JunoEnv    env_;
+    JunoNoise  hiss_;          /* the card's own noise, inside the filter */
 
     int   note_    = JUNO_CENTER_NOTE;
     float baseInc_ = 0.0f;

--- a/instruments/PicoFaceJ6/src/juno/juno.cpp
+++ b/instruments/PicoFaceJ6/src/juno/juno.cpp
@@ -170,7 +170,9 @@ void Juno::applyParameter(int id)
         tuneSemis_ = (v * 2.0f - 1.0f) * (JUNO_TUNE_CENTS / 100.0f);
         break;
     case JUNO_BEND_RANGE:
-        bendRange_ = (float) junoParamStep(v, 13);
+        /* Eight positions, 0..7 semitones: the range of the instrument's
+         * own Bend Sens (DCO) control. See JUNO_BEND_MAX_SEMITONES. */
+        bendRange_ = (float) junoParamStep(v, 8);
         break;
     case JUNO_TRANSPOSE:
         transpose_ = junoParamStep(v, 5) - 2;

--- a/instruments/PicoFaceJ6/src/juno/juno_params.cpp
+++ b/instruments/PicoFaceJ6/src/juno/juno_params.cpp
@@ -50,8 +50,8 @@ const char* const kJunoArpRangeLabels[3] = { "1 Oct", "2 Oct", "3 Oct" };
 
 /* Pitch bender travel in semitones, as a rotary switch so the display can name
  * the value without a special case. */
-static const char* const kBendLabels[13] = {
-    "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12"
+static const char* const kBendLabels[8] = {
+    "0", "1", "2", "3", "4", "5", "6", "7"
 };
 
 /* The contour polarity switch is drawn on the panel as two shapes rather than
@@ -105,7 +105,7 @@ const JunoParamDesc kJunoParams[JUNO_TOTAL_COUNT] = {
 
     /* --- Not on the panel ----------------------------------------------- */
     /* JUNO_TUNE          */ BIPOLAR("Tune",  87, JUNO_TUNE_CENTS),
-    /* JUNO_BEND_RANGE    */ ROTARY ("Bend", 13, 20, kBendLabels),
+    /* JUNO_BEND_RANGE    */ ROTARY ("Bend",  8, 20, kBendLabels),
     /* JUNO_LFO_TRIG      */ ROTARY ("Trig",  2, 104, kJunoTrigLabels),
     /* JUNO_TRANSPOSE     */ ROTARY ("Octave",5, 105, kJunoTransposeLabels),
 

--- a/instruments/PicoFaceJ6/src/juno/juno_presets.cpp
+++ b/instruments/PicoFaceJ6/src/juno/juno_presets.cpp
@@ -42,7 +42,7 @@
 #define R3(i)  (((float) (i) + 0.5f) /  3.0f)
 #define R4(i)  (((float) (i) + 0.5f) /  4.0f)
 #define R5(i)  (((float) (i) + 0.5f) /  5.0f)
-#define R13(i) (((float) (i) + 0.5f) / 13.0f)
+#define R8(i)  (((float) (i) + 0.5f) /  8.0f)
 
 #define OFF 0.0f
 #define ON  1.0f
@@ -72,7 +72,7 @@
 #define TRIG_MAN  R2(1)
 
 #define OCT0  R5(2)
-#define BEND2 R13(2)
+#define BEND2 R8(2)
 
 #define LFO(rate, delay)  rate, delay
 

--- a/instruments/PicoFaceJ6/src/juno/juno_presets.cpp
+++ b/instruments/PicoFaceJ6/src/juno/juno_presets.cpp
@@ -4,10 +4,53 @@
 /*
   juno_presets.cpp -- factory patch settings
 
-  The Juno-60 stores 56 patches of its own (8 per bank, 7 banks), and the
-  factory set is not published in the service notes. These 48 come from the
-  patch table of junox (GPL v3, the same licence as this project), which
-  reproduces the same parameters and is where their names come from.
+  All 56 factory patches, transcribed from the chart on pages 25 to 28 of the
+  Juno-60 owner's manual. That chart prints the complete front panel of every
+  patch on the instrument's own 0..10 scale, and it settles what was previously
+  imported from junox and believed to be unpublished.
+
+  The transcription was checked against the imported set cell by cell. Of 720
+  numeric cells across the 48 patches the two sets share, 590 agree exactly and
+  the remaining 130 fall into four groups:
+
+    125  junox truncated the half-steps. Wherever the chart says 6.5 it had 6.
+         That is the bulk of what changes here.
+      3  junox misread a digit: patch 33 pulse width 8 not 9, and both
+         Pizzicato patches resonance 3 not 4. Re-read at high magnification.
+      2  deliberate, and kept -- see below.
+
+  Two further columns junox dropped altogether:
+
+    The octave transpose. Every imported patch sat at 8'; the chart puts
+    roughly twenty of them at 16' or 4', and it reads like an instrument list
+    when it does -- both basses and both clavichords down, xylophone,
+    glockenspiel, flute and the reeds up, tuba down.
+
+    Bank 7, eight patches. The owner's manual explains why nobody reproduces
+    them: "Bank 7 includes the patches whose sound sources are VCF self-
+    oscillation." Their chart rows carry no waveform at all and resonance 10
+    throughout, so they sound only if the filter really sings.
+
+  Not transcribed: the VCA level column. It is printed as a signed value in a
+  range no 0..10 slider has, and it defeated junox (which substituted a
+  constant 7) and the Patch Book author (who drew every level slider at the
+  same height) as well as this reading. Each patch therefore keeps the level it
+  shipped with, and bank 7 takes the same 0.700 the rest mostly use.
+
+  Two values depart from the chart, both kept from a hardware listening test:
+
+    Piano 1       DCO LFO 4.5 -> 0
+    Clavichord 1  DCO LFO 4.0 -> 0
+        The chart really does put vibrato on both. Neither instrument has any,
+        and with the trigger mode on manual the LFO runs free rather than
+        waiting for the button, so it is heard on every note. At the corrected
+        modulation depth of three semitones this would be over a hundred cents
+        on a piano. Worth a listen before it is trusted either way.
+
+    Brass         VCA level 0.7 -> 1.0
+        Also from that test, and independently supported: the chart's own level
+        column ranks Brass above the strings, whatever its scale turns out to
+        be.
 
   Each entry is a complete front panel, in the order of the enum in
   juno_params.h and grouped by the sections of the instrument. The macros make
@@ -19,20 +62,6 @@
   Positions of rotary switches are written as R3(1) and so on -- the middle of
   the slot, so a value surviving a round trip through the per mille IPC or the
   settings record cannot land one position over.
-
-  Three values depart from the imported set, each because the sound and the
-  name disagreed:
-
-    Piano I       DCO LFO 0.4 -> 0
-    Clavichord I  DCO LFO 0.4 -> 0
-        Forty cents of vibrato at five hertz. Neither instrument has any
-        vibrato at all, and it is what a listener described as a ghost. The
-        other fourteen patches that use the DCO LFO keep it -- ten to twenty
-        cents on a violin, a clarinet or an oboe is what those instruments do.
-
-    Brass         VCA level 0.7 -> 1.0
-        The timbre was right and the level sat six decibels under everything
-        else, which for a brass patch is the wrong way round.
 */
 
 #include "juno/juno_presets.h"
@@ -94,243 +123,243 @@
 
 const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
 
-{ "Strings I", {
+{ "Strings 1", {
     LFO(0.600f, 0.000f),
-    DCO(F8, 0.000f, 0.000f, PWM_LFO,
+    DCO(F8 , 0.000f, 0.000f, PWM_LFO,
         ON , OFF, OFF, 0.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.700f, 0.000f, 0.000f, POL_POS, 0.000f, 1.000f),
     VCA(0.700f, VCA_ENV),
-    ENV(0.400f, 0.000f, 1.000f, 0.400f),
+    ENV(0.400f, 0.000f, 1.000f, 0.450f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
 
-{ "Strings II", {
+{ "Strings 2", {
     LFO(0.400f, 0.000f),
-    DCO(F8, 0.000f, 0.600f, PWM_LFO,
+    DCO(F8 , 0.000f, 0.600f, PWM_LFO,
         ON , ON , OFF, 0.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.700f, 0.000f, 0.000f, POL_POS, 0.000f, 1.000f),
     VCA(0.700f, VCA_ENV),
-    ENV(0.400f, 0.000f, 1.000f, 0.400f),
+    ENV(0.400f, 0.000f, 1.000f, 0.450f),
     CHOR(CH_II),
     SYS(TRIG_AUTO, OCT0) }},
 
-{ "Strings III", {
+{ "Strings 3", {
     LFO(0.300f, 0.800f),
-    DCO(F8, 0.000f, 0.700f, PWM_LFO,
+    DCO(F8 , 0.000f, 0.700f, PWM_LFO,
         ON , ON , ON , 1.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.500f, 0.000f, 0.000f, POL_POS, 0.000f, 1.000f),
     VCA(0.700f, VCA_ENV),
     ENV(0.300f, 0.000f, 1.000f, 0.600f),
     CHOR(CH_II),
-    SYS(TRIG_MAN, OCT0) }},
+    SYS(TRIG_MAN , OCT0) }},
 
-{ "Organ I", {
+{ "Organ 1", {
     LFO(0.200f, 0.800f),
-    DCO(F8, 0.000f, 0.500f, PWM_MAN,
+    DCO(F8 , 0.000f, 0.500f, PWM_MAN,
         OFF, ON , ON , 1.000f, 0.000f),
     HPF_(R4(0)),
-    VCF(0.400f, 0.600f, 0.400f, POL_POS, 0.000f, 1.000f),
+    VCF(0.400f, 0.600f, 0.450f, POL_POS, 0.000f, 1.000f),
     VCA(0.700f, VCA_GATE),
     ENV(0.000f, 0.000f, 0.000f, 0.000f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
 
-{ "Organ II", {
+{ "Organ 2", {
     LFO(0.500f, 0.400f),
-    DCO(F8, 0.000f, 0.500f, PWM_LFO,
+    DCO(F8 , 0.000f, 0.550f, PWM_LFO,
         OFF, ON , ON , 0.800f, 0.000f),
     HPF_(R4(0)),
-    VCF(0.300f, 0.500f, 0.400f, POL_POS, 0.000f, 1.000f),
+    VCF(0.350f, 0.550f, 0.400f, POL_POS, 0.000f, 1.000f),
     VCA(0.700f, VCA_GATE),
     ENV(0.000f, 0.100f, 0.000f, 0.100f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
 
-{ "Organ III", {
+{ "Organ 3", {
     LFO(0.500f, 0.400f),
-    DCO(F8, 0.000f, 0.500f, PWM_LFO,
+    DCO(F4 , 0.000f, 0.550f, PWM_LFO,
         OFF, ON , ON , 0.800f, 0.000f),
     HPF_(R4(0)),
-    VCF(0.300f, 0.500f, 0.300f, POL_POS, 0.000f, 1.000f),
+    VCF(0.350f, 0.550f, 0.350f, POL_POS, 0.000f, 1.000f),
     VCA(0.700f, VCA_GATE),
     ENV(0.000f, 0.100f, 0.000f, 0.100f),
     CHOR(CH_II),
     SYS(TRIG_AUTO, OCT0) }},
 
 { "Brass", {
-    LFO(0.500f, 0.600f),
-    DCO(F8, 0.100f, 0.000f, PWM_MAN,
+    LFO(0.500f, 0.650f),
+    DCO(F8 , 0.150f, 0.000f, PWM_MAN,
         ON , OFF, OFF, 0.000f, 0.000f),
     HPF_(R4(0)),
-    VCF(0.000f, 0.000f, 0.800f, POL_POS, 0.000f, 0.400f),
+    VCF(0.000f, 0.000f, 0.850f, POL_POS, 0.000f, 0.400f),
     VCA(1.000f, VCA_ENV),
-    ENV(0.200f, 0.400f, 0.600f, 0.200f),
+    ENV(0.250f, 0.400f, 0.600f, 0.200f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
 
 { "Phase Brass", {
     LFO(0.600f, 0.000f),
-    DCO(F8, 0.000f, 1.000f, PWM_ENV,
+    DCO(F8 , 0.000f, 1.000f, PWM_ENV,
         ON , ON , OFF, 1.000f, 0.000f),
     HPF_(R4(0)),
-    VCF(0.300f, 0.100f, 0.500f, POL_POS, 0.000f, 1.000f),
+    VCF(0.300f, 0.100f, 0.550f, POL_POS, 0.000f, 1.000f),
     VCA(0.700f, VCA_GATE),
     ENV(0.200f, 0.400f, 0.400f, 0.300f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
 
-{ "Piano I", {
+{ "Piano 1", {
     LFO(0.600f, 0.300f),
-    DCO(F8, 0.000f, 0.600f, PWM_MAN,
+    DCO(F8 , 0.000f, 0.600f, PWM_MAN,
         OFF, ON , OFF, 0.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.100f, 0.000f, 0.700f, POL_POS, 0.000f, 0.400f),
     VCA(0.700f, VCA_ENV),
-    ENV(0.000f, 0.800f, 0.100f, 0.300f),
+    ENV(0.000f, 0.800f, 0.150f, 0.300f),
     CHOR(CH_OFF),
-    SYS(TRIG_MAN, OCT0) }},
+    SYS(TRIG_MAN , OCT0) }},
 
-{ "Piano II", {
+{ "Piano 2", {
     LFO(0.400f, 0.000f),
-    DCO(F8, 0.000f, 0.400f, PWM_MAN,
-        OFF, ON , ON , 0.400f, 0.000f),
+    DCO(F4 , 0.000f, 0.400f, PWM_MAN,
+        OFF, ON , ON , 0.450f, 0.000f),
     HPF_(R4(0)),
-    VCF(0.300f, 0.000f, 0.200f, POL_POS, 0.200f, 0.800f),
+    VCF(0.350f, 0.000f, 0.250f, POL_POS, 0.200f, 0.800f),
     VCA(0.700f, VCA_ENV),
-    ENV(0.000f, 0.700f, 0.000f, 0.300f),
+    ENV(0.000f, 0.750f, 0.000f, 0.350f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
 
 { "Celesta", {
-    LFO(0.300f, 0.600f),
-    DCO(F8, 0.000f, 0.500f, PWM_ENV,
+    LFO(0.350f, 0.600f),
+    DCO(F8 , 0.000f, 0.500f, PWM_ENV,
         ON , ON , OFF, 1.000f, 0.000f),
-    HPF_(R4(0)),
-    VCF(0.300f, 0.800f, 0.000f, POL_POS, 0.000f, 1.000f),
+    HPF_(R4(1)),
+    VCF(0.350f, 0.800f, 0.000f, POL_POS, 0.000f, 1.000f),
     VCA(0.700f, VCA_ENV),
-    ENV(0.000f, 0.600f, 0.200f, 0.500f),
-    CHOR(CH_OFF),
+    ENV(0.000f, 0.650f, 0.200f, 0.550f),
+    CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
 
 { "Mellow Piano", {
     LFO(0.500f, 0.000f),
-    DCO(F8, 0.000f, 0.500f, PWM_MAN,
+    DCO(F8 , 0.000f, 0.500f, PWM_MAN,
         OFF, ON , OFF, 1.000f, 0.000f),
     HPF_(R4(0)),
-    VCF(0.300f, 0.000f, 0.200f, POL_POS, 0.100f, 0.900f),
+    VCF(0.300f, 0.000f, 0.250f, POL_POS, 0.100f, 0.900f),
     VCA(0.700f, VCA_ENV),
-    ENV(0.100f, 0.700f, 0.200f, 0.800f),
+    ENV(0.100f, 0.750f, 0.200f, 0.850f),
     CHOR(CH_I),
-    SYS(TRIG_MAN, OCT0) }},
+    SYS(TRIG_MAN , OCT0) }},
 
-{ "Harpsichord I", {
+{ "Harpsichord 1", {
     LFO(0.500f, 0.400f),
-    DCO(F8, 0.000f, 0.300f, PWM_MAN,
+    DCO(F4 , 0.000f, 0.300f, PWM_MAN,
         OFF, ON , ON , 0.700f, 0.000f),
-    HPF_(R4(0)),
+    HPF_(R4(1)),
     VCF(0.300f, 0.000f, 0.500f, POL_POS, 0.000f, 0.700f),
     VCA(0.700f, VCA_ENV),
-    ENV(0.000f, 0.600f, 0.300f, 0.200f),
+    ENV(0.000f, 0.600f, 0.350f, 0.250f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
 
-{ "Harpsicord II", {
-    LFO(0.500f, 0.600f),
-    DCO(F8, 0.000f, 0.200f, PWM_MAN,
-        OFF, ON , ON , 0.800f, 0.000f),
-    HPF_(R4(0)),
-    VCF(0.500f, 0.200f, 0.300f, POL_POS, 0.000f, 1.000f),
+{ "Harpsichord 2", {
+    LFO(0.550f, 0.600f),
+    DCO(F4 , 0.000f, 0.200f, PWM_MAN,
+        OFF, ON , ON , 0.850f, 0.000f),
+    HPF_(R4(1)),
+    VCF(0.500f, 0.250f, 0.300f, POL_POS, 0.000f, 1.000f),
     VCA(0.700f, VCA_ENV),
-    ENV(0.000f, 0.500f, 0.100f, 0.500f),
+    ENV(0.000f, 0.500f, 0.150f, 0.500f),
     CHOR(CH_II),
     SYS(TRIG_AUTO, OCT0) }},
 
 { "Guitar", {
     LFO(0.600f, 0.600f),
-    DCO(F8, 0.000f, 0.600f, PWM_MAN,
+    DCO(F8 , 0.000f, 0.600f, PWM_MAN,
         OFF, ON , OFF, 1.000f, 0.000f),
-    HPF_(R4(0)),
-    VCF(0.300f, 0.000f, 0.400f, POL_POS, 0.100f, 0.500f),
+    HPF_(R4(2)),
+    VCF(0.300f, 0.000f, 0.450f, POL_POS, 0.150f, 0.500f),
     VCA(0.750f, VCA_ENV),
-    ENV(0.000f, 0.500f, 0.300f, 0.600f),
+    ENV(0.000f, 0.550f, 0.350f, 0.650f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
 
-{ "Synthetiser Har", {
+{ "Synth Harp", {
     LFO(0.300f, 0.800f),
-    DCO(F8, 0.000f, 0.000f, PWM_MAN,
+    DCO(F8 , 0.000f, 0.000f, PWM_MAN,
         ON , OFF, OFF, 1.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.300f, 0.000f, 0.500f, POL_POS, 0.000f, 0.800f),
     VCA(0.700f, VCA_ENV),
-    ENV(0.000f, 0.500f, 0.300f, 0.500f),
+    ENV(0.000f, 0.550f, 0.300f, 0.500f),
     CHOR(CH_I),
-    SYS(TRIG_MAN, OCT0) }},
+    SYS(TRIG_MAN , OCT0) }},
 
-{ "Bass I", {
+{ "Bass 1", {
     LFO(0.500f, 0.600f),
-    DCO(F8, 0.000f, 0.500f, PWM_MAN,
+    DCO(F16, 0.000f, 0.500f, PWM_MAN,
         ON , ON , ON , 0.300f, 0.000f),
     HPF_(R4(0)),
-    VCF(0.300f, 0.200f, 0.300f, POL_POS, 0.000f, 0.000f),
+    VCF(0.300f, 0.250f, 0.350f, POL_POS, 0.000f, 0.000f),
     VCA(0.700f, VCA_GATE),
-    ENV(0.000f, 0.400f, 0.100f, 0.200f),
+    ENV(0.000f, 0.400f, 0.100f, 0.250f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
 
-{ "Bass II", {
+{ "Bass 2", {
     LFO(0.500f, 0.600f),
-    DCO(F8, 0.000f, 0.500f, PWM_MAN,
+    DCO(F16, 0.000f, 0.500f, PWM_MAN,
         ON , ON , OFF, 0.300f, 0.000f),
     HPF_(R4(0)),
-    VCF(0.300f, 0.500f, 0.400f, POL_POS, 0.000f, 0.500f),
+    VCF(0.300f, 0.500f, 0.450f, POL_POS, 0.000f, 0.500f),
     VCA(0.700f, VCA_GATE),
-    ENV(0.000f, 0.300f, 0.300f, 0.200f),
+    ENV(0.000f, 0.300f, 0.350f, 0.250f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
 
-{ "Clavichord I", {
-    LFO(0.600f, 0.200f),
-    DCO(F8, 0.000f, 0.900f, PWM_MAN,
+{ "Clavichord 1", {
+    LFO(0.600f, 0.250f),
+    DCO(F16, 0.000f, 0.800f, PWM_MAN,
         OFF, ON , OFF, 0.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.000f, 0.300f, 0.800f, POL_POS, 0.000f, 0.600f),
     VCA(0.700f, VCA_ENV),
-    ENV(0.000f, 0.500f, 0.300f, 0.100f),
+    ENV(0.000f, 0.500f, 0.350f, 0.150f),
     CHOR(CH_I),
-    SYS(TRIG_MAN, OCT0) }},
+    SYS(TRIG_MAN , OCT0) }},
 
-{ "Clavichord II", {
+{ "Clavichord 2", {
     LFO(0.100f, 0.000f),
-    DCO(F8, 0.000f, 0.800f, PWM_MAN,
+    DCO(F16, 0.000f, 0.800f, PWM_MAN,
         OFF, ON , OFF, 1.000f, 0.000f),
-    HPF_(R4(0)),
-    VCF(0.500f, 0.700f, 0.200f, POL_POS, 0.200f, 0.700f),
+    HPF_(R4(1)),
+    VCF(0.550f, 0.700f, 0.200f, POL_POS, 0.250f, 0.700f),
     VCA(0.850f, VCA_ENV),
-    ENV(0.000f, 0.400f, 0.200f, 0.200f),
+    ENV(0.000f, 0.450f, 0.200f, 0.200f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
 
-{ "Pizzicato Sound", {
+{ "Pizzicato Snd1", {
     LFO(0.500f, 0.600f),
-    DCO(F8, 0.000f, 0.300f, PWM_MAN,
+    DCO(F8 , 0.000f, 0.350f, PWM_MAN,
         OFF, ON , OFF, 0.300f, 0.000f),
     HPF_(R4(0)),
-    VCF(0.400f, 0.400f, 0.300f, POL_POS, 0.300f, 1.000f),
+    VCF(0.450f, 0.300f, 0.300f, POL_POS, 0.300f, 1.000f),
     VCA(0.700f, VCA_ENV),
-    ENV(0.000f, 0.200f, 0.300f, 0.500f),
+    ENV(0.000f, 0.200f, 0.350f, 0.550f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
 
-{ "Pizzicato Sound", {
+{ "Pizzicato Snd2", {
     LFO(0.500f, 0.600f),
-    DCO(F8, 0.000f, 0.200f, PWM_MAN,
+    DCO(F4 , 0.000f, 0.200f, PWM_MAN,
         OFF, ON , ON , 0.300f, 0.000f),
     HPF_(R4(0)),
-    VCF(0.500f, 0.400f, 0.300f, POL_POS, 0.000f, 1.000f),
+    VCF(0.500f, 0.300f, 0.300f, POL_POS, 0.000f, 1.000f),
     VCA(0.700f, VCA_ENV),
     ENV(0.000f, 0.300f, 0.300f, 0.400f),
     CHOR(CH_II),
@@ -338,289 +367,377 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
 
 { "Xylophone", {
     LFO(0.500f, 0.000f),
-    DCO(F8, 0.000f, 0.500f, PWM_MAN,
+    DCO(F4 , 0.000f, 0.500f, PWM_MAN,
         OFF, OFF, ON , 1.000f, 0.000f),
-    HPF_(R4(0)),
+    HPF_(R4(1)),
     VCF(0.400f, 0.500f, 0.300f, POL_POS, 0.000f, 0.600f),
     VCA(0.850f, VCA_ENV),
-    ENV(0.000f, 0.300f, 0.000f, 0.300f),
+    ENV(0.000f, 0.350f, 0.000f, 0.350f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
 
 { "Glockenspiel", {
     LFO(0.500f, 0.000f),
-    DCO(F8, 0.000f, 0.000f, PWM_MAN,
+    DCO(F4 , 0.000f, 0.000f, PWM_MAN,
         OFF, ON , OFF, 0.000f, 0.000f),
-    HPF_(R4(0)),
-    VCF(0.400f, 0.500f, 0.300f, POL_POS, 0.000f, 0.600f),
+    HPF_(R4(1)),
+    VCF(0.450f, 0.500f, 0.300f, POL_POS, 0.000f, 0.600f),
     VCA(0.750f, VCA_ENV),
-    ENV(0.000f, 0.300f, 0.200f, 0.500f),
+    ENV(0.000f, 0.300f, 0.250f, 0.500f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
 
-{ "Violin", {
+{ "Violine", {
     LFO(0.600f, 0.600f),
-    DCO(F8, 0.200f, 0.000f, PWM_LFO,
+    DCO(F8 , 0.200f, 0.000f, PWM_LFO,
         ON , OFF, OFF, 0.000f, 0.000f),
-    HPF_(R4(0)),
-    VCF(0.600f, 0.000f, 0.000f, POL_POS, 0.000f, 1.000f),
+    HPF_(R4(1)),
+    VCF(0.650f, 0.000f, 0.000f, POL_POS, 0.000f, 1.000f),
     VCA(0.700f, VCA_ENV),
     ENV(0.400f, 0.000f, 1.000f, 0.400f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
 
 { "Trumpet", {
-    LFO(0.200f, 0.600f),
-    DCO(F8, 0.100f, 0.000f, PWM_MAN,
+    LFO(0.250f, 0.650f),
+    DCO(F8 , 0.150f, 0.000f, PWM_MAN,
         ON , OFF, OFF, 0.000f, 0.000f),
     HPF_(R4(0)),
-    VCF(0.000f, 0.000f, 0.800f, POL_POS, 0.000f, 0.400f),
+    VCF(0.000f, 0.000f, 0.850f, POL_POS, 0.000f, 0.400f),
     VCA(0.700f, VCA_ENV),
-    ENV(0.200f, 0.400f, 0.600f, 0.200f),
+    ENV(0.250f, 0.400f, 0.600f, 0.200f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
 
 { "Horn", {
-    LFO(0.200f, 0.700f),
-    DCO(F8, 0.000f, 0.000f, PWM_MAN,
+    LFO(0.250f, 0.700f),
+    DCO(F8 , 0.000f, 0.000f, PWM_MAN,
         ON , OFF, OFF, 0.000f, 0.000f),
     HPF_(R4(0)),
-    VCF(0.200f, 0.000f, 0.500f, POL_POS, 0.200f, 0.400f),
+    VCF(0.200f, 0.000f, 0.550f, POL_POS, 0.200f, 0.400f),
     VCA(0.700f, VCA_ENV),
     ENV(0.400f, 0.500f, 0.600f, 0.300f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
 
-{ "Tube", {
-    LFO(0.200f, 0.700f),
-    DCO(F8, 0.100f, 0.000f, PWM_MAN,
+{ "Tuba", {
+    LFO(0.250f, 0.700f),
+    DCO(F16, 0.150f, 0.000f, PWM_MAN,
         ON , OFF, OFF, 0.000f, 0.000f),
     HPF_(R4(0)),
-    VCF(0.100f, 0.000f, 0.600f, POL_POS, 0.000f, 0.400f),
+    VCF(0.150f, 0.000f, 0.600f, POL_POS, 0.000f, 0.400f),
     VCA(0.850f, VCA_ENV),
     ENV(0.300f, 0.400f, 0.400f, 0.300f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
 
 { "Flute", {
-    LFO(0.500f, 0.500f),
-    DCO(F8, 0.000f, 0.000f, PWM_MAN,
-        ON , OFF, OFF, 0.000f, 0.100f),
-    HPF_(R4(0)),
+    LFO(0.550f, 0.500f),
+    DCO(F4 , 0.000f, 0.000f, PWM_MAN,
+        ON , OFF, OFF, 0.000f, 0.150f),
+    HPF_(R4(1)),
     VCF(0.500f, 0.000f, 0.000f, POL_POS, 0.200f, 0.600f),
     VCA(0.850f, VCA_ENV),
-    ENV(0.200f, 0.600f, 0.500f, 0.200f),
+    ENV(0.200f, 0.600f, 0.500f, 0.250f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
 
 { "Clarinet", {
-    LFO(0.500f, 0.600f),
-    DCO(F8, 0.100f, 0.000f, PWM_MAN,
+    LFO(0.500f, 0.650f),
+    DCO(F8 , 0.150f, 0.000f, PWM_MAN,
         OFF, ON , OFF, 0.000f, 0.000f),
-    HPF_(R4(0)),
-    VCF(0.500f, 0.300f, 0.200f, POL_POS, 0.000f, 0.600f),
+    HPF_(R4(1)),
+    VCF(0.500f, 0.300f, 0.250f, POL_POS, 0.000f, 0.600f),
     VCA(0.700f, VCA_ENV),
-    ENV(0.200f, 0.600f, 0.600f, 0.200f),
+    ENV(0.250f, 0.600f, 0.600f, 0.250f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
 
 { "Oboe", {
-    LFO(0.500f, 0.600f),
-    DCO(F8, 0.100f, 0.600f, PWM_MAN,
+    LFO(0.550f, 0.650f),
+    DCO(F8 , 0.150f, 0.650f, PWM_MAN,
         OFF, ON , OFF, 0.000f, 0.000f),
-    HPF_(R4(1)),
-    VCF(0.400f, 0.500f, 0.200f, POL_POS, 0.000f, 0.500f),
+    HPF_(R4(3)),
+    VCF(0.450f, 0.500f, 0.250f, POL_POS, 0.000f, 0.500f),
     VCA(0.850f, VCA_ENV),
-    ENV(0.200f, 0.600f, 0.600f, 0.200f),
+    ENV(0.200f, 0.600f, 0.600f, 0.250f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
 
 { "English Horn", {
     LFO(0.500f, 0.700f),
-    DCO(F8, 0.200f, 0.600f, PWM_MAN,
+    DCO(F16, 0.200f, 0.650f, PWM_MAN,
         OFF, ON , OFF, 0.000f, 0.000f),
-    HPF_(R4(1)),
-    VCF(0.500f, 0.700f, 0.000f, POL_POS, 0.100f, 0.500f),
+    HPF_(R4(3)),
+    VCF(0.500f, 0.700f, 0.000f, POL_POS, 0.150f, 0.500f),
     VCA(0.850f, VCA_ENV),
-    ENV(0.200f, 0.600f, 0.600f, 0.200f),
+    ENV(0.200f, 0.600f, 0.600f, 0.250f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
 
 { "Funny Cat", {
     LFO(0.600f, 0.200f),
-    DCO(F8, 0.300f, 0.000f, PWM_MAN,
+    DCO(F8 , 0.300f, 0.000f, PWM_MAN,
         ON , OFF, OFF, 0.000f, 0.000f),
-    HPF_(R4(0)),
-    VCF(0.100f, 0.700f, 0.500f, POL_POS, 0.200f, 0.500f),
+    HPF_(R4(1)),
+    VCF(0.150f, 0.750f, 0.500f, POL_POS, 0.200f, 0.500f),
     VCA(0.700f, VCA_ENV),
-    ENV(0.200f, 0.400f, 1.000f, 0.100f),
+    ENV(0.250f, 0.400f, 1.000f, 0.100f),
     CHOR(CH_OFF),
-    SYS(TRIG_MAN, OCT0) }},
+    SYS(TRIG_MAN , OCT0) }},
 
 { "Wah Brass", {
     LFO(0.600f, 0.200f),
-    DCO(F8, 0.300f, 0.000f, PWM_MAN,
+    DCO(F8 , 0.300f, 0.000f, PWM_MAN,
         ON , OFF, OFF, 0.000f, 0.000f),
     HPF_(R4(0)),
-    VCF(0.300f, 0.700f, 0.400f, POL_POS, 0.000f, 0.600f),
+    VCF(0.300f, 0.700f, 0.450f, POL_POS, 0.000f, 0.600f),
     VCA(0.700f, VCA_GATE),
     ENV(0.300f, 0.300f, 0.400f, 0.200f),
     CHOR(CH_OFF),
-    SYS(TRIG_MAN, OCT0) }},
+    SYS(TRIG_MAN , OCT0) }},
 
-{ "Phase Combinati", {
+{ "Phase Combin.", {
     LFO(0.600f, 0.200f),
-    DCO(F8, 0.000f, 0.800f, PWM_MAN,
+    DCO(F8 , 0.000f, 0.800f, PWM_MAN,
         ON , ON , OFF, 0.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.600f, 0.200f, 0.300f, POL_POS, 0.000f, 0.200f),
     VCA(0.700f, VCA_ENV),
     ENV(0.000f, 0.700f, 0.200f, 0.200f),
     CHOR(CH_I),
-    SYS(TRIG_MAN, OCT0) }},
+    SYS(TRIG_MAN , OCT0) }},
 
-{ "Reed I", {
+{ "Reed 1", {
     LFO(0.600f, 0.200f),
-    DCO(F8, 0.400f, 0.000f, PWM_MAN,
-        OFF, ON , ON , 0.000f, 0.000f),
+    DCO(F8 , 0.400f, 0.000f, PWM_MAN,
+        OFF, ON , OFF, 0.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.100f, 0.600f, 0.700f, POL_POS, 0.000f, 0.500f),
     VCA(0.700f, VCA_GATE),
-    ENV(0.000f, 0.800f, 0.500f, 0.100f),
+    ENV(0.000f, 0.850f, 0.500f, 0.100f),
     CHOR(CH_I),
-    SYS(TRIG_MAN, OCT0) }},
+    SYS(TRIG_MAN , OCT0) }},
 
 { "Popcorn", {
     LFO(0.000f, 0.000f),
-    DCO(F8, 0.000f, 0.000f, PWM_MAN,
+    DCO(F4 , 0.000f, 0.000f, PWM_MAN,
         OFF, OFF, ON , 1.000f, 0.000f),
-    HPF_(R4(0)),
-    VCF(0.200f, 0.200f, 0.500f, POL_POS, 0.000f, 1.000f),
+    HPF_(R4(1)),
+    VCF(0.250f, 0.200f, 0.550f, POL_POS, 0.000f, 1.000f),
     VCA(0.700f, VCA_ENV),
     ENV(0.000f, 0.300f, 0.200f, 0.000f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
 
-{ "Reed II", {
+{ "Reed 2", {
     LFO(0.300f, 0.800f),
-    DCO(F8, 0.000f, 0.000f, PWM_MAN,
+    DCO(F4 , 0.000f, 0.000f, PWM_MAN,
         OFF, OFF, ON , 1.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.200f, 0.000f, 0.600f, POL_POS, 0.000f, 0.800f),
     VCA(0.700f, VCA_ENV),
-    ENV(0.000f, 0.500f, 0.300f, 0.600f),
+    ENV(0.000f, 0.550f, 0.300f, 0.600f),
     CHOR(CH_I),
-    SYS(TRIG_MAN, OCT0) }},
+    SYS(TRIG_MAN , OCT0) }},
 
-{ "Reed III", {
+{ "Reed 3", {
     LFO(0.600f, 0.200f),
-    DCO(F8, 0.200f, 0.500f, PWM_MAN,
+    DCO(F4 , 0.200f, 0.500f, PWM_MAN,
         OFF, OFF, ON , 1.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.300f, 0.200f, 0.300f, POL_POS, 0.000f, 1.000f),
     VCA(0.700f, VCA_ENV),
-    ENV(0.200f, 0.000f, 1.000f, 0.200f),
+    ENV(0.250f, 0.000f, 1.000f, 0.200f),
     CHOR(CH_OFF),
-    SYS(TRIG_MAN, OCT0) }},
+    SYS(TRIG_MAN , OCT0) }},
 
 { "PWM Chorus", {
     LFO(0.300f, 0.000f),
-    DCO(F8, 0.000f, 0.500f, PWM_LFO,
+    DCO(F8 , 0.000f, 0.500f, PWM_LFO,
         OFF, ON , ON , 1.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.800f, 0.000f, 0.000f, POL_POS, 0.000f, 1.000f),
     VCA(0.700f, VCA_ENV),
     ENV(0.300f, 0.000f, 1.000f, 0.400f),
     CHOR(CH_II),
-    SYS(TRIG_MAN, OCT0) }},
+    SYS(TRIG_MAN , OCT0) }},
 
-{ "Synthetiser Org", {
-    LFO(0.400f, 0.600f),
-    DCO(F8, 0.000f, 0.600f, PWM_MAN,
-        OFF, ON , ON , 0.700f, 0.000f),
+{ "Synth Organ", {
+    LFO(0.450f, 0.600f),
+    DCO(F8 , 0.000f, 0.650f, PWM_MAN,
+        OFF, ON , ON , 0.750f, 0.000f),
     HPF_(R4(0)),
-    VCF(0.200f, 0.000f, 0.500f, POL_POS, 0.200f, 0.700f),
+    VCF(0.250f, 0.000f, 0.500f, POL_POS, 0.200f, 0.700f),
     VCA(0.700f, VCA_GATE),
-    ENV(0.000f, 0.200f, 0.500f, 0.200f),
+    ENV(0.000f, 0.200f, 0.500f, 0.250f),
     CHOR(CH_II),
     SYS(TRIG_AUTO, OCT0) }},
 
-{ "Effect Sound", {
-    LFO(0.400f, 0.600f),
-    DCO(F8, 0.100f, 1.000f, PWM_MAN,
+{ "Effect Sound 1", {
+    LFO(0.450f, 0.600f),
+    DCO(F4 , 0.150f, 1.000f, PWM_MAN,
         ON , ON , ON , 0.700f, 0.000f),
     HPF_(R4(0)),
-    VCF(0.600f, 0.000f, 0.400f, POL_NEG, 0.000f, 0.700f),
+    VCF(0.650f, 0.000f, 0.450f, POL_NEG, 0.000f, 0.700f),
     VCA(0.700f, VCA_ENV),
-    ENV(0.000f, 0.500f, 0.000f, 0.500f),
+    ENV(0.000f, 0.500f, 0.000f, 0.550f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
 
-{ "Effect Sound II", {
-    LFO(0.500f, 0.900f),
-    DCO(F8, 0.000f, 0.300f, PWM_LFO,
-        ON , OFF, ON , 0.600f, 0.000f),
+{ "Effect Sound 2", {
+    LFO(0.550f, 0.900f),
+    DCO(F8 , 0.000f, 0.300f, PWM_LFO,
+        ON , OFF, ON , 0.650f, 0.000f),
     HPF_(R4(0)),
-    VCF(0.600f, 0.300f, 0.400f, POL_NEG, 0.000f, 0.100f),
+    VCF(0.650f, 0.300f, 0.400f, POL_NEG, 0.000f, 0.100f),
     VCA(0.700f, VCA_GATE),
-    ENV(0.600f, 0.500f, 0.200f, 0.600f),
+    ENV(0.650f, 0.550f, 0.200f, 0.650f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
 
-{ "Space Harm", {
-    LFO(0.500f, 0.000f),
-    DCO(F8, 0.200f, 0.000f, PWM_ENV,
+{ "Space Harp", {
+    LFO(0.550f, 0.000f),
+    DCO(F8 , 0.200f, 0.000f, PWM_ENV,
         ON , OFF, OFF, 0.000f, 0.000f),
     HPF_(R4(0)),
-    VCF(0.600f, 0.500f, 0.500f, POL_POS, 0.000f, 1.000f),
+    VCF(0.650f, 0.500f, 0.550f, POL_POS, 0.000f, 1.000f),
     VCA(0.700f, VCA_ENV),
     ENV(0.000f, 0.800f, 0.800f, 0.900f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
 
 { "Funk", {
-    LFO(0.300f, 0.200f),
-    DCO(F8, 0.000f, 0.600f, PWM_MAN,
+    LFO(0.300f, 0.250f),
+    DCO(F8 , 0.000f, 0.600f, PWM_MAN,
         ON , ON , ON , 1.000f, 0.000f),
     HPF_(R4(0)),
-    VCF(0.700f, 0.600f, 0.500f, POL_NEG, 0.000f, 0.400f),
+    VCF(0.750f, 0.600f, 0.500f, POL_NEG, 0.000f, 0.450f),
     VCA(0.700f, VCA_GATE),
     ENV(0.600f, 0.500f, 0.000f, 0.000f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
 
-{ "Space Sound I", {
+{ "Space Sound 1", {
     LFO(0.600f, 0.700f),
-    DCO(F8, 0.200f, 0.400f, PWM_MAN,
+    DCO(F8 , 0.200f, 0.450f, PWM_MAN,
         OFF, ON , ON , 1.000f, 0.000f),
     HPF_(R4(0)),
-    VCF(0.600f, 0.700f, 0.500f, POL_NEG, 0.000f, 1.000f),
+    VCF(0.650f, 0.700f, 0.550f, POL_NEG, 0.000f, 1.000f),
     VCA(0.700f, VCA_GATE),
     ENV(0.000f, 0.800f, 0.000f, 0.300f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
 
-{ "Mysterious Inve", {
+{ "Mysterious Inv", {
     LFO(0.600f, 0.800f),
-    DCO(F8, 0.200f, 0.800f, PWM_ENV,
+    DCO(F8 , 0.200f, 0.800f, PWM_ENV,
         ON , ON , OFF, 1.000f, 0.000f),
     HPF_(R4(0)),
-    VCF(0.800f, 0.700f, 0.600f, POL_NEG, 0.200f, 0.000f),
+    VCF(0.800f, 0.700f, 0.600f, POL_NEG, 0.250f, 0.000f),
     VCA(0.700f, VCA_ENV),
     ENV(0.000f, 1.000f, 0.000f, 1.000f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
 
-{ "Space Sound II", {
+{ "Space Sound 2", {
     LFO(0.300f, 0.300f),
-    DCO(F8, 0.000f, 0.600f, PWM_MAN,
+    DCO(F8 , 0.000f, 0.600f, PWM_MAN,
         ON , ON , OFF, 0.800f, 0.000f),
     HPF_(R4(0)),
-    VCF(0.200f, 0.800f, 0.600f, POL_POS, 0.000f, 1.000f),
+    VCF(0.200f, 0.850f, 0.600f, POL_POS, 0.000f, 1.000f),
     VCA(0.700f, VCA_ENV),
     ENV(1.000f, 1.000f, 1.000f, 1.000f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
+
+{ "Percussive Sd1", {
+    LFO(0.000f, 0.000f),
+    DCO(F4 , 0.000f, 0.000f, PWM_ENV,
+        OFF, OFF, OFF, 0.000f, 1.000f),
+    HPF_(R4(1)),
+    VCF(0.400f, 1.000f, 0.150f, POL_POS, 0.000f, 1.000f),
+    VCA(0.700f, VCA_ENV),
+    ENV(0.000f, 0.300f, 0.000f, 0.400f),
+    CHOR(CH_OFF),
+    SYS(TRIG_AUTO, OCT0) }},
+
+{ "Percussive Sd2", {
+    LFO(0.000f, 0.000f),
+    DCO(F8 , 0.000f, 0.000f, PWM_ENV,
+        OFF, OFF, OFF, 0.000f, 0.000f),
+    HPF_(R4(1)),
+    VCF(0.500f, 1.000f, 0.350f, POL_NEG, 0.000f, 1.000f),
+    VCA(0.700f, VCA_ENV),
+    ENV(0.000f, 0.300f, 0.000f, 0.400f),
+    CHOR(CH_OFF),
+    SYS(TRIG_AUTO, OCT0) }},
+
+{ "Whistle", {
+    LFO(0.550f, 0.500f),
+    DCO(F4 , 0.000f, 0.000f, PWM_MAN,
+        OFF, OFF, OFF, 0.000f, 0.200f),
+    HPF_(R4(1)),
+    VCF(0.350f, 1.000f, 0.150f, POL_POS, 0.200f, 1.000f),
+    VCA(0.700f, VCA_ENV),
+    ENV(0.300f, 0.000f, 1.000f, 0.100f),
+    CHOR(CH_OFF),
+    SYS(TRIG_AUTO, OCT0) }},
+
+{ "Effect Sound 3", {
+    LFO(0.550f, 0.400f),
+    DCO(F8 , 0.000f, 0.000f, PWM_ENV,
+        OFF, OFF, OFF, 0.000f, 0.000f),
+    HPF_(R4(1)),
+    VCF(0.350f, 1.000f, 0.000f, POL_POS, 0.200f, 1.000f),
+    VCA(0.700f, VCA_ENV),
+    ENV(0.000f, 0.400f, 0.550f, 0.700f),
+    CHOR(CH_OFF),
+    SYS(TRIG_AUTO, OCT0) }},
+
+{ "UFO", {
+    LFO(0.600f, 0.000f),
+    DCO(F4 , 0.000f, 0.000f, PWM_MAN,
+        OFF, OFF, OFF, 0.000f, 0.200f),
+    HPF_(R4(0)),
+    VCF(0.000f, 1.000f, 0.700f, POL_POS, 0.400f, 1.000f),
+    VCA(0.700f, VCA_ENV),
+    ENV(0.000f, 0.600f, 1.000f, 0.800f),
+    CHOR(CH_I),
+    SYS(TRIG_AUTO, OCT0) }},
+
+{ "Space Sound 3", {
+    LFO(0.600f, 0.000f),
+    DCO(F4 , 0.000f, 0.000f, PWM_MAN,
+        OFF, OFF, OFF, 0.000f, 0.200f),
+    HPF_(R4(0)),
+    VCF(0.500f, 1.000f, 0.400f, POL_NEG, 0.000f, 1.000f),
+    VCA(0.700f, VCA_ENV),
+    ENV(0.000f, 1.000f, 0.000f, 0.800f),
+    CHOR(CH_I),
+    SYS(TRIG_AUTO, OCT0) }},
+
+{ "Surf", {
+    LFO(0.000f, 0.000f),
+    DCO(F8 , 0.000f, 0.000f, PWM_ENV,
+        OFF, OFF, OFF, 1.000f, 1.000f),
+    HPF_(R4(0)),
+    VCF(0.600f, 0.000f, 0.000f, POL_POS, 0.600f, 1.000f),
+    VCA(0.700f, VCA_ENV),
+    ENV(0.000f, 0.400f, 1.000f, 0.800f),
+    CHOR(CH_OFF),
+    SYS(TRIG_AUTO, OCT0) }},
+
+{ "Synth Drum", {
+    LFO(0.000f, 0.000f),
+    DCO(F8 , 0.000f, 0.000f, PWM_ENV,
+        OFF, OFF, OFF, 0.000f, 0.000f),
+    HPF_(R4(0)),
+    VCF(0.200f, 1.000f, 0.400f, POL_POS, 0.000f, 1.000f),
+    VCA(0.700f, VCA_ENV),
+    ENV(0.000f, 0.500f, 0.000f, 0.600f),
+    CHOR(CH_OFF),
+    SYS(TRIG_MAN , OCT0) }},
 
 };
 


### PR DESCRIPTION
Two commits from reading the Juno-60 service notes and owner's manual.

---

## 1. Modulation depths and the bender range

The service notes carry something the Minimoog ones did not: a **circuit
description stating modulation depths in cents**, and **factory adjustment
procedures** — calibration targets rather than round numbers in a table.

| | before | after | source |
|---|---|---|---|
| LFO → DCO at full depth | 1 semitone | **3 semitones** | master oscillator range, "LFO ±300 cents" |
| Bender range | 0..12 st | **0..7 st** | "BENDER ±700 cents", plus adjustment 3 |
| LFO rate ceiling | 20 Hz | **22 Hz** | adjustment 7-1: 45 ms period |

The LFO one matters most. It held 1.0 semitone, taken from junox by
construction. The notes settle it: describing the master oscillator they give
its range per input — BENDER ±700 cents, LFO ±300, TUNE ±50 — and check the
arithmetic themselves, *"the maximum shiftable range is ±1050 cents"*.

At 1.0 the factory patches were too timid to hear: the fifteen that use the
slider got 10 to 40 cents of vibrato, where a violin or an oboe wants three or
four times that.

Also records a departure that was previously silent: **a Juno-60 is tuned to
A = 442 Hz**, said four times over in the notes. 440 is kept — this is played
alongside other instruments over MIDI — but the reasoning now sits at the
constant instead of being assumed.

Verified: pitch swing at full DCO LFO 284 cents peak against a nominal 300,
bender exactly ±7.000 semitones, LFO 21.1 Hz at the top of the slider.

---

## 2. All 56 factory patches

The preset file said the factory set *"is not published in the service notes"*.
True — but **the owner's manual publishes it**, pages 25 to 28, the complete
front panel of every one of the 56 patches on the instrument's own 0..10 scale.

Transcribed and checked cell by cell against the imported set. Of the **720
numeric cells** across the 48 patches the two share, **590 agree exactly**. The
other 130:

| | cells |
|---|---|
| junox truncated the half-steps (chart 6.5 → its 6) | **125** |
| junox misread a digit — patch 33 PW 8 not 9, both Pizzicatos res 3 not 4 | **3** |
| a deliberate divergence of ours, kept | 2 |

That 590-of-720 exact agreement is what makes the rest trustworthy: two
independent readings of the same table, differing in one systematic way and
three cells, each of which was then re-read at magnification.

**Two columns junox dropped altogether**, both now in:

- **The octave transpose.** Every imported patch sat at 8'; the chart puts about
  twenty at 16' or 4' — and it reads like an instrument list when it does: both
  basses and both clavichords down, xylophone, glockenspiel, flute and the reeds
  up, tuba down.
- **Bank 7**, eight patches. The manual says why nobody reproduces them:
  *"Bank 7 includes the patches whose sound sources are VCF self-oscillation."*
  Their rows carry no waveform at all and resonance 10 throughout.

### Bank 7 exposed a real gap

Three of its patches rendered **silent**. A digital filter fed exactly zero
stays at exactly zero however high the resonance, while an IR3109 turned up
that far sings on its own transistor noise. This engine had a noise floor, but
it sat *after* the voices were summed — outside every filter loop, where it can
never start one. Moved inside, per voice and separately seeded. Two of the three
now sound.

### Where the chart could not be read

The **chorus** column sits at the page edge and this scan cannot resolve it —
two readings of it were wrong before the error surfaced. It is taken instead
from the LED graphics of the **Juno-60 Patch Book** (Sunshine Jones, 2021),
which redraws the same data legibly and agrees with the chart in every column
the chart *can* be read. That document is derived and its author says so, so it
is used only where the original is illegible.

The **VCA level** column is not transcribed at all. It is printed as a signed
value in a range no 0..10 slider has, and it defeated junox (which substituted a
constant 7), the Patch Book author (who drew every level slider at the same
height), and this reading. Each patch keeps the level it shipped with; bank 7
takes 0.700.

## Open, and flagged rather than settled

- **Piano 1 and Clavichord 1** keep their DCO LFO zeroed, from an earlier
  listening test, where the chart puts vibrato on both. With the trigger mode on
  manual the LFO runs free rather than waiting for the button, so it would be
  heard on every note — and at the corrected depth that is over a hundred cents
  on a piano. Worth a listen before it is trusted either way.
- **Patch 72 Percussive Sound 2** comes out 43 dB under the loudest patch. Its
  inverted filter contour shuts the filter exactly when the instant attack opens
  the amplifier. Plausible for a patch of that name, but also where an envelope
  shape difference would show.

No preset produces non-finite output; loudest peaks at 0.607. Firmware links at
RAM 6.12 %.

## What to listen for

**Bank 7 (49–56 in the list)** — entirely new, and the filter has to sing for
them to exist at all. Then the transposed patches: **Bass 1/2**, **Tuba**,
**Xylophone**, **Glockenspiel**, **Flute** should now sit an octave from where
they did. And anything with vibrato — **Violine**, **Oboe**, **Reed 1** — for
the corrected LFO depth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
