### PR TITLE
tools/d5_vst: automated comparison against Roland's D-50 VST

### DIFF
--- a/tools/d5_vst/.gitignore
+++ b/tools/d5_vst/.gitignore
@@ -1,0 +1,4 @@
+render_note
+__pycache__/
+.venv/
+*.csv

--- a/tools/d5_vst/README.md
+++ b/tools/d5_vst/README.md
@@ -1,0 +1,31 @@
+# D5 against Roland's D-50 VST, automated
+
+Renders the same factory patch through Roland's D-50 VST3 (via
+[pedalboard](https://github.com/spotify/pedalboard), no DAW) and through the
+D5 engine on the host, and compares them. The VST exposes the whole
+448-byte D-50 patch as parameters in SysEx order, so both sides play
+exactly the bytes the firmware plays.
+
+Local only: needs the Roland Cloud D-50 installed, a configured D5 build
+directory (the ROM set, `build-d5` by default) for the patch table and the
+PCM blob, and a Python venv.
+
+```bash
+python3 -m venv .venv && .venv/bin/pip install -r tools/d5_vst/requirements.txt
+tools/d5_vst/build_render.sh              # engine-side renderer
+.venv/bin/python tools/d5_vst/compare.py 3 21 36     # a few patches
+.venv/bin/python tools/d5_vst/compare.py --bank 1 --csv bank1.csv
+.venv/bin/python tools/d5_vst/compare.py --all --dry --csv all_dry.csv
+```
+
+Per patch: level under the note (V = VST, O = ours), tail one second
+after the key, spectral centroid, h2 and h5 re h1, L/R correlation, and
+how many bytes had to be clamped to the VST's parameter range (0 for the
+factory bank). `--dry` zeroes reverb and chorus balance on both sides,
+`--keep DIR` keeps the stereo f32 renders (32 kHz) for closer analysis.
+
+Traps found on the way: the VST renders silence at 32 kHz once a patch is
+set (it renders at 44.1 kHz and the tool resamples); changing the sample
+rate on one plugin instance hangs it; program change and SysEx do
+nothing, the parameters are the only way in. `d5vst.py` is the mapper
+(`set_patch(bytes448)`, `render(note, vel, hold, tail, sr)`).

--- a/tools/d5_vst/build_render.sh
+++ b/tools/d5_vst/build_render.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Builds the engine-side renderer against a configured D5 build directory
+# (default build-d5), which carries the generated patch table.
+set -e
+cd "$(dirname "$0")/../.."
+BUILD=${1:-build-d5}
+clang++ -std=c++17 -O2 -DD5_HOST_BUILD -Iinstruments/PicoFaceD5/include -Icore/include \
+    -I"$BUILD/PicoFaceD5_rom" tools/host_tests/d5/render_note.cpp -o tools/d5_vst/render_note
+echo "[ok] tools/d5_vst/render_note (pcm: $BUILD/PicoFaceD5_rom/d5_pcm.bin)"

