### PR TITLE
PicoFaceD5: PCM samples at the machine's one rate (#142)

### DIFF
--- a/instruments/PicoFaceD5/README.md
+++ b/instruments/PicoFaceD5/README.md
@@ -199,9 +199,11 @@ Where this still differs from the machine:
   from the ROM; the one constant that scales all of them was calibrated against
   four measurements in reference recordings, and is good to a few percent
   rather than exact.
-- **Root pitch of the attack samples.** The sustained loops are exact (each is
-  one cycle, so the root is the sample rate divided by its length); the attacks
-  carry a measured estimate.
+- **The PCM sample rate.** Every sample is transposed by the machine's one
+  rule (four octaves below the square of the same coarse, IC25 `0x0F49`; the
+  chip's 2048-word reference from munt), which puts a sample at its stored
+  rate at coarse 36 on C4. The rule is proven; the 32 kHz the blob assumes for
+  the chip is the MT-32's figure, not measured on a D-50.
 - **Sixteen voices are allocated, not always rendered.** The allocator is the
   machine's, but the RP2350 is not the LA32: on the heaviest patches -- two
   resonant synth partials and a three-second release, Spacious Sweep being the

--- a/instruments/PicoFaceD5/include/d5_engine/d5_patch_map.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_patch_map.h
@@ -257,7 +257,6 @@ inline void map_partial(const uint8_t* p, int index, VoiceSpec& v,
         }
         r.length = smp.length;
         r.looped = smp.looped;
-        r.root_hz = smp.root_hz;
     }
 
     // ---- TVF: cutoff, resonance and its envelope

--- a/instruments/PicoFaceD5/include/d5_engine/d5_pcm_voice.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_pcm_voice.h
@@ -6,13 +6,13 @@
 // of the sample ROMs; the synth partials (sawtooth/square with TVF, and the
 // ring modulation that pairs them) are separate.
 //
-// The D-50's own table carries a root pitch per sample, but that table lives
-// in the MB87136's mask ROM and cannot be read out. For the 29 sustained
-// loops it did not need to be: each is one cycle of 2^k words, so the root is
-// 32000/length exactly. The attacks have no cycle to measure against and
-// carry an estimate. Material with no pitch at all -- Noise, and some
-// percussion -- reports 0 and always plays at the ROM rate, because
-// transposing noise onto a note turns it into a buzz.
+// There is no root pitch per sample anywhere in the machine. The firmware
+// sends a PCM partial the pitch word a square would get, four octaves lower
+// (IC25 0x0F49), and the chip turns that into a playback step by one rule
+// for every sample -- see kPcmPitchRefHz below. Roland tuned the material to
+// that rule, not the other way round: the sustained loops are 2^k-word
+// cycles so they land on C octaves, and the attacks sit wherever the patch
+// programmer's coarse puts them. Noise follows the key like everything else.
 #pragma once
 
 #include <cmath>
@@ -34,8 +34,27 @@ struct PcmSampleRef {
     uint32_t start = 0;
     uint32_t length = 0;
     bool looped = false;
-    float root_hz = 0.0f;
 };
