### PR TITLE
PicoFaceD5: key modes as the D-50 VST plays them, solo per split side

### DIFF
--- a/instruments/PicoFaceD5/include/d5_engine/d5_patch.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_patch.h
@@ -125,7 +125,10 @@ public:
         return true;
     }
 
-    void note_off(int note) {
+    // cut: the solo modes replace the old note rather than release it --
+    // Roland's D-50 VST drops it by 67 dB within 200 ms where our envelope
+    // release still held it at -21; a 20 ms fade cannot click.
+    void note_off(int note, bool cut = false) {
         for (int i = 0; i < kVoices; ++i) {
             // Keyed by the KEY, not by whether the voice still sounds:
             // the firmware's key array outlives the envelope, so a
@@ -134,7 +137,10 @@ public:
             // back when it does.
             if (!key_[i] || note_[i] != note) continue;
             key_[i] = false;
-            if (active_[i]) voices_[i].note_off();
+            if (active_[i]) {
+                if (cut) voices_[i].quick_release();
+                else voices_[i].note_off();
+            }
             // The slot rejoins the pool at key-up, not when its release
             // ends -- that is what lets a fast passage keep taking voices
             // whose tails are still audible.
@@ -304,6 +310,11 @@ struct PatchSpec {
     // The "-S" key modes (WHOL-S, DUAL-S, SEP-S) play monophonically: one
     // note at a time, the new note ends the old one's hold at once.
     bool solo = false;
+    // The split solo modes (SPL-US, SPL-LS) hold one note per side only:
+    // Roland's D-50 VST plays byte 5 as a split with a polyphonic Lower
+    // and a monophonic Upper, byte 6 the other way round.
+    bool solo_upper = false;
+    bool solo_lower = false;
     int split_point = 60;         // panel "Split Point", C4 by default
     float balance = 0.5f;         // panel "Tone Balance", upper to lower
     // Panel "Bender Range", pb[26], 0..12 semitones. Patch-common: the
@@ -355,7 +366,7 @@ public:
         upper_.silence();
         lower_.silence();
         reverb_.configure(spec_.reverb, sr_);
-        solo_note_ = -1;
+        solo_note_[0] = solo_note_[1] = -1;
     }
 
     void configure(const PatchSpec& spec, float sample_rate) {
@@ -377,39 +388,43 @@ public:
         // release segment rather than cutting it -- close enough to the
         // steal that no factory patch tells them apart, and it cannot
         // click.
-        if (spec_.solo && solo_note_ >= 0 && solo_note_ != note) {
-            upper_.note_off(solo_note_);
-            lower_.note_off(solo_note_);
-        }
         bool sounded = false;
         switch (spec_.key_mode) {
             case KeyMode::kDual: {
+                if (spec_.solo) solo_cut(0, note), solo_cut(1, note);
                 const bool u = upper_.note_on(note, velocity);
                 const bool l = lower_.note_on(note, velocity);
                 sounded = u || l;
+                if (spec_.solo) solo_note_[0] = solo_note_[1] = note;
                 break;
             }
-            case KeyMode::kSplit:
-                sounded = (note >= spec_.split_point)
-                              ? upper_.note_on(note, velocity)
-                              : lower_.note_on(note, velocity);
+            case KeyMode::kSplit: {
+                const int side = note >= spec_.split_point ? 0 : 1;
+                const bool solo = side == 0 ? spec_.solo_upper : spec_.solo_lower;
+                if (solo) solo_cut(side, note);
+                sounded = side == 0 ? upper_.note_on(note, velocity)
+                                    : lower_.note_on(note, velocity);
+                if (solo) solo_note_[side] = note;
                 break;
+            }
             case KeyMode::kWhole:
             default:
+                if (spec_.solo) solo_cut(0, note);
                 sounded = upper_.note_on(note, velocity);
+                if (spec_.solo) solo_note_[0] = note;
                 break;
         }
         // The gate and reverse reverbs time their wet envelope against the
         // note; a note the pool refused never reached the chip, so it must
         // not re-arm them either.
         if (sounded) reverb_.note_activity();
-        if (spec_.solo) solo_note_ = note;
     }
 
     void note_off(int note) {
         upper_.note_off(note);
         lower_.note_off(note);
-        if (note == solo_note_) solo_note_ = -1;
+        for (int i = 0; i < 2; ++i)
+            if (note == solo_note_[i]) solo_note_[i] = -1;
     }
 
     // Mono fold is the L/MONO jack again: the left side as it ships. In the
@@ -565,7 +580,15 @@ private:
     Tone<8> lower_{};
     Reverb reverb_{};
     float sr_ = 32000.0f;
-    int solo_note_ = -1;          // the solo modes' single held note
+    int solo_note_[2] = {-1, -1}; // the solo modes' held note per tone (0 upper, 1 lower)
+
+    // A solo side ends its previous note when a new one arrives.
+    void solo_cut(int side, int note) {
+        if (solo_note_[side] >= 0 && solo_note_[side] != note) {
+            if (side == 0) upper_.note_off(solo_note_[side], true);
+            else lower_.note_off(solo_note_[side], true);
+        }
+    }
 };
 
 }  // namespace d5

--- a/instruments/PicoFaceD5/include/d5_engine/d5_patch_map.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_patch_map.h
@@ -460,24 +460,26 @@ inline PatchSpec patch_from_bytes(const uint8_t* patch, const int16_t* blob) {
     map_common(patch_block(patch, kBlkLowerCommon), p.lower);
 
     const uint8_t* pb = patch_block(patch, kBlkPatch);
-    // Key modes 0..8 (D-05 UI strings at BQ3 0x164628: WHOLE, DUAL, SEP,
-    // DUAL-S, WHOL-S, SEP-S, SPL-LS, SPL-US, SPLIT -- the string order is
-    // the panel menu, not the byte: drums-set splits sit on byte 2, so byte
-    // 2 must be SPLIT, and the bank's solo leads sit on 4/5 with names like
-    // "Monophonic Lead"). The -S bytes are the monophonic family; byte 5
-    // must route both tones, because four factory patches on it carry the
-    // upper tone muted -- with upper-only routing they would be dead
-    // presets (they were, before this mapping). Separate folds onto dual:
-    // its difference is the output jack, not the sound.
+    // Key modes 0..8 as Roland's D-50 VST plays them, probed with a
+    // split-friendly patch (Output Mode 2 puts the Lower left and the Upper
+    // right) at notes 48 and 72 plus two overlapping notes for the solo
+    // test: 0 WHOLE, 1 DUAL, 2 SPLIT, 3 WHOL-S, 4 DUAL-S, 5 SPL-US (split,
+    // Upper solo, Lower polyphonic), 6 SPL-LS, 7 SEP and 8 SEP-S (separate
+    // channels; on one channel the VST plays them as a split with a
+    // monophonic Lower). The earlier reading had 3/4/5/8 shifted and made
+    // byte 5 route both tones everywhere, which woke five "dead" presets --
+    // they are split basses whose muted Upper is silent above C4 in the VST
+    // too (Hammer Feel, DoubleGritBs, MoonStroller Bs, MultiMod Ld,
+    // Synthectric Bass).
     switch (pb[18]) {
-        case 3:                                   // SEPARATE
         case 1:  p.key_mode = KeyMode::kDual;  break;
-        case 2:
-        case 6:                                   // SPL-LS
-        case 7:  p.key_mode = KeyMode::kSplit; break;   // SPL-US
-        case 4:  p.key_mode = KeyMode::kWhole; p.solo = true; break;  // WHOL-S
-        case 5:                                   // DUAL-S
-        case 8:  p.key_mode = KeyMode::kDual;  p.solo = true; break;  // SEP-S
+        case 2:  p.key_mode = KeyMode::kSplit; break;
+        case 3:  p.key_mode = KeyMode::kWhole; p.solo = true; break;   // WHOL-S
+        case 4:  p.key_mode = KeyMode::kDual;  p.solo = true; break;   // DUAL-S
+        case 5:  p.key_mode = KeyMode::kSplit; p.solo_upper = true; break;   // SPL-US
+        case 6:                                                        // SPL-LS
+        case 7:                                                        // SEP
+        case 8:  p.key_mode = KeyMode::kSplit; p.solo_lower = true; break;   // SEP-S
         default: p.key_mode = KeyMode::kWhole; break;
     }
     p.split_point = 36 + pb[19];                 // panel C2..C7


### PR DESCRIPTION
First result of the automated VST comparison (#151): a bank sweep showed five patches that our engine plays at C4 while the VST is silent there.

**Probe.** Stereo Polysynth with Output Mode 2 (Lower left, Upper right), all nine key-mode bytes, notes 48 and 72, plus two overlapping notes:

| byte | VST | ours before | ours now |
|---|---|---|---|
| 0 | WHOLE | whole | whole |
| 1 | DUAL | dual | dual |
| 2 | SPLIT | split | split |
| 3 | WHOL-S | dual | whole, solo |
| 4 | DUAL-S | whole, solo | dual, solo |
| 5 | SPL-US (Upper solo, Lower poly) | dual, solo, both tones everywhere | split, Upper solo |
| 6 | SPL-LS | split | split, Lower solo |
| 7 / 8 | split, Lower solo (one channel) | split / dual solo | split, Lower solo |

Byte 5's old reading had woken five "dead" presets (Hammer Feel, DoubleGritBs, MoonStroller Bs, MultiMod Ld, Synthectric Bass). They are split basses: the VST is silent above C4 on them too. The bank uses 0, 1, 2, 4 (one patch) and 5 (13 patches).

**Solo cut.** A solo side now replaces its old note with a 20 ms cut; the VST drops it by 67 dB within 200 ms, our envelope release kept it at −21 dB. Host test: −80 dB, the same as never played.

Host tests 18/18, stress over 384 patches finite, firmware builds (RAM 52 %).

**Hearing test:** Mono Octabass 2-39 (DUAL-S) and the 13 byte-5 patches — the basses stop above C4, the leads (Lead with Joystk 2-03, Gargle Lead 2-19, TrashTalk Ld 2-43) are monophonic above the split only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