--- a/tools/d5_vst/compare.py
+++ b/tools/d5_vst/compare.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+"""Render the same factory patch through Roland's D-50 VST and through the
+D5 engine, and compare: level under the note, tail one second after the
+key, harmonic profile, spectral centroid, stereo correlation.
+
+  compare.py [--note 60] [--vel 127] [--hold 1.5] [--tail 2.0] [--dry]
+             [--csv out.csv] [--keep DIR] IDX [IDX ...] | --all | --bank N
+
+Needs: tools/d5_vst/render_note (build_render.sh), the ROM build's
+d5_pcm.bin, and a venv with requirements.txt. The VST renders at 32 kHz,
+the engine's own rate, after rendering at 44.1 kHz (see below).
+"""
+import argparse, os, subprocess, sys, tempfile
+import numpy as np
+from scipy.signal import resample_poly
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from d5vst import D50VST, name_of
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+ROOT = os.path.abspath(os.path.join(HERE, '..', '..'))
+SR = 32000
+
+def metrics(x, hold, f0):
+    """x: (n, 2) float32 at 32 kHz. Levels in dB, profile re h1."""
+    m = x.mean(axis=1)
+    def lev(a, b):
+        seg = m[int(a*SR):int(b*SR)]; return 10*np.log10((seg**2).mean()+1e-20)
+    t1 = max(0.1, hold - 0.6)
+    seg = m[int(t1*SR):int(hold*SR)]
+    w = seg*np.hanning(len(seg)); S = np.abs(np.fft.rfft(w))**2; f = np.fft.rfftfreq(len(seg), 1/SR)
+    prof = [10*np.log10(S[(f > k*f0*0.97) & (f < k*f0*1.03)].max()+1e-20) for k in range(1, 11)]
+    band = (f > 30) & (f < 12000); cent = (f[band]*S[band]).sum()/(S[band].sum()+1e-20)
+    l, r = x[int(t1*SR):int(hold*SR), 0], x[int(t1*SR):int(hold*SR), 1]
+    corr = float(np.corrcoef(l, r)[0, 1]) if l.std() > 0 and r.std() > 0 else 1.0
+    env = [lev(t, t+0.1) for t in np.arange(0.0, hold+1.0, 0.1)]
+    return dict(hold=lev(t1, hold), attack=lev(0.0, 0.1), tail1=lev(hold+1.0, hold+1.5), tail2=lev(hold+1.5, hold+2.0),
+                centroid=cent, prof=[p-prof[0] for p in prof], corr=corr, peak=float(np.abs(x).max()), env=env)
+
+def render_ours(pcm, idx, note, vel, hold, tail, dry, out):
+    cmd = [os.path.join(HERE, 'render_note'), pcm, out, str(idx), str(note), str(vel), str(hold), str(tail)] + (['dry'] if dry else [])
+    subprocess.run(cmd, check=True)
+    return np.fromfile(out, dtype=np.float32).reshape(-1, 2)
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('idx', nargs='*', type=int)
+    ap.add_argument('--all', action='store_true'); ap.add_argument('--bank', type=int)
+    ap.add_argument('--note', type=int, default=60); ap.add_argument('--vel', type=int, default=127)
+    ap.add_argument('--hold', type=float, default=1.5); ap.add_argument('--tail', type=float, default=2.0)
+    ap.add_argument('--dry', action='store_true', help='reverb and chorus balance 0 on both sides')
+    ap.add_argument('--csv'); ap.add_argument('--keep', help='directory to keep the renders (f32 stereo)')
+    ap.add_argument('--pcm', default=os.path.join(ROOT, 'build-d5', 'PicoFaceD5_rom', 'd5_pcm.bin'))
+    a = ap.parse_args()
+    tmp = a.keep or tempfile.mkdtemp(prefix='d5vst_')
+    os.makedirs(tmp, exist_ok=True)
+    bankfile = os.path.join(tmp, 'bank.bin')
+    subprocess.run([os.path.join(HERE, 'render_note'), 'dumpbank', bankfile], check=True)
+    bank = open(bankfile, 'rb').read(); n_patches = len(bank)//448
+    idxs = list(range(n_patches)) if a.all else (list(range((a.bank-1)*64, a.bank*64)) if a.bank else a.idx)
+    vst = D50VST()
+    f0 = 440.0*2**((a.note-69)/12)
+    rows = []
+    print(f'{"idx":>4} {"name":20s} {"hold V/O":>13} {"dLev":>6} {"tail1 V/O":>13} {"dTail":>6} {"cent V/O":>11} {"h2 V/O":>11} {"h5 V/O":>11} {"corr V/O":>11} {"clamped":>7}')
+    for idx in idxs:
+        b = bank[idx*448:(idx+1)*448]
+        if a.dry:
+            b = bytearray(b); b[384+31] = 0; b[128+10+35] = 0; b[320+10+35] = 0; b = bytes(b)
+        log = vst.set_patch(b)
+        # The VST renders silence at 32 kHz once a patch is set; 44.1 kHz
+        # works, so it renders there and the comparison resamples (320/441).
+        x44 = vst.render(a.note, a.vel, a.hold, a.tail, 44100.0)
+        x_v = np.ascontiguousarray(resample_poly(x44, 320, 441, axis=1).T.astype(np.float32))
+        x_o = render_ours(a.pcm, idx, a.note, a.vel, a.hold, a.tail, a.dry, os.path.join(tmp, f'ours_{idx}.f32'))
+        if a.keep: x_v.tofile(os.path.join(tmp, f'vst_{idx}.f32'))
+        mv, mo = metrics(x_v, a.hold, f0), metrics(x_o, a.hold, f0)
+        name = name_of(b)
+        print(f'{idx:4d} {name:20s} {mv["hold"]:6.1f}/{mo["hold"]:6.1f} {mo["hold"]-mv["hold"]:6.1f} {mv["tail1"]:6.1f}/{mo["tail1"]:6.1f} {mo["tail1"]-mv["tail1"]:6.1f} {mv["centroid"]:5.0f}/{mo["centroid"]:5.0f} {mv["prof"][1]:5.1f}/{mo["prof"][1]:5.1f} {mv["prof"][4]:5.1f}/{mo["prof"][4]:5.1f} {mv["corr"]:5.2f}/{mo["corr"]:5.2f} {len(log):7d}', flush=True)
+        rows.append((idx, name, mv, mo, len(log)))
+    if a.csv:
+        with open(a.csv, 'w') as f:
+            f.write('idx,name,hold_vst,hold_ours,tail1_vst,tail1_ours,tail2_vst,tail2_ours,attack_vst,attack_ours,centroid_vst,centroid_ours,corr_vst,corr_ours,peak_vst,peak_ours,clamped,' + ','.join(f'h{k}_vst' for k in range(2, 11)) + ',' + ','.join(f'h{k}_ours' for k in range(2, 11)) + '\n')
+            for idx, name, mv, mo, cl in rows:
+                f.write(f'{idx},"{name}",{mv["hold"]:.2f},{mo["hold"]:.2f},{mv["tail1"]:.2f},{mo["tail1"]:.2f},{mv["tail2"]:.2f},{mo["tail2"]:.2f},{mv["attack"]:.2f},{mo["attack"]:.2f},{mv["centroid"]:.0f},{mo["centroid"]:.0f},{mv["corr"]:.3f},{mo["corr"]:.3f},{mv["peak"]:.4f},{mo["peak"]:.4f},{cl},' + ','.join(f'{v:.1f}' for v in mv['prof'][1:]) + ',' + ','.join(f'{v:.1f}' for v in mo['prof'][1:]) + '\n')
+    if len(rows) > 1:
+        d = np.array([mo['hold']-mv['hold'] for _, _, mv, mo, _ in rows]); dt = np.array([mo['tail1']-mv['tail1'] for _, _, mv, mo, _ in rows])
+        dc = np.array([1200*np.log2(mo['centroid']/mv['centroid']) for _, _, mv, mo, _ in rows if mv['centroid'] > 0 and mo['centroid'] > 0])
+        print(f'\n{len(rows)} patches: level ours-VST median {np.median(d):+.1f} dB (p10 {np.percentile(d,10):+.1f}, p90 {np.percentile(d,90):+.1f}); tail+1s median {np.median(dt):+.1f} dB; centroid median {np.median(dc):+.0f} cents (p10 {np.percentile(dc,10):+.0f}, p90 {np.percentile(dc,90):+.0f})')
+if __name__ == '__main__':
+    main()