+
+// The D-50 transposes every PCM sample by one rule, whatever the material.
+// Firmware IC25 0x0F44-0x0F4E (and again at 0x0F9A, the negative-keyfollow
+// branch of the same composer) shifts the partial's type byte and, when the
+// carry -- bit 7, the PCM flag -- is set, subtracts 0x4000 from the pitch
+// word: exactly four octaves in the chip's 4096-per-octave scale. The chip
+// itself (munt LA32WaveGenerator: synth step 2^(p/4096+4) over a 2^20
+// period, PCM step 2^(p/4096+3) in 1/256 word) advances a PCM by
+// f*2048/32000 words per output sample for the pitch word that makes a
+// square wave sound at f. Together: words per sample = f / (32000/128) =
+// f / 250 Hz. At coarse 36 on C4 that is 1.046, the stored rate -- which is
+// also why every sustained loop is a 2^k-word cycle: 32000/2^k Hz times
+// 261.6/250 lands them on the C octaves by construction. Nothing in the
+// firmware carries a root pitch per sample; the PCM number only selects the
+// start page and the length class (IC25 0x04B0-0x04CF). So the natural
+// pitch of the material must not enter the playback rate. It did, until
+// issue #142: FluteH and Breath (~1 kHz material) were transposed onto the
+// square's pitch and came out two octaves low, the Spect loops four octaves
+// high, the bass and piano loops one to two octaves high.
+inline constexpr float kPcmPitchRefHz = 32000.0f / 128.0f;
 
 class PcmVoice {
 public:
@@ -48,8 +67,7 @@ public:
         active_ = s.data != nullptr && s.length > 0;
         gain_ = velocity;
         const float f = 440.0f * std::pow(2.0f, (note - 69.0f) / 12.0f);
-        // Unpitched material has nothing to transpose from: play it as stored.
-        rate_ = (s.root_hz > 0.0f) ? f / s.root_hz : 1.0f;
+        rate_ = f / kPcmPitchRefHz;
         rate_ *= sample_rate > 0.0f ? (32000.0f / sample_rate) : 1.0f;
         rate_ *= detune;
         sr_ = sample_rate;
@@ -90,9 +108,10 @@ private:
     // second. This is also *more* precise: the integer part cannot lose bits
     // to the mantissa however long the note is held.
     //
-    // The whole-word step never reaches the sample length: it is
-    // freq * length / 32000, and no MIDI note reaches 32 kHz. So one
-    // conditional subtract is enough to wrap, no division and no modulo.
+    // The whole-word step is f/250 words: past the length of a 128-word
+    // cycle only for a square pitch above 32 kHz, which no key and coarse
+    // combination in the bank produces. One conditional subtract wraps;
+    // the modulo below is the guard for the absurd case.
     void advance(float step) {
         frac_ += step;
         const uint32_t whole = static_cast<uint32_t>(frac_);

--- a/instruments/PicoFaceD5/include/d5_presets.h
+++ b/instruments/PicoFaceD5/include/d5_presets.h
@@ -38,7 +38,6 @@ inline void preset_bind(PatchSpec& spec, const int16_t* blob, int pcm1, int pcm2
         r.start = s.start;
         r.length = s.length;
         r.looped = s.looped;
-        r.root_hz = s.root_hz;
     }
 }
 

--- a/tools/d5_extract/README.md
+++ b/tools/d5_extract/README.md
@@ -339,12 +339,18 @@ arithmetic (the last 14 samples fill the last 14 pages, one page each, so
 nothing is left to choose), 24 unresolved combination ranges. Regions
 1..76 tile the ROM without a gap.
 
-What the table does **not** carry is a root pitch per sample -- that lives
-in the chip with the addresses. `d5_make_blob.py` measures one from the
-material instead (lowest prominent partial, unpitched material reports 0).
-Those values are estimates; the three pianos come out an octave apart as
-they audibly are, but individual entries can be off by an octave and want
-a pass against reference recordings once the engine plays.
+What the table does **not** carry is a root pitch per sample -- and neither
+does the machine. The firmware's pitch composer subtracts four octaves from
+the pitch word of every PCM partial (IC25 `0x0F44`-`0x0F4E`, keyed on the
+PCM bit of the type byte) and otherwise sends the same word a square would
+get; the PCM number only selects the start page and the length class. With
+the chip's 2048-word reference (munt's LA32 model) that is a step of
+f/250 Hz for every sample, 1.046 at coarse 36 on C4 -- the stored rate.
+The `root_hz` column `d5_make_blob.py` still measures (lowest prominent
+partial, unpitched material reports 0) is the natural pitch of the
+material, kept for reading the ROM, not for playing it: the engine used it
+as a transposition target until issue #142, which put FluteH and Breath two
+octaves low and the Spect loops four octaves high.
 
 **With a real D-50/D-550** (`d5_probe_midi.py` + `d5_match.py`): the
 precision path, open to anyone with the hardware. `d5_probe_midi.py` emits

--- a/tools/d5_extract/d5_make_blob.py
+++ b/tools/d5_extract/d5_make_blob.py
@@ -53,7 +53,8 @@ struct PcmSample {{
     uint32_t start;      // in samples, into d5_pcm_blob
     uint32_t length;     // 48..76: exactly one cycle, so the loop is the entry
     bool     looped;     // 48..76 are the sustained loops
-    float    root_hz;    // 48..76 exact as 32000/length; attacks measured
+    float    root_hz;    // natural pitch of the material, informational only:
+                         // playback is f/250 Hz for every sample (d5_pcm_voice.h)
     char     name[7];
 }};
 

--- a/tools/host_tests/README.md
+++ b/tools/host_tests/README.md
@@ -12,6 +12,7 @@ land next to their script and are gitignored.
 |---|---|---|
 | [`veeprom/`](veeprom/) | nothing | unit test of the core's virtual EEPROM: wear levelling, CRC, oversize rejection, 1000 saves. Prints PASS/FAIL per case. This one covers `core/`, not an instrument. |
 | [`yc/`](yc/) | nothing | renders the YC organ engine to a WAV file. No audio device involved. |
