### PR TITLE
PicoFaceD5: linear LFO depths, log-domain envelope rises, EQ makeup (VST probes)

### DIFF
--- a/instruments/PicoFaceD5/include/d5_engine/d5_effects.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_effects.h
@@ -119,11 +119,19 @@ public:
         const int hq = clamp_index(spec.high_q, 9);
         low_.set_low_shelf(kLowEqFreq[lf], spec.low_gain_db, sr);
         high_.set_peaking(kHighEqFreq[hf], kHighEqQ[hq], spec.high_gain_db, sr);
+        // A boost costs headroom: Roland's D-50 VST pulls the whole signal
+        // down by half the boost (+12 dB low shelf: shelf +5.5, the rest
+        // -6.2; +6: +2.5 and -3.5), cuts leave the rest alone. Shape,
+        // corner frequencies and Q match ours without it.
+        const float boost = (spec.low_gain_db > 0.0f ? spec.low_gain_db : 0.0f)
+                          + (spec.high_gain_db > 0.0f ? spec.high_gain_db : 0.0f);
+        makeup_ = std::pow(10.0f, -0.5f * boost / 20.0f);
     }
 
-    float D5_HOT(process)(float x) { return high_.process(low_.process(x)); }
+    float D5_HOT(process)(float x) { return makeup_ * high_.process(low_.process(x)); }
 
 private:
+    float makeup_ = 1.0f;
     static int clamp_index(int v, int n) { return v < 0 ? 0 : (v >= n ? n - 1 : v); }
     Biquad low_{};
     Biquad high_{};

--- a/instruments/PicoFaceD5/include/d5_engine/d5_env.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_env.h
@@ -355,11 +355,14 @@ private:
         // precomputes to zero -- cut held notes to silence in one sample.
         // That was the light pop on every pluck released early.
         //
-        // Log-linear glide for FALLING segments only: a decay at constant
-        // dB/s is what the chip's linear log-domain ramp produces, but a
-        // rise in the log domain spends most of its time inaudibly near
-        // the floor -- attacks keep the linear ramp.
-        seg_log_ = spec_.log_segments && target < level_;
+        // Log-linear glide for every segment after the attack: the chip
+        // ramps its log-domain level at a constant rate in both directions,
+        // and Roland's D-50 VST shows it -- a T3 of 70 rising from 0 to 100
+        // climbs at 12.5 dB/s, straight in dB, from -35 to -3 dB in 2.6 s;
+        // the linear-amplitude rise we had reached -10 dB by 1.8 s where the
+        // VST was still at -23. The attack keeps the linear ramp (its law
+        // was calibrated that way on the VST's Arco onset).
+        seg_log_ = spec_.log_segments && (target < level_ || seg >= 1);
         // -60 dB, not -96: the last segment glides to "zero" through this
         // floor, and the deeper it lies the steeper that dive reads in
         // dB/s against what a recording shows.

--- a/instruments/PicoFaceD5/include/d5_engine/d5_patch_map.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_patch_map.h
@@ -69,11 +69,17 @@ inline constexpr float kDepthCurve[101] = {
     0.499967f, 0.535880f, 0.574344f, 0.615556f, 0.659776f, 0.707071f,
     0.757833f, 0.812259f, 0.870544f, 0.933015f, 1.000000f};
 
+// The three modulation routes read their depth LINEARLY -- Roland's D-50
+// VST, one partial with LFO-1 on the route: TVA depth 25/50/75/100 ducks
+// 4.4/8.7/13.1/17.5 dB peak to peak (a straight line, downward only),
+// the TVF cutoff swing and the pulse-width swing grow in the same steps.
+// Through kDepthCurve they were near-silent up to 75 and wild at 100 --
+// Ham and Organ and Star Peace Chorus sat 25 dB under the VST on it.
 inline LfoRoute lfo_route(uint8_t select, uint8_t depth) {
     LfoRoute r;
     const int s = select > 5 ? 0 : select;
     r.lfo = s / 2;
-    r.depth = ((s & 1) ? -1.0f : 1.0f) * kDepthCurve[depth > 100 ? 100 : depth];
+    r.depth = ((s & 1) ? -1.0f : 1.0f) * (depth > 100 ? 100 : depth) * 0.01f;
     return r;
 }
 