--- a/tools/d5_vst/compare.py
+++ b/tools/d5_vst/compare.py
@@ -22,12 +22,14 @@ SR = 32000
 
 def metrics(x, hold, f0):
     """x: (n, 2) float32 at 32 kHz. Levels in dB, profile re h1."""
-    m = x.mean(axis=1)
+    # Levels and spectra as the power mean of both channels, never the mono
+    # fold: a reverb with inverted sides (Large Room) cancels in L+R.
     def lev(a, b):
-        seg = m[int(a*SR):int(b*SR)]; return 10*np.log10((seg**2).mean()+1e-20)
+        seg = x[int(a*SR):int(b*SR)]; return 10*np.log10((seg**2).mean()+1e-20)
     t1 = max(0.1, hold - 0.6)
-    seg = m[int(t1*SR):int(hold*SR)]
-    w = seg*np.hanning(len(seg)); S = np.abs(np.fft.rfft(w))**2; f = np.fft.rfftfreq(len(seg), 1/SR)
+    seg = x[int(t1*SR):int(hold*SR)]
+    w = np.hanning(len(seg))[:, None]
+    S = (np.abs(np.fft.rfft(seg*w, axis=0))**2).sum(axis=1); f = np.fft.rfftfreq(len(seg), 1/SR)
     prof = [10*np.log10(S[(f > k*f0*0.97) & (f < k*f0*1.03)].max()+1e-20) for k in range(1, 11)]
     band = (f > 30) & (f < 12000); cent = (f[band]*S[band]).sum()/(S[band].sum()+1e-20)
     l, r = x[int(t1*SR):int(hold*SR), 0], x[int(t1*SR):int(hold*SR), 1]