+| [`d5/`](d5/) | nothing | pins the D-50 PCM pitch law (every sample advances at f/250 words per output sample: four octaves below the square in the firmware, 2048-word reference in the chip) with synthetic cycles. Prints pass/FAIL per case. |
 | [`ob/`](ob/) | nothing | regression checks on the OB-X engine - pitch bend ranges, LFO->cutoff without LFO->pitch, mod lever vibrato, all presets finite - plus a WAV render. Prints pass/FAIL per case. |
 | [`dx_sysex/`](dx_sysex/) | nothing | round trip through PicoFaceDX's SysEx layer, both directions: a voice dump requested by an editor is parsed back and compared byte for byte, and a voice sent by an editor is compared against what reaches the engine. Prints pass/FAIL per direction. |
 | [`j6/build_ui.sh`](j6/) | nothing | drives `J6_Controller` and the patch store through a scripted panel session - menu navigation, patch save/load, the free-slot rule. |

--- a/tools/host_tests/d5/build_d5.sh
+++ b/tools/host_tests/d5/build_d5.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Michi71
+# build_d5.sh -- host build of the PicoFaceD5 engine checks.
+# Pins the PCM pitch law with synthetic cycles; no ROM, no audio device.
+set -e
+
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$HERE/../../.." && pwd)"
+ROOT="$REPO/instruments/PicoFaceD5"
+OUT="$HERE/pcm_pitch_host_test"
+
+CXX="${CXX:-c++}"
+"$CXX" -std=c++17 -O2 -Wall -DD5_HOST_BUILD -I"$ROOT/include" -I"$REPO/core/include" \
+    "$HERE/pcm_pitch_host_test.cpp" -o "$OUT"
+
+echo "[ok]   $OUT"
+"$OUT"

--- a/tools/host_tests/d5/pcm_pitch_host_test.cpp
+++ b/tools/host_tests/d5/pcm_pitch_host_test.cpp
@@ -1,0 +1,85 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Michi71
+//
+// The D-50's PCM pitch law, pinned. A PCM partial advances through its
+// sample at f/250 words per output sample, where f is the frequency a
+// square partial with the same bytes would sound at: the firmware subtracts
+// four octaves from the pitch word for PCM (IC25 0x0F49) and the chip's PCM
+// reference is 2048 words per period (munt LA32WaveGenerator). So a 128-word
+// cycle played at C4 sounds at C4 and a 2048-word cycle at C0, whatever
+// material the cycle holds. Issue #142 was this law being replaced by the
+// measured pitch of each sample. No ROM is needed: synthetic cycles suffice.
+#include <cmath>
+#include <cstdio>
+#include <vector>
+
+#include "d5_engine/d5_pcm_voice.h"
+
+namespace {
+
+constexpr float kSR = 32000.0f;
+int g_failed = 0;
+
+void check(bool ok, const char* what, double got, double want) {
+    std::printf("%s  %-46s got %.3f want %.3f\n", ok ? "pass" : "FAIL", what, got, want);
+    if (!ok) ++g_failed;
+}
+
+// One cycle of a sine over `words` samples, as int16.
+std::vector<int16_t> cycle(unsigned words) {
+    std::vector<int16_t> v(words);
+    for (unsigned i = 0; i < words; ++i)
+        v[i] = static_cast<int16_t>(std::lround(20000.0 * std::sin(2.0 * M_PI * i / words)));
+    return v;
+}
+
+// Frequency from rising zero crossings over `seconds` of output.
+double sounding_hz(const std::vector<int16_t>& data, float note, double seconds) {
+    d5::PcmSampleRef ref;
+    ref.data = data.data();
+    ref.start = 0;
+    ref.length = static_cast<uint32_t>(data.size());
+    ref.looped = true;
+    d5::Env5Spec env;                       // full level, held: the shape is not under test
+    env.t[0] = 0.001f;
+    env.l[0] = env.l[1] = env.l[2] = 1.0f;
+    env.sustain = 1.0f;
+    d5::PcmVoice v;
+    v.note_on(ref, note, 1.0f, env, kSR);
+    const int n = static_cast<int>(kSR * seconds);
+    const int skip = static_cast<int>(kSR * 0.05f);
+    float prev = 0.0f;
+    int crossings = 0, first = -1, last = -1;
+    for (int i = 0; i < n; ++i) {
+        const float x = v.next();
+        if (i >= skip && prev < 0.0f && x >= 0.0f) {
+            if (first < 0) first = i;
+            last = i;
+            ++crossings;
+        }
+        prev = x;
+    }
+    if (crossings < 2) return 0.0;
+    return (crossings - 1) * static_cast<double>(kSR) / (last - first);
+}
+
+}  // namespace
+
+int main() {
+    check(d5::kPcmPitchRefHz == 250.0f, "reference: 32000 / 128 = 250 Hz", d5::kPcmPitchRefHz, 250.0);
+
+    const double c4 = 261.6256, c0 = c4 / 16.0, c5 = 2.0 * c4;
+    const auto w128 = cycle(128), w2048 = cycle(2048), w32 = cycle(32);
+
+    double f = sounding_hz(w128, 60.0f, 2.0);
+    check(std::fabs(f / c4 - 1.0) < 0.002, "128-word cycle at C4 sounds C4 (stored rate)", f, c4);
+    f = sounding_hz(w128, 72.0f, 2.0);
+    check(std::fabs(f / c5 - 1.0) < 0.002, "an octave up on the key doubles it", f, c5);
+    f = sounding_hz(w2048, 60.0f, 4.0);
+    check(std::fabs(f / c0 - 1.0) < 0.01, "2048-word cycle at C4 sounds C0 (Spect loops)", f, c0);
+    f = sounding_hz(w32, 60.0f, 2.0);
+    check(std::fabs(f / (4.0 * c4) - 1.0) < 0.002, "32-word cycle at C4 sounds C6 (FluteH class)", f, 4.0 * c4);
+
+    std::printf("%s\n", g_failed ? "FAILED" : "all pass");
+    return g_failed ? 1 : 0;
+}