--- a/instruments/PicoFaceD5/include/d5_engine/d5_voice.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_voice.h
@@ -56,6 +56,28 @@ inline constexpr Structure kStructures[7] = {
 
 // How far a partial follows one of the three LFOs. The panel writes this as
 // +1..+3 / -1..-3 (which LFO, and in which direction) plus a depth.
+#ifndef D5_TVA_LFO_DB
+#define D5_TVA_LFO_DB 17.5f
+#endif
+#ifndef D5_TVF_LFO_UNITS
+#define D5_TVF_LFO_UNITS 26.0f
+#endif
+#ifndef D5_PW_LFO_SWING
+#define D5_PW_LFO_SWING 0.55f
+#endif
+// Roland's D-50 VST, one partial with LFO-1 (rate 50) on the route:
+//   TVA: 4.4/8.7/13.1/17.5 dB peak to peak at depth 25/50/75/100, downward
+//        from the static level, a straight line.
+//   TVF: the centroid of a cutoff-50 sawtooth swings 560-612 / 543-646 /
+//        531-684 / 525-725 Hz; 26 units of swing reproduce it (24 -> 524-703).
+//   PW:  a square's duty reaches 0.355 / 0.248 / 0.168 / 0.106 at the narrow
+//        turn, i.e. 32 / 65 / 101 / 143 register units -- 1.3 per depth unit,
+//        so 0.55 of the 0..255 register at depth 100 (the wide turn stays at
+//        the 0.5 floor).
+inline constexpr float kTvaLfoDb = D5_TVA_LFO_DB;       // pk-pk duck at depth 100
+inline constexpr float kTvfLfoUnits = D5_TVF_LFO_UNITS; // cutoff swing amplitude at depth 100
+inline constexpr float kPwLfoSwing = D5_PW_LFO_SWING;   // of the 0..255 register at depth 100
+
 struct LfoRoute {
     int lfo = 0;            // 0..2
     float depth = 0.0f;     // -1..+1, sign is the panel's polarity
@@ -401,13 +423,20 @@ public:
                 partial_st != 0.0f ? fast_exp2(partial_st * (1.0f / 12.0f))
                                    : 1.0f;
             const float tgt_pitch = factor * ctl_bend * glide;
-            mod_[i].pw = 0.5f * spec_.pw_lfo[i].depth * lfo_value(l, spec_.pw_lfo[i])
+            // Route depths are linear 0..1 (d5_patch_map.h lfo_route), the
+            // VST's laws: the pulse width swings kPwLfoSwing of the 0..255
+            // register at full depth (the VST's swing hits the narrow floor
+            // from depth 50 on), the cutoff swings kTvfLfoUnits chip units,
+            // and the amplitude ducks kTvaLfoDb dB peak to peak, downward
+            // from the static level.
+            mod_[i].pw = kPwLfoSwing * spec_.pw_lfo[i].depth * lfo_value(l, spec_.pw_lfo[i])
                        + 0.65f * spec_.pw_at[i] * at_;
-            mod_[i].cutoff = 0.5f * spec_.tvf_lfo[i].depth * lfo_value(l, spec_.tvf_lfo[i])
+            mod_[i].cutoff = (kTvfLfoUnits / 100.0f) * spec_.tvf_lfo[i].depth * lfo_value(l, spec_.tvf_lfo[i])
                            + 0.65f * spec_.tvf_at[i] * at_;
-            // amplitude modulation only ever ducks, never boosts past unity
-            const float am = spec_.tva_lfo[i].depth * lfo_value(l, spec_.tva_lfo[i]);
-            float tgt_amp = 1.0f + 0.5f * (am - std::fabs(spec_.tva_lfo[i].depth));
+            const float tva_d = std::fabs(spec_.tva_lfo[i].depth);
+            const float tva_l = spec_.tva_lfo[i].depth < 0.0f ? -lfo_value(l, spec_.tva_lfo[i])
+                                                              : lfo_value(l, spec_.tva_lfo[i]);
+            float tgt_amp = fast_exp2(-kTvaLfoDb * tva_d * 0.5f * (1.0f - tva_l) * (1.0f / 6.0206f));
             // TVA aftertouch (ROM 0x11A9): a positive range rests ~3 dB down
             // and rises to unity at full press; a negative one ducks ~3 dB
             // (the ROM's scale is 2|s| chip units of 0.376 dB, i.e. ~5.3 dB


### PR DESCRIPTION
Single-partial probes against Roland's D-50 VST (via #151), chasing the remaining per-patch level spread after #153.

**Three laws corrected**

| law | VST | ours before | ours now |
|---|---|---|---|
| TVA LFO depth 25/50/75/100 | 4.4 / 8.7 / 13.1 / 17.5 dB pk-pk, downward | 0.3 / 0.5 / 1.9 / 39 dB | 4.4 / 8.6 / 12.9 / 17.2 |
| TVF LFO depth 100 (centroid swing) | 525–725 Hz | 523–878 (nothing below 75) | 523–715 |
| PW LFO depth 25/50/75/100 (narrow duty) | 0.355 / 0.248 / 0.168 / 0.106 | floor from 25 | 0.349 / 0.244 / 0.169 / 0.117 |
| TVA rise T3 70 (0 → 100) | straight in dB, −35 → −3 in 2.6 s | linear amplitude, −10 dB at 1.8 s | matches within 1 dB |
| EQ +12 dB boost | shelf +5.5, rest −6.2 (makeup −gain/2) | shelf +12, rest 0 | shelf +6, rest −6 |

The three depth routes had used Roland's pitch-depth curve (assigned by shape); Ham and Organ and Star Peace Chorus sat 25 dB under the VST on their tremolo, Classical Horn 8 dB above on its EQ.

**Probed and found correct:** TVA bias (four points × five levels × seven keys, shape identical), TVF keyfollow against coarse (kf 0/½/1/2 × coarse 24/36/48 × three keys, centroids within 2 %), release times, all 100 PCM wave levels (±1.4 dB) and pitches (except Loop19, an octave high — open).

Host tests 18/18, stress finite and none at full scale, firmware builds (RAM 52 %).

**Hearing test:** Ham and Organ 3-49 and Star Peace Chorus 3-57 (tremolo now audible and moderate), anything with a swelling envelope (Alienz in G 2-17, DigitalNativeDance 1-09, Intruder FX 1-57 — slower rises), Classical Horn 3-17 (EQ boost quieter), Rock Organ / rotary-style patches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Dry bank sweep (384 patches, note 60, vel 127), per-patch level spread after removing the median: std 4.2 → 3.2 dB, patches more than 6 dB off 44 → 20.** Largest remaining: Good and Old Days 3-52 (−15), Breeze Pipe 5-36 (−12), SlapBass-SynBrass 4-48 (−12), Harmonic E-Piano 4-11 (−11), F-1 Grand Prix 6-59 (−11).