--- a/tools/d5_vst/d5vst.py
+++ b/tools/d5_vst/d5vst.py
@@ -1,0 +1,43 @@
+"""Drive Roland's D-50 VST3 from the 448-byte D-50 patch format (pedalboard host)."""
+import numpy as np
+from pedalboard import load_plugin
+from mido import Message
+
+PLUGIN = '/Library/Audio/Plug-Ins/VST3/Roland/D-50.vst3'
+
+class D50VST:
+    def __init__(self, path=PLUGIN):
+        self.p = load_plugin(path)
+        self.names = list(self.p.parameters.keys())
+        n = self.names
+        assert n[0] == 'upper1_wg_coarse_tune' and n[54] == 'upper2_wg_coarse_tune' and n[108] == 'upper_structure'
+        assert n[146] == 'lower1_wg_coarse_tune' and n[200] == 'lower2_wg_coarse_tune' and n[254] == 'lower_structure'
+        assert n[292] == 'key_mode' and n[310] == 'chase_time' and n[145] == 'upper_partial_bal'
+        self.ranges = {k: self.p.parameters[k].range for k in n}
+
+    def _set(self, name, value, log):
+        lo, hi, _ = self.ranges[name]
+        v = float(value)
+        if v < lo or v > hi:
+            log.append(f'{name}={value} clamped to [{lo:.0f},{hi:.0f}]'); v = min(max(v, lo), hi)
+        setattr(self.p, name, v)
+
+    def set_patch(self, b):
+        """b: 448 bytes in SysEx order UP1 UP2 UC LP1 LP2 LC PATCH (64 each)."""
+        assert len(b) == 448
+        log = []
+        for tone, base, pidx in (('upper', 0, 0), ('lower', 192, 146)):
+            for k in range(54): self._set(self.names[pidx + k], b[base + k], log)
+            for k in range(54): self._set(self.names[pidx + 54 + k], b[base + 64 + k], log)
+            for k in range(38): self._set(self.names[pidx + 108 + k], b[base + 128 + 10 + k], log)
+        for k in range(19): self._set(self.names[292 + k], b[384 + 18 + k], log)
+        return log
+
+    def render(self, note=60, vel=127, hold=1.0, tail=2.0, sr=44100.0):
+        msgs = [Message('note_on', note=note, velocity=vel, time=0.0), Message('note_off', note=note, velocity=0, time=hold)]
+        a = self.p(msgs, duration=hold + tail, sample_rate=sr, reset=True)
+        return a  # (2, n)
+
+def name_of(b):
+    alpha = ' ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz1234567890-'
+    return ''.join(alpha[c] if c < len(alpha) else '?' for c in b[384:402]).strip()

--- a/tools/d5_vst/requirements.txt
+++ b/tools/d5_vst/requirements.txt
@@ -1,0 +1,4 @@
+pedalboard>=0.9
+mido>=1.3
+numpy>=1.24
+scipy>=1.10