### PR DESCRIPTION
Fixes #142.

**What was wrong.** The engine transposed every PCM sample so that its *measured* natural pitch landed on the pitch a square partial with the same bytes would sound at. The D-50 does no such thing. Its pitch composer (IC25 `0x0F44`–`0x0F4E`, and again at `0x0F9A` for the negative-keyfollow branch) tests the PCM bit of the partial's type byte and subtracts `0x4000` from the pitch word — exactly four octaves — and otherwise sends a PCM partial the same word a square gets. The PCM number only selects the start page and the length class (`0x04B0`–`0x04CF`); there is no per-sample root pitch anywhere in the firmware. With the chip's 2048-word PCM reference (munt `LA32WaveGenerator`, PCM step `>>9` against the synth's `>>8`), that is a playback step of **f / 250 Hz for every sample**: the stored rate at coarse 36 on C4, and the 2^k-word loops on C octaves by construction.

**Who was off, and by how much.** The old rule was right only for samples whose material sat at 250 Hz. FluteH, Breath, IndFlt, Bells, Harp, Trumpt, Bones, Violns (32-word period) played **two octaves low** — luginf's "2 octaves lower attack" on Pipe Solo, word for word. Vibes, Hpiano, Steam, Harmo one octave low; the 256-word loops one octave high; the bass, clav and piano loops **two octaves high**; Marmba, Contra, Ooh three; the Spect loops **four octaves high**, with their content above Nyquist. Noise did not follow the key at all.

**Evidence that does not depend on the ROM.** Under the uncompensated chip law the factory bank's 288 attack partials would sit three to five octaves above the key (mode +3/+4); with the four-octave shift they sit at −1/0. The piano family is the control: Hpiano at coarse 12 and Lpiano at coarse 48 land in the same register under this rule and three octaves apart under the old one. The structure table was checked against the Owner's Manual (p. 22) on the way: structure 6 is a plain P+P mix, as implemented.

**Against luginf's recording** (Pipe Solo, real D-50): 80–300 Hz band in the first 100 ms relative to the 700–1100 Hz flute rank — original −36 / −42 / −49 dB, engine before **−3 dB**, after **−37 dB**.

**Checks.** All 384 patches finite and below full scale (four-note chord, full velocity). New host test `tools/host_tests/d5/build_d5.sh` pins the law with synthetic 128/2048/32-word cycles (C4 → C4 / C0 / C6), no ROM needed. Firmware builds, RAM 51.8 %.

`root_hz` stays in the sample table as a description of the material; the engine no longer reads it. Listening candidates: Pipe Solo (1-22), Living Calliope (1-06), Bass Marimba (1-10), Pizzagogo (1-28), and any piano or bass patch built on the loops.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
