### PR TITLE
PicoFaceD5: gate reverbs follow the send, cutoff ceiling 218 (Intruder FX)

### DIFF
--- a/instruments/PicoFaceD5/include/d5_engine/d5_effects.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_effects.h
@@ -482,6 +482,9 @@ public:
         pol_r_ = t.pol_r;
         mode_ = t.mode < 3 ? t.mode : 3;
         age_ = 0;
+        follow_ = 0.0f;
+        hold_ = 0;
+        gain_ = 0.0f;
         gate_ = static_cast<int>(t.gate_ms * 0.001f * sr);
         reverse_ = static_cast<int>(t.reverse_ms * 0.001f * sr);
         if (mode_ < 3) {
@@ -588,12 +591,28 @@ public:
         // one-sample cut of a sounding tail reads as a pop.
         float g = 1.0f;
         if (gate_ > 0) {
-            const int fade = static_cast<int>(sr_ * 0.005f);
-            g = age_ < gate_ ? 1.0f
-                : (age_ < gate_ + fade
-                       ? 1.0f - static_cast<float>(age_ - gate_) / fade
-                       : 0.0f);
-            ++age_;
+            // The gate follows the send, not the note: a gated reverb opens
+            // while its input is above the threshold and closes the gate
+            // time after it fell below. Intruder FX is the proof -- Long
+            // Gate at balance 100 (no dry at all) under an Upper tone that
+            // swells in over seconds and releases over more: cut 480 ms
+            // after the note starts, the patch was a half-second blip and
+            // then digital silence under the held key. Followed, the tail
+            // rides through, and the release is cut 480 ms after it sinks
+            // under the threshold -- the tone after the key that the VST
+            // plays. Threshold and hold are PLAUSIBLE, not measured.
+            const float a = x < 0.0f ? -x : x;
+            follow_ = a > follow_ ? a : follow_ * kFollowDecay;
+            if (follow_ > kGateThreshold) {
+                hold_ = gate_;
+            } else if (hold_ > 0) {
+                --hold_;
+            }
+            const float step = 1.0f / (sr_ * 0.005f);   // 5 ms ramps
+            const float target = hold_ > 0 ? 1.0f : 0.0f;
+            gain_ += gain_ < target ? (target - gain_ < step ? target - gain_ : step)
+                                    : (gain_ - target < step ? target - gain_ : -step);
+            g = gain_;
         } else if (reverse_ > 0) {
             const int fade = static_cast<int>(sr_ * 0.005f);
             g = age_ < reverse_ ? static_cast<float>(age_) / reverse_
@@ -622,6 +641,13 @@ private:
     int gate_ = 0;
     int reverse_ = 0;
     int age_ = 0;
+    // Gate follower state: rectified send with a 30 ms decay, the hold
+    // countdown, and the ramped gain.
+    static constexpr float kGateThreshold = 1e-5f;     // -100 dBFS on x: the VST's Long Gate cuts Intruder FX only at -106 dB, i.e. when the input is gone
+    static constexpr float kFollowDecay = 0.99896f;    // exp(-1/(0.03*32000))
+    float follow_ = 0.0f;
+    int hold_ = 0;
+    float gain_ = 0.0f;
 
     float pool_[kPool] = {};
     ReverbAllpass ap_[3];

--- a/instruments/PicoFaceD5/include/d5_engine/d5_synth_voice.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_synth_voice.h
@@ -228,7 +228,7 @@ public:
         // mod.cutoff arrives on the old 0..1 scale from the LFO routes;
         // 100 units span that scale, same as the panel byte.
         float cv = base_cv_ + env_units_ * 100.0f * env + mod.cutoff * 100.0f;
-        if (cv > 240.0f) cv = 240.0f;                       // the chip's clamp
+        if (cv > kCutoffCeiling) cv = kCutoffCeiling;       // the chip's clamp
         edge_frac_ = 0.5f;
         inv_edge_ = 2.0f;
         atten_ = 1.0f;
@@ -417,6 +417,16 @@ private:
     float phase_ = 0.0f;
     float base_cv_ = 128.0f;       // cutoffVal at env 0, chip units
     float env_units_ = 0.0f;       // chip units per unit of envelope level
+    // Ceiling of the composed cutoff (base + envelope + modulation). munt
+    // reads 240 for the MT-32; Roland's D-50 VST says about 218: Intruder
+    // FX releases its TVF to full depth (target byte 66 on base 156, twice
+    // that in chip units) with resonance 30, and the peak settles at
+    // 3255 Hz -- 216 puts it at 3016, 220 at 3541. One key (C4) measured;
+    // whether the ceiling follows the key like the base cap is open.
+#ifndef D5_CUTOFF_CEILING
+#define D5_CUTOFF_CEILING 218.0f
+#endif
+    static constexpr float kCutoffCeiling = D5_CUTOFF_CEILING;
     float edge_frac_ = 0.5f;       // cosine edge as fraction of the period
     float inv_edge_ = 2.0f;        // 1/edge_frac_, a block constant
     float pulse_frac_ = 0.5f;

--- a/instruments/PicoFaceD5/include/d5_engine/d5_synth_voice.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_synth_voice.h
@@ -421,8 +421,11 @@ private:
     // reads 240 for the MT-32; Roland's D-50 VST says about 218: Intruder
     // FX releases its TVF to full depth (target byte 66 on base 156, twice
     // that in chip units) with resonance 30, and the peak settles at
-    // 3255 Hz -- 216 puts it at 3016, 220 at 3541. One key (C4) measured;
-    // whether the ceiling follows the key like the base cap is open.
+    // 3255 Hz -- 216 puts it at 3016, 220 at 3541. The ceiling is flat,
+    // not key-following like the base cap: at note 48 the VST's peak
+    // sits in the 1.6 kHz band and at note 72 near 5 kHz, which is what
+    // 218 gives at both (a key-following 234/202 would put them at 3.2
+    // and 2.5-3.2 kHz).
 #ifndef D5_CUTOFF_CEILING
 #define D5_CUTOFF_CEILING 218.0f
 #endif


### PR DESCRIPTION
Follow-up to #148, from Michael's Intruder FX recording on Roland's D-50 VST.

**Two things were wrong, both audible on Intruder FX (1-57):**

1. **The gate cut the whole patch.** Intruder runs Long Gate at reverb balance 100 (no dry) under an Upper tone that swells in over seconds. Our gate closed 480 ms after the note started, leaving a half-second blip and digital silence under the held key. The VST holds the tail through the whole 4.5 s release and cuts at −106 dB: a gated reverb follows its input. The gate now tracks a rectified send (30 ms decay, −100 dBFS threshold, 5 ms ramps). Reverse gates still key on the note.
2. **The tone after the key is the TVF release.** End level 1 drives the cutoff to full depth (firmware target byte 66 on base 156, IC25 0x0AC2–0x0AE8) with resonance 30; the VST's peak settles at 3255 Hz and stays. Ours hit munt's ceiling of 240 (an open sawtooth, weak peak near 7 kHz). The ceiling of the composed cutoff is now 218 (216 → 3016 Hz, 220 → 3541 Hz), `D5_CUTOFF_CEILING` overrides it.

| after key release | VST | before | now |
|---|---|---|---|
| 2.9–3.6 kHz band re fundamental | 0…+5 dB | −20…−28 dB | −4…−8 dB |
| tail | 4.5 s, cut at −106 dB | silence from 0.5 s | full release, cut when the input is gone |

**Open:** one key (C4) measured — whether the ceiling follows the key like the firmware's base cap needs Intruder FX at C2 and C5. Our resonance peak sits ~6 dB under the VST's.

Bank 1 at note 60 changes only on Spacious Sweep (+0.9 dB). Host tests 18/18, stress over 384 patches finite, firmware builds (RAM 52 %).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