--- a/tools/host_tests/d5/render_note.cpp
+++ b/tools/host_tests/d5/render_note.cpp
@@ -1,0 +1,79 @@
+// Render one note of a factory patch through the D5 engine, stereo f32 at
+// 32 kHz, for the VST comparison in tools/d5_vst. Needs the ROM build
+// (d5_patch_data.h and d5_pcm.bin from the configured build directory).
+//
+//   render_note <d5_pcm.bin> <out.f32> <patch index> <note> <velocity 1..127>
+//               <hold s> <tail s> [dry]
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <fstream>
+#include <vector>
+#include "d5_engine/d5_patch.h"
+#include "d5_engine/d5_patch_map.h"
+#include "d5_patch_data.h"
+
+static std::vector<int16_t> load_blob(const char* p) {
+    std::ifstream f(p, std::ios::binary);
+    std::vector<int16_t> v;
+    int16_t w;
+    while (f.read(reinterpret_cast<char*>(&w), 2)) v.push_back(w);
+    return v;
+}
+
+int main(int argc, char** argv) {
+    // "render_note dumpbank out.bin" writes the 384 x 448 patch bytes the
+    // engine plays, so the VST side gets exactly the same bytes.
+    if (argc == 3 && std::strcmp(argv[1], "dumpbank") == 0) {
+        std::ofstream f(argv[2], std::ios::binary);
+        for (int i = 0; i < d5::kPatchCount; ++i)
+            f.write(reinterpret_cast<const char*>(d5::kPatchData[i]), 448);
+        std::FILE* n = std::fopen((std::string(argv[2]) + ".names").c_str(), "w");
+        for (int i = 0; i < d5::kPatchCount; ++i) std::fprintf(n, "%d\t%s\n", i, d5::kPatchNames[i]);
+        std::fclose(n);
+        return 0;
+    }
+    if (argc < 8) {
+        std::fprintf(stderr, "usage: render_note pcm.bin out.f32 idx note vel hold tail [dry]\n"
+                             "       render_note dumpbank out.bin\n");
+        return 2;
+    }
+    const float kSR = 32000.0f;
+    auto blob = load_blob(argv[1]);
+    const int idx = std::atoi(argv[3]);
+    const int note = std::atoi(argv[4]);
+    const float vel = std::atof(argv[5]) / 127.0f;   // the engine takes 0..1
+    const float hold = std::atof(argv[6]);
+    const float tail = std::atof(argv[7]);
+    const bool dry = argc > 8 && std::strcmp(argv[8], "dry") == 0;
+    if (idx < 0 || idx >= d5::kPatchCount) return 2;
+    d5::PatchSpec s = d5::patch_from_bytes(d5::kPatchData[idx], blob.data());
+    if (dry) {
+        s.reverb.balance = 0.0f;
+        s.upper.chorus.balance = 0.0f;
+        s.lower.chorus.balance = 0.0f;
+    }
+    d5::Patch p;
+    p.configure(s, kSR);
+    p.note_on(note, vel);
+    std::vector<float> o;
+    o.reserve(static_cast<size_t>(kSR * (hold + tail)) * 2);
+    for (int i = 0; i < static_cast<int>(kSR * hold); ++i) {
+        float l, r;
+        p.next_stereo(l, r);
+        o.push_back(l);
+        o.push_back(r);
+    }
+    p.note_off(note);
+    for (int i = 0; i < static_cast<int>(kSR * tail); ++i) {
+        float l, r;
+        p.next_stereo(l, r);
+        o.push_back(l);
+        o.push_back(r);
+    }
+    std::ofstream f(argv[2], std::ios::binary);
+    f.write(reinterpret_cast<const char*>(o.data()), o.size() * sizeof(float));
+    return 0;
+}


### PR DESCRIPTION
Roland's D-50 VST3 loads headless in [pedalboard](https://github.com/spotify/pedalboard) and exposes the whole 448-byte D-50 patch as parameters in SysEx order. So both sides can play exactly the bytes the firmware plays, and every comparison that took one recording per round so far becomes one command.

- `d5vst.py`: `set_patch(bytes448)`, `render(note, vel, hold, tail, sr)`; the factory bank maps with zero clamped bytes.
- `tools/host_tests/d5/render_note.cpp`: the engine side, same bytes, stereo f32 at 32 kHz; also dumps the bank.
- `compare.py`: per patch level under the note, tail at +1 s, centroid, h2/h5 re h1, L/R correlation; `--bank N`, `--all`, `--dry`, `--csv`.

First five patches (wet, note 60, vel 127):

| patch | level ours−VST | tail ours−VST | centroid V/O |
|---|---|---|---|
| Fantasia | −7.3 dB | −6.0 | 318/305 Hz |
| Arco Strings | −6.7 | −3.6 | 376/390 |
| Pipe Solo | −9.6 | −18.3 | 566/863 |
| Stereo Polysynth | +1.0 | +6.2 | 175/149 |
| Intruder FX | −6.8 | −13.1 | 317/391 |

Traps documented in the README: silence at 32 kHz once a patch is set (renders at 44.1 kHz, resampled), sample-rate change hangs the instance, program change and SysEx are inert. Local only; nothing of it reaches the firmware or CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
