### PR TITLE
PicoFaceD5: reverb calibrated on the D-50 VST, Bright Hall no longer rings

### DIFF
--- a/instruments/PicoFaceD5/include/d5_engine/d5_effects.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_effects.h
@@ -297,12 +297,19 @@ private:
 
 // The thirty-two panel types, mapped onto the Boss core of the sister
 // machine (see the file header) plus a tapped delay line for the delay
-// family. Type names follow the panel list; the T60 anchors measured from
-// the reference recordings (type 3 Large Hall 5.4 s, type 4 Chapel 3.6 s,
-// type 2 Medium Hall 3.2 s, type 9 1.6 s, type 32 6.0 s) pick the time
-// index inside each mode. The wet column normalizes the steady-state wet
-// level to a constant across time settings (measured on the model: -13.0
-// to -6.5 dBFS over time 0..7, normalized to -11).
+// family. Type names follow the panel list; rows are zero-based (pb30),
+// the panel shows row + 1. Decay times are calibrated on Roland's D-50
+// VST (one note, reverb balance 100, per type): Small Hall 1.5 s, Medium
+// Hall 2.9, Large Hall 3.3, Chapel 6.5, Medium Large Room 2.0, Large Room
+// 2.1 (its sides inverted, correlation -0.95); the short rooms and the
+// gates hide under the source's own 55 dB/s release there, so they only
+// carry an upper bound of about a second. The delays showed the direct
+// copy on the right and the delayed tap on the left, at 0.35..0.5 of it,
+// Delay 248 with the left side inverted; the feedback follows the measured
+// tails (2.7 s at 248 ms, 2.4 s at 252 ms). The Boss loop is stable only
+// below fb 0.625 (DC loop gain fb/(1 - 0.375)); the wet column holds the
+// steady-state level of the wet part near -3 dB re the send at balance 1,
+// the delays' right side included.
 struct ReverbType {
     int mode;               // 0 room, 1 hall, 2 plate, 3 tapped delay
     int time;               // Boss feedback index 0..7 (modes 0..2)
@@ -317,39 +324,42 @@ struct ReverbType {
                             // decay anchors (measured tail dB/s of the
                             // reference recordings) land between them, so
                             // these interpolate while keeping the geometry.
+    float echo = 1.0f;      // mode 3: gain of the left (delayed) tap, sign =
+                            // its polarity; the right tap is the direct copy
+    float pol_r = 1.0f;     // polarity of the right wet side (-1 inverts)
 };
 
 inline constexpr ReverbType kReverbTypes[32] = {
-    {1, 1, 1.23f,   0,   0, 0.0f,   0.0f,   0.0f, 0.0000f}, //  1 Small Hall
-    {1, 6, 0.85f,   0,   0, 0.0f,   0.0f,   0.0f, 0.5469f}, //  2 Medium Hall  (anchor -10.5 dB/s, fb 8C)
-    {1, 5, 0.89f,   0,   0, 0.0f,   0.0f,   0.0f, 0.5312f}, //  3 Large Hall   (anchor -12 dB/s, fb 88)
-    {1, 5, 0.95f,   0,   0, 0.0f,   0.0f,   0.0f, 0.5078f}, //  4 Chapel       (T60 3.6, anchor 3.6, fb 82)
+    {1, 1, 1.23f,   0,   0, 0.0f,   0.0f,   0.0f, 0.3900f}, //  1 Small Hall   (VST T60 1.5)
+    {1, 6, 0.85f,   0,   0, 0.0f,   0.0f,   0.0f, 0.5000f}, //  2 Medium Hall  (VST T60 2.9)
+    {1, 5, 0.89f,   0,   0, 0.0f,   0.0f,   0.0f, 0.5150f}, //  3 Large Hall   (VST T60 3.3)
+    {1, 5, 0.95f,   0,   0, 0.0f,   0.0f,   0.0f, 0.5700f}, //  4 Chapel       (VST T60 6.5)
     {0, 0, 1.26f,   0,   0, 0.0f,   0.0f,   0.0f, 0.0000f}, //  5 Box
     {2, 2, 1.02f,   0,   0, 0.0f,   0.0f,   0.0f, 0.0000f}, //  6 Small Metal Room (plate ring)
     {0, 1, 1.20f,   0,   0, 0.0f,   0.0f,   0.0f, 0.0000f}, //  7 Small Room   (T60 0.9)
-    {0, 3, 1.00f,   0,   0, 0.0f,   0.0f,   0.0f, 0.4609f}, //  8 Medium Room  (anchor -28 dB/s, fb 76)
-    {1, 2, 1.15f,   0,   0, 0.0f,   0.0f,   0.0f, 0.0000f}, //  9 Medium Large Room (T60 1.65, anchor 1.6)
-    {0, 3, 0.92f,   0,   0, 0.0f,   0.0f,   0.0f, 0.5000f}, // 10 Large Room   (T60 2.8, fb 80)
-    {3, 0, 2.50f, 102, 102, 0.20f,  0.0f,   0.0f, 0.0000f}, // 11 Single Delay (102 ms)
-    {3, 0, 2.50f, 180, 360, 0.30f,  0.0f,   0.0f, 0.0000f}, // 12 Cross Delay (180 ms)
-    {3, 0, 2.50f, 224, 448, 0.30f,  0.0f,   0.0f, 0.0000f}, // 13 Cross Delay (224 ms)
-    {3, 0, 2.50f, 148, 296, 0.30f,  0.0f,   0.0f, 0.0000f}, // 14 Cross Delay (148/296 ms)
+    {0, 3, 1.00f,   0,   0, 0.0f,   0.0f,   0.0f, 0.3500f}, //  8 Medium Room  (VST: under the 55 dB/s source, T60 <= 1)
+    {1, 2, 1.15f,   0,   0, 0.0f,   0.0f,   0.0f, 0.4500f}, //  9 Medium Large Room (VST T60 2.0)
+    {0, 3, 0.92f,   0,   0, 0.0f,   0.0f,   0.0f, 0.4800f, 1.0f, -1.0f}, // 10 Large Room (VST T60 2.1, sides inverted, corr -0.95)
+    {3, 0, 1.20f, 102,   0, 0.50f,  0.0f,   0.0f, 0.0000f, -0.5f}, // 11 Single Delay (102 ms; as 20)
+    {3, 0, 1.20f, 180,   0, 0.30f,  0.0f,   0.0f, 0.0000f,  0.35f}, // 12 Cross Delay (180 ms; VST: right direct, left 180, tail under the source)
+    {3, 0, 1.20f, 224,   0, 0.40f,  0.0f,   0.0f, 0.0000f,  0.40f}, // 13 Cross Delay (224 ms; as 23)
+    {3, 0, 1.20f, 148,   0, 0.40f,  0.0f,   0.0f, 0.0000f,  0.40f}, // 14 Cross Delay (148 ms; as 23)
     {1, 3, 1.05f,   0,   0, 0.0f, 200.0f,   0.0f, 0.0000f}, // 15 Short Gate (200 ms)
     {1, 3, 1.05f,   0,   0, 0.0f, 480.0f,   0.0f, 0.0000f}, // 16 Long Gate (480 ms)
     {1, 5, 0.89f,   0,   0, 0.0f,   0.0f,   0.0f, 0.5312f}, // 17 Bright Hall (brighter injection, fb 88)
-    {1, 6, 0.80f,   0,   0, 0.0f,   0.0f,   0.0f, 0.0000f}, // 18 Large Cave (dark, long)
+    {1, 6, 0.80f,   0,   0, 0.0f,   0.0f,   0.0f, 0.4600f}, // 18 Large Cave (dark: loop damping x1.25, T60 4.4; fb < 0.53 or it rings)
     {2, 5, 0.77f,   0,   0, 0.0f,   0.0f,   0.0f, 0.0000f}, // 19 Steel Pan (plate, metallic)
-    {3, 0, 2.50f, 248, 248, 0.25f,  0.0f,   0.0f, 0.0000f}, // 20 Delay (248 ms)
-    {3, 0, 2.50f, 338, 338, 0.25f,  0.0f,   0.0f, 0.0000f}, // 21 Delay (338 ms)
-    {3, 0, 2.50f, 157, 314, 0.30f,  0.0f,   0.0f, 0.0000f}, // 22 Cross Delay (157 ms)
-    {3, 0, 2.50f, 252, 504, 0.30f,  0.0f,   0.0f, 0.0000f}, // 23 Cross Delay (252 ms)
-    {3, 0, 2.50f, 274, 137, 0.30f,  0.0f,   0.0f, 0.0000f}, // 24 Cross Delay (274/137 ms)
+    {3, 0, 1.20f, 248,   0, 0.53f,  0.0f,   0.0f, 0.0000f, -0.5f}, // 20 Delay (248 ms; VST: right direct, left inverted, T60 2.7)
+    {3, 0, 1.20f, 338,   0, 0.53f,  0.0f,   0.0f, 0.0000f, -0.5f}, // 21 Delay (338 ms; as 20)
+    {3, 0, 1.20f, 157,   0, 0.40f,  0.0f,   0.0f, 0.0000f,  0.40f}, // 22 Cross Delay (157 ms; as 23)
+    {3, 0, 1.20f, 252,   0, 0.48f,  0.0f,   0.0f, 0.0000f,  0.45f}, // 23 Cross Delay (252 ms; VST: right direct, left 252 in phase, T60 2.4)
+    {3, 0, 1.20f, 274,   0, 0.40f,  0.0f,   0.0f, 0.0000f,  0.40f}, // 24 Cross Delay (274 ms; as 23)
     {1, 4, 0.98f,   0,   0, 0.0f, 300.0f,   0.0f, 0.0000f}, // 25 Gate Reverb
     {1, 4, 0.98f,   0,   0, 0.0f,   0.0f, 360.0f, 0.0000f}, // 26 Reverse Gate (360 ms)
     {1, 4, 0.98f,   0,   0, 0.0f,   0.0f, 480.0f, 0.0000f}, // 27 Reverse Gate (480 ms)
-    {3, 0, 2.50f,  80,  80, 0.00f,  0.0f,   0.0f, 0.0000f}, // 28 Slap Back (short)
-    {3, 0, 2.50f, 160, 160, 0.00f,  0.0f,   0.0f, 0.0000f}, // 29 Slap Back (mid)
-    {3, 0, 2.50f, 240, 240, 0.00f,  0.0f,   0.0f, 0.0000f}, // 30 Slap Back (long)
+    {3, 0, 1.20f,  80,   0, 0.00f,  0.0f,   0.0f, 0.0000f,  0.50f}, // 28 Slap Back (short)
+    {3, 0, 1.20f, 160,   0, 0.00f,  0.0f,   0.0f, 0.0000f,  0.50f}, // 29 Slap Back (mid)
+    {3, 0, 1.20f, 240,   0, 0.00f,  0.0f,   0.0f, 0.0000f,  0.50f}, // 30 Slap Back (long)
     {1, 7, 0.65f,   0,   0, 0.0f,   0.0f,   0.0f, 0.0000f}, // 31 Twisted Space (T60 ~14 s)
     {1, 6, 0.84f,   0,   0, 0.0f,   0.0f,   0.0f, 0.5508f}, // 32 Space (T60 ~6.0, anchor 6.0, fb 8D)
 };
@@ -468,16 +478,20 @@ public:
         sr_ = sr;
         const ReverbType& t = kReverbTypes[clamp_index(spec.type, 32)];
         wet_ = t.wet;
+        echo_ = t.echo;
+        pol_r_ = t.pol_r;
         mode_ = t.mode < 3 ? t.mode : 3;
         age_ = 0;
         gate_ = static_cast<int>(t.gate_ms * 0.001f * sr);
         reverse_ = static_cast<int>(t.reverse_ms * 0.001f * sr);
         if (mode_ < 3) {
             const BossMode& m = boss_mode(mode_);
-            // Types 17 and 18 tune the injection: the bright hall eases the
-            // entrance damping, the cave tightens the loop damping.
-            const float filt_scale = spec.type == 17 ? 0.85f
-                                   : (spec.type == 16 ? 1.25f : 1.0f);
+            // Panel types 17 and 18 (rows 16/17) tune the damping: the bright
+            // hall eases both, the cave tightens the loop. Rows, not panel
+            // numbers: the swapped comparison once gave Bright Hall the
+            // cave's damping, and it rang at 140 Hz forever.
+            const float filt_scale = spec.type == 16 ? 0.85f
+                                   : (spec.type == 17 ? 1.25f : 1.0f);
             const float lpf = (spec.type == 16 ? 0x80 : m.lpf_amp) / 256.0f;
             const float scale = sr / 32000.0f;  // geometry is 32 kHz native
             for (int a = 0; a < 3; ++a) {
@@ -497,8 +511,9 @@ public:
             boss_ = &m;
             sr_scale_ = scale;
         } else {
-            tap_l_ = static_cast<int>(t.tap_l_ms * 0.001f * sr);
-            tap_r_ = static_cast<int>(t.tap_r_ms * 0.001f * sr);
+            // at(1) is the word just written: a 0 ms tap is the direct copy
+            tap_l_ = static_cast<int>(t.tap_l_ms * 0.001f * sr) + 1;
+            tap_r_ = static_cast<int>(t.tap_r_ms * 0.001f * sr) + 1;
             tap_fb_ = t.fb;
             tap_line_.bind(pool_, 16200);
             tap_line_.clear();
@@ -506,6 +521,19 @@ public:
     }
 
     void set_balance(float b) { spec_.balance = clamp01(b); }
+
+    // Rebind the three tail loops with another feedback, geometry and
+    // damping unchanged. Calibration and tests only: it clears the loops.
+    void set_feedback(float fb) {
+        if (mode_ >= 3) return;
+        const BossMode& m = *boss_;
+        const float filt_scale = spec_.type == 16 ? 0.85f : (spec_.type == 17 ? 1.25f : 1.0f);
+        for (int c = 0; c < 3; ++c) {
+            comb_[c].bind(pool_ + 6900 + 4600 * c,
+                          static_cast<int>(m.comb_sizes[1 + c] * sr_scale_),
+                          m.filter[1 + c] / 256.0f * filt_scale, fb);
+        }
+    }
 
     void note_activity() { age_ = 0; }      // a gate restarts with the note
 
@@ -540,12 +568,16 @@ public:
             wr = 1.5f * (comb_[0].out_at(static_cast<int>(m.out_r[0] * sr_scale_))
                      + comb_[1].out_at(static_cast<int>(m.out_r[1] * sr_scale_)))
                      + comb_[2].out_at(static_cast<int>(m.out_r[2] * sr_scale_));
+            // A type with an inverted right side sends the same wet to both
+            // outputs (the VST's Large Room: L/R correlation -0.95); the
+            // chip's own tap pairs are decorrelated and would stay so.
+            if (pol_r_ < 0.0f) wr = wl;
         } else {
             // Tapped delay: one line, two read positions, the left tap feeds
             // back so cross delays alternate sides.
             tap_line_.buf_[tap_line_.i_] = x + tap_fb_ * tap_line_.at(tap_l_);
             tap_line_.next();
-            wl = tap_line_.at(tap_l_);
+            wl = echo_ * tap_line_.at(tap_l_);
             wr = tap_line_.at(tap_r_);
         }
 
@@ -573,7 +605,7 @@ public:
 
         const float b = clamp01(spec_.balance);
         l = xl * (1.0f - b) + wl * b * wet_ * g;
-        r = xr * (1.0f - b) + wr * b * wet_ * g;
+        r = xr * (1.0f - b) + pol_r_ * wr * b * wet_ * g;
     }
 
 private:
@@ -599,6 +631,8 @@ private:
     ReverbLine tap_line_;
     int tap_l_ = 0, tap_r_ = 0;
     float tap_fb_ = 0.0f;
+    float echo_ = 1.0f;
+    float pol_r_ = 1.0f;
 };
 
 }  // namespace d5


### PR DESCRIPTION
Closes nothing by itself; part of the #142 effect calibration (after #146 Output Mode and #147 chorus).

**Source:** Michael's fourteen VST recordings (one note per reverb type, balance 100) plus the dry reference. The source releases at 55 dB/s, so short rooms and gates only yield an upper bound (~1 s); halls and delays are measurable.

**Measured on the VST → set in `kReverbTypes`**

| Type | VST T60 | ours before | ours now |
|---|---|---|---|
| 1 Small Hall | 1.5 s | 0.91 | 1.41 |
| 2 Medium Hall | 2.9 | 4.76 | 2.87 |
| 3 Large Hall | 3.3 | 3.92 | 3.30 |
| 4 Chapel | 6.5 | 3.07 | 6.92 |
| 8 Medium Room | ≤ 1 | 1.73 | 0.91 |
| 9 Medium Large Room | 2.0 | 1.32 | 1.98 |
| 10 Large Room | 2.1, sides inverted (corr −0.95) | 2.35, corr 0 | 1.99, corr −1.00 |
| 12 Cross Delay 180 | ≤ 1, right direct / left 180 | symmetric taps | right direct, left 180 at 0.35 |
| 20 Delay 248 | 2.7, left inverted | 1.49 | 2.74, left inverted |
| 23 Cross Delay 252 | 2.4, in phase | 1.51 | 2.43 |

The remaining delay rows follow their measured siblings; the right/left level ratios of the delays land at 2.0–2.9 (VST 2.0–3.2), and their wet factor drops to 1.2 so the direct copy sits at the halls' wet level.

**Two defects fixed**
- `configure()` compared the zero-based row with panel numbers 17/18: Bright Hall got the cave's loop damping and rang forever at 140 Hz (−49 dB, never decaying). Large Cave now 4.4 s at fb 0.46.
- A 0 ms tap read the oldest word of the line (0.5 s), not the word just written.

**Verification:** host sweep over all 32 types (T60, residual at 9 s, L/R correlation, first-echo positions, level ratio, wet level), `tools/host_tests/d5` 18/18, stress over 384 patches finite. Firmware builds (RAM 52 %).

**Hearing test candidates:** any Chapel patch (Cathedral Organ 1-24, Pizzagogo 1-28, Staccato Heaven 1-41) — twice as long as before; Medium Hall patches (Fantasia 1-01, Arco Strings 1-04) — noticeably shorter; Legato Strings 1-44 (Delay 248) and Living Calliope 1-06 (Cross Delay 252) — the echo now starts on the right; Bright Hall (panel 17) no longer leaves a tone in the silence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
