### PR TITLE
PicoFaceD5: output mode gains as the VST mixes them (mode 1 half, modes 2-4 full)

### DIFF
--- a/instruments/PicoFaceD5/include/d5_engine/d5_patch.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_patch.h
@@ -434,7 +434,7 @@ public:
     float D5_HOT(next)() {
         float l, r;
         next_stereo(l, r);
-        return spec_.output_mode == 0 ? l : 0.5f * (l + r);
+        return (spec_.key_mode == KeyMode::kWhole || spec_.output_mode == 0) ? l : 0.5f * (l + r);
     }
 
     // Stereo: the tones keep their own left and right through the balance
@@ -458,21 +458,30 @@ public:
         float ul, ur, ll, lr;
         upper_.next_stereo(ul, ur);
         lower_.next_stereo(ll, lr);
-        if (spec_.output_mode == 0) {
-            const float send = ul * uw + ll * lw;
-            reverb_.process(send, ul * uw + ll * lw, ur * uw + lr * lw, l, r);
+        // Output mode gains, measured on Roland's D-50 VST with one tone at
+        // a time (Stereo Polysynth and Arco Strings, dry): mode 1 puts each
+        // tone at HALF amplitude on both outputs, modes 2 to 4 put each tone
+        // at full amplitude on its own output -- 5.8 dB apart, the EPROM
+        // mixer's rows 0x80 against 0xFF. A whole patch ignores the output
+        // mode: both outputs, mode-1 level, in every mode. The reverb send
+        // is both tones at half in modes 1 and 2 (rows 80 80) and one tone
+        // at full in modes 3 and 4.
+        const int om = spec_.key_mode == KeyMode::kWhole ? 0 : spec_.output_mode;
+        if (om == 0) {
+            const float xl = 0.5f * (ul * uw + ll * lw);
+            const float xr = 0.5f * (ur * uw + lr * lw);
+            reverb_.process(xl, xl, xr, l, r);
         } else {
-            // Output modes 2-4: Lower left, Upper right, each tone as its
-            // L/MONO signal. Mode 2 sends both tones to the reverb and its
-            // return reaches both outputs (the VST puts the Upper's tail on
-            // the left at -48 dB, on the right at -41). Modes 3 and 4 send
-            // one tone, and its return stays on that tone's own side -- the
-            // other channel is digitally silent in the VST -- while the
-            // other tone goes to its output dry and whole, past the balance.
+            // Lower left, Upper right, each tone as its L/MONO signal. Mode
+            // 2 sends both tones and its return reaches both outputs (the
+            // VST puts the Upper's tail on the left at -48 dB, on the right
+            // at -41). Modes 3 and 4 send one tone, and its return stays on
+            // that tone's own side -- the other channel is digitally silent
+            // in the VST -- while the other tone goes to its output dry.
             const float lo = ll * lw, up = ul * uw;
-            if (spec_.output_mode == 1) {
-                reverb_.process(lo + up, lo, up, l, r);
-            } else if (spec_.output_mode == 2) {
+            if (om == 1) {
+                reverb_.process(0.5f * (lo + up), lo, up, l, r);
+            } else if (om == 2) {
                 reverb_.process(up, 0.0f, up, l, r);
                 l = lo;
             } else {

--- a/instruments/PicoFaceD5/include/d5_engine/d5_patch_map.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_patch_map.h
@@ -547,8 +547,11 @@ inline PatchSpec patch_from_bytes(const uint8_t* patch, const int16_t* blob) {
     // -3.9 dB across the whole bank. Roland's own level relationships are
     // untouched -- the spread from Glockenspiel to Power Key Bs is theirs and
     // stays -- this only moves the ceiling out of the way of it.
-    p.upper.level = 0.37f;
-    p.lower.level = 0.37f;
+    // Doubled from 0.37 when output mode 1 went to half amplitude per tone
+    // (d5_patch.h next_stereo): the mode-1 majority keeps its loudness, the
+    // 37 patches in modes 2-4 gain the 6 dB the VST gives them.
+    p.upper.level = 0.74f;
+    p.lower.level = 0.74f;
 
     // Portamento is patch-common: switch pb[41], time pb[28], and mode
     // pb[20] -- 0 = upper only, 1 = lower only, 2 = both (the U/L/UL of

--- a/instruments/PicoFaceD5/include/d5_presets.h
+++ b/instruments/PicoFaceD5/include/d5_presets.h
@@ -46,7 +46,7 @@ inline PatchSpec preset_common() {
     p.key_mode = KeyMode::kWhole;
     p.balance = 0.0f;                     // upper tone only until patches use both
     p.volume = 0.9f;
-    p.upper.level = 0.35f;      // same headroom the bank path took, see d5_patch_map.h
+    p.upper.level = 0.70f;      // same headroom the bank path took, see d5_patch_map.h
     p.upper.voice.balance = 0.5f;
     // a partial pair with an attack that decays and a sustain that holds
     p.upper.voice.pcm_env[0].t[0] = 0.002f;


### PR DESCRIPTION
From the automated VST comparison (#151): the dry bank sweep's clearest systematic term was output mode — the 37 patches in modes 2–4 sat 6 dB under the VST relative to everything else.

**Measured** (VST, one tone at a time, dry, per-channel level):

| | mode 1 | mode 2 | mode 3 |
|---|---|---|---|
| Stereo Polysynth, upper only | −23.5 both | −17.7 right | −16.6 right |
| Arco Strings, upper only | −20.2 both | −14.4 right | −13.4 right |
| whole patch | −23.7 both | −23.7 both | −23.7 both |

So mode 1 mixes each tone at half amplitude on both outputs, modes 2–4 at full on the tone's own output (5.8 dB, the EPROM mixer rows 0x80 vs 0xFF), and a whole patch ignores the mode. Ours had mode 1 at full on both sides, and a whole patch in mode 2 on the right only.

**Change:** mixer in `Patch::next_stereo` follows the measured law (send: both tones at half in modes 1/2, one tone at full in 3/4, wet/dry ratio unchanged); level base doubled (0.37 → 0.74) so the mode-1 majority keeps its loudness. Stereo Polysynth mode 2 now −17.1 dB right (VST −17.7).

Host tests 18/18, stress finite and none at full scale, firmware builds (RAM 52 %).

**Hearing test:** Jazz Guitar Duo 1-03, Stereo Polysynth 1-37, Picked Guitar Duo, Slap Bass n Brass 1-51, Pianissimo — 6 dB louder than before, as loud as their neighbours in the VST.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
