### PR TITLE
PicoFaceD5: aftertouch, LFO shapes and the attack ramp as the VST plays them

### DIFF
--- a/instruments/PicoFaceD5/include/d5_engine/d5_env.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_env.h
@@ -26,6 +26,13 @@ struct Env5Spec {
     // dives. TVA envelopes set this; TVF keeps linear segments because its
     // output feeds a cutoff that is already exponential.
     bool log_segments = false;
+    // Amplitude of chip level 0 (100 units under full, -37.6 dB) for the
+    // TVA: a segment to level 0 ramps there in its own time and then keeps
+    // falling at that rate to silence -- the VST's fall from 48 to 0 at
+    // T4 68 runs at 25 dB/s where the fall from 100 runs at 52, the rate
+    // scaling with the start level, and both continue straight past -40
+    // to -80 dB. Zero (the default) keeps the plain floor.
+    float zero = 0.0f;
     // Per-segment decay RATES in dB/s, used for falling log segments when
     // non-zero. The LA chip's time bytes set rates, not durations -- the
     // proof is Horn Section, whose measured release of -37.8 dB/s equals
@@ -155,6 +162,11 @@ inline int tva_chip_level(int p35, int p36, int p14, bool is_pcm,
         bias = prod >> 5;
     }
     int chip = base + velT - bias;
+    // The chip level tops out at 142 -- Roland's D-50 VST: level 100 and
+    // level 90 with velocity sensitivity 100 both land at the same +4.2 dB
+    // over level 100's neutral at velocity 127, level 80 stays 3.8 dB
+    // under it, and a bias point below the key comes off before the cap.
+    if (chip > 142) chip = 142;
     return chip < 0 ? 0 : chip;
 }
 
@@ -214,6 +226,7 @@ inline void build_tva_env(const EnvBytes& b, int key, int vel127,
     const int kf = env_kf_shift(key, b.time_kf, 4);
     const int voff = (vel127 - 64) >> (6 - (b.vel_kf > 4 ? 4 : b.vel_kf));
     out.log_segments = true;
+    out.zero = level * fast_exp2(-6.25f);
     for (int k = 0; k < 3; ++k)
         out.l[k] = fast_exp2((static_cast<int>(b.l[k]) - 100) * 0.0625f) * level;
     out.sustain = b.l[3] == 0
@@ -300,8 +313,17 @@ public:
     }
 
     bool finished() const { return !held_ && seg_ >= 5; }
+    // Past chip zero the ramp keeps its rate down to -90 dB, then silence.
+    void coast_step() {
+        level_ *= factor_;
+        if (level_ <= 3.2e-5f) {
+            level_ = 0.0f;
+            coast_ = false;
+            if (!held_ && seg_ == 4) seg_ = 5;
+        }
+    }
     float level() const {
-        if (spec_.log_segments && level_ <= 1.05e-3f && remaining_ <= 0) return 0.0f;
+        if (spec_.log_segments && remaining_ <= 0 && !coast_ && level_ <= 1.05e-3f) return 0.0f;
         return level_ < 0.0f ? 0.0f : level_;
     }
 
@@ -321,6 +343,9 @@ public:
                 n -= k;
             } else if (held_ && seg_ < 3) {
                 arm(seg_ + 1, seg_ + 1 < 3 ? spec_.l[seg_ + 1] : spec_.sustain);
+            } else if (coast_) {
+                for (int32_t j = 0; j < n && coast_; ++j) coast_step();
+                break;
             } else if (held_) {
                 level_ = spec_.sustain;
                 break;
@@ -342,6 +367,8 @@ public:
             --remaining_;
         } else if (held_ && seg_ < 3) {
             arm(seg_ + 1, seg_ + 1 < 3 ? spec_.l[seg_ + 1] : spec_.sustain);
+        } else if (coast_) {
+            coast_step();
         } else if (held_ && seg_ == 3) {
             level_ = spec_.sustain;          // hold until release
         } else if (!held_ && seg_ == 4) {
@@ -375,9 +402,13 @@ private:
         // floor, and the deeper it lies the steeper that dive reads in
         // dB/s against what a recording shows.
         const float kFloor = 1.0e-3f;
+        coast_ = false;
         if (seg_log_) {
             const float from = level_ < kFloor ? kFloor : level_;
-            const float to = target < kFloor ? kFloor : target;
+            const float z = spec_.zero > kFloor ? spec_.zero : kFloor;
+            const bool to_zero = target <= z && (seg >= 3 || (seg == 4));
+            const float to = to_zero ? z : (target < kFloor ? kFloor : target);
+            coast_ = to_zero && spec_.zero > 0.0f;
             if (spec_.r[seg] > 0.0f) {
                 // Rate semantics: duration follows from the dB distance.
                 const float dist_db = 20.0f * std::log10(from / to);
@@ -409,6 +440,7 @@ private:
     float step_ = 0.0f;
     float factor_ = 1.0f;
     bool seg_log_ = false;
+    bool coast_ = false;          // ramping past chip zero at the segment's rate
     int32_t remaining_ = 0;
     int seg_ = 0;
     bool held_ = false;

--- a/instruments/PicoFaceD5/include/d5_engine/d5_env.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_env.h
@@ -225,11 +225,18 @@ inline void build_tva_env(const EnvBytes& b, int key, int vel127,
     // ~3 ms), NOT an instant jump -- a snapped attack steps the sample by
     // a quarter of full scale and crackles in sequences. Only a zero
     // target has no distance to travel.
+    // Duration against Roland's D-50 VST (one partial, L1 100, time to
+    // -1 dB): T1 40/50/60/70 take 0.07/0.16/0.38/0.89 s there, 0.53 of the
+    // firmware-index reading; a lower target lengthens the VST's attack
+    // only mildly (L1 50: x1.2, L1 25: x1.6), half the law's effect. And
+    // the chip climbs in the log domain here as well -- -20 dB at two
+    // thirds of the way, -6 dB at 0.9 -- so Env5 ramps the attack like
+    // the other segments (kFloor up).
     if (b.l[0] == 0) {
         out.t[0] = 0.0f;
     } else {
-        const int idx = env_clamp_idx(b.t[0] + env_law(b.l[0]) - voff - kf);
-        out.t[0] = env_ramp_seconds(160 + b.l[0], idx);
+        const int idx = env_clamp_idx(b.t[0] + env_law(b.l[0]) / 2 - voff - kf);
+        out.t[0] = env_ramp_seconds(160 + b.l[0], idx) * 0.53f;
     }
     out.r[0] = 0.0f;
     for (int k = 1; k < 4; ++k) {
@@ -355,14 +362,15 @@ private:
         // precomputes to zero -- cut held notes to silence in one sample.
         // That was the light pop on every pluck released early.
         //
-        // Log-linear glide for every segment after the attack: the chip
+        // Log-linear glide for every segment, the attack included: the chip
         // ramps its log-domain level at a constant rate in both directions,
         // and Roland's D-50 VST shows it -- a T3 of 70 rising from 0 to 100
         // climbs at 12.5 dB/s, straight in dB, from -35 to -3 dB in 2.6 s;
         // the linear-amplitude rise we had reached -10 dB by 1.8 s where the
-        // VST was still at -23. The attack keeps the linear ramp (its law
-        // was calibrated that way on the VST's Arco onset).
-        seg_log_ = spec_.log_segments && (target < level_ || seg >= 1);
+        // VST was still at -23. The attack reaches -20 dB at two thirds of
+        // its time and -6 dB at 0.9 (T1 60: 0.235/0.34/0.38 s), the mark
+        // of a rise from the floor at constant dB/s.
+        seg_log_ = spec_.log_segments;
         // -60 dB, not -96: the last segment glides to "zero" through this
         // floor, and the deeper it lies the steeper that dive reads in
         // dB/s against what a recording shows.

--- a/instruments/PicoFaceD5/include/d5_engine/d5_env.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_env.h
@@ -404,7 +404,14 @@ private:
         const float kFloor = 1.0e-3f;
         coast_ = false;
         if (seg_log_) {
-            const float from = level_ < kFloor ? kFloor : level_;
+            // A level already under the floor (a coasting tail) starts a
+            // FALLING segment from where it is -- raising it to the floor
+            // first put a -60 dB bump under every key-up of a percussive
+            // note, a faint ghost tone. Rises still start at the floor.
+            const float kBelow = 3.2e-5f;
+            const bool rising = target > level_;
+            const float lo = rising ? kFloor : kBelow;
+            const float from = level_ < lo ? lo : level_;
             const float z = spec_.zero > kFloor ? spec_.zero : kFloor;
             const bool to_zero = target <= z && (seg >= 3 || (seg == 4));
             const float to = to_zero ? z : (target < kFloor ? kFloor : target);
@@ -421,7 +428,7 @@ private:
             }
             step_ = 0.0f;
             factor_ = std::pow(to / from, 1.0f / static_cast<float>(remaining_));
-            if (level_ < kFloor) level_ = kFloor;
+            if (level_ < from) level_ = from;
             return;
         }
         if (spec_.r[seg] > 0.0f && target < level_) {

--- a/instruments/PicoFaceD5/include/d5_engine/d5_lfo.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_lfo.h
@@ -86,7 +86,13 @@ public:
         spec_ = spec;
         sr_ = sample_rate;
         inc_ = lfo_rate_hz(spec.rate) / sr_;
-        if (spec_.sync != 0) phase_ = 0.0f;
+        // A synced LFO starts at phase 0, the top of its triangle (Roland's
+        // D-50 VST: the vibrato starts at its highest pitch and falls, the
+        // tremolo fully ducked). A free-running one starts half a cycle
+        // in, at the bottom: the VST's rate-0 tremolo sits open right after
+        // the patch loads, and Ham and Organ lives on that.
+        phase_ = spec_.sync != 0 ? 0.0f : 0.5f;
+        half_ = phase_ >= 0.5f;
         rng_ = seed ? seed : 0x2545F491u;
         sample_ = next_random();
         restart_delay();
@@ -96,6 +102,7 @@ public:
     // its delay in the voices already sounding.
     void retrigger() {
         phase_ = 0.0f;
+        half_ = false;
         restart_delay();
     }
 
@@ -118,19 +125,28 @@ public:
     // Returns the gated value; raw() and gate() expose the parts.
     float next_n(int32_t n) {
         float v;
+        // Shapes as the VST plays them on the pitch route: the triangle
+        // starts at +1 and falls, the sawtooth falls from +1 to -1, the
+        // square is +/-0.5 (half the triangle's swing, high first), the
+        // random value is drawn from +/-0.5 and holds for HALF a period.
         switch (spec_.wave) {
-            case LfoWave::kSawtooth: v = 2.0f * phase_ - 1.0f; break;
-            case LfoWave::kSquare:   v = phase_ < 0.5f ? 1.0f : -1.0f; break;
+            case LfoWave::kSawtooth: v = 1.0f - 2.0f * phase_; break;
+            case LfoWave::kSquare:   v = phase_ < 0.5f ? 0.5f : -0.5f; break;
             case LfoWave::kRandom:   v = sample_; break;
             case LfoWave::kTriangle:
-            default: v = phase_ < 0.5f ? (4.0f * phase_ - 1.0f)
-                                       : (3.0f - 4.0f * phase_); break;
+            default: v = phase_ < 0.5f ? (1.0f - 4.0f * phase_)
+                                       : (4.0f * phase_ - 3.0f); break;
         }
         raw_ = v;
         phase_ += inc_ * n;
+        if (!half_ && phase_ >= 0.5f) {
+            half_ = true;
+            sample_ = next_random();
+        }
         while (phase_ >= 1.0f) {
             phase_ -= 1.0f;
-            sample_ = next_random();      // random holds for one period
+            half_ = false;
+            sample_ = next_random();
         }
         if (delay_left_ > 0.0f) {
             delay_left_ -= n;
@@ -161,13 +177,14 @@ private:
         rng_ ^= rng_ << 13;
         rng_ ^= rng_ >> 17;
         rng_ ^= rng_ << 5;
-        return (rng_ >> 8) * (2.0f / 16777216.0f) - 1.0f;
+        return (rng_ >> 8) * (1.0f / 16777216.0f) - 0.5f;   // +/-0.5, the VST's random swing
     }
 
     LfoSpec spec_{};
     float sr_ = 32000.0f;
     float inc_ = 0.0f;
     float phase_ = 0.0f;
+    bool half_ = false;           // second half of the period reached (random redraw)
     float delay_left_ = 0.0f;
     float gate_ = 0.0f;
     float gate_step_ = 1.0f;

--- a/instruments/PicoFaceD5/include/d5_engine/d5_synth_voice.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_synth_voice.h
@@ -293,6 +293,18 @@ public:
         // 50) carry one; a square's mean is zero.
         dc_shape_ = h_frac_ > 0.0f ? 2.0f * pulse_frac_ - 1.0f
                                    : 2.0f * edge_frac_ - 1.0f;
+        // A narrow pulse keeps its level: Roland's D-50 VST holds a square
+        // within 0.5 dB from duty 0.5 down to the 1/16 floor (a fixed-
+        // amplitude pulse would lose 6.4 dB at the floor, and ours did).
+        // The sawtooth, a square ring-modulated with its cosine, is flat
+        // against the pulse width on both sides and needs nothing.
+        if (spec_.waveform == Waveform::kSquare) {
+            // the pulse the chip actually plays: never narrower than its edge pair
+            const float d = pulse_frac_ > edge_frac_ ? pulse_frac_ : edge_frac_;
+            pw_gain_ = std::pow(0.25f / (d * (1.0f - d)), 0.47f);
+        } else {
+            pw_gain_ = 1.0f;
+        }
     }
 
     float D5_HOT_TAG(d5_synth_next, next)(const Modulation& mod = Modulation{}) {
@@ -390,10 +402,9 @@ public:
         // partial -- DC included -- but the D-50's line out is AC-coupled
         // and never passes it. A saw keeps its shape mean on the cosine
         // carrier (mean zero), so only the square reports one.
-        dc_out_ = spec_.waveform == Waveform::kSquare
-                      ? dc_shape_ * atten_ * amp * gain_ * mod.amp * 0.5f
-                      : 0.0f;
-        return out * amp * gain_ * mod.amp * 0.5f;
+        const float scale = amp * gain_ * mod.amp * 0.5f * pw_gain_;
+        dc_out_ = spec_.waveform == Waveform::kSquare ? dc_shape_ * atten_ * scale : 0.0f;
+        return out * scale;
     }
 
     // DC of this partial's contribution next() just returned (see above).
@@ -435,6 +446,7 @@ private:
     float pulse_frac_ = 0.5f;
     float h_frac_ = 0.0f;
     float dc_shape_ = 0.0f;        // mean of the bare shape (duty imbalance)
+    float pw_gain_ = 1.0f;         // narrow-pulse level compensation (VST)
     float dc_out_ = 0.0f;          // dc_shape_ with all output scaling on
     float atten_ = 1.0f;           // sub-middle broadband attenuation
     bool res_on_ = false;

--- a/instruments/PicoFaceD5/include/d5_engine/d5_voice.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_voice.h
@@ -432,19 +432,26 @@ public:
             mod_[i].pw = kPwLfoSwing * spec_.pw_lfo[i].depth * lfo_value(l, spec_.pw_lfo[i])
                        + 0.65f * spec_.pw_at[i] * at_;
             mod_[i].cutoff = (kTvfLfoUnits / 100.0f) * spec_.tvf_lfo[i].depth * lfo_value(l, spec_.tvf_lfo[i])
-                           + 0.65f * spec_.tvf_at[i] * at_;
+                           + 0.85f * spec_.tvf_at[i] * at_;   // VST: range 14 at full pressure lifts the centroid 583 -> 1018 Hz
             const float tva_d = std::fabs(spec_.tva_lfo[i].depth);
             const float tva_l = spec_.tva_lfo[i].depth < 0.0f ? -lfo_value(l, spec_.tva_lfo[i])
                                                               : lfo_value(l, spec_.tva_lfo[i]);
+            // The VST's tremolo (select byte 1, our negative route) starts fully
+            // ducked on a synced LFO, where the vibrato starts at its highest
+            // pitch; with the route sign folded into tva_l that is (1 - l)/2.
             float tgt_amp = fast_exp2(-kTvaLfoDb * tva_d * 0.5f * (1.0f - tva_l) * (1.0f / 6.0206f));
-            // TVA aftertouch (ROM 0x11A9): a positive range rests ~3 dB down
-            // and rises to unity at full press; a negative one ducks ~3 dB
-            // (the ROM's scale is 2|s| chip units of 0.376 dB, i.e. ~5.3 dB
-            // at s=7 -- the 3-dB reading is PLAUSIBLE, hearing test pending).
+            // TVA aftertouch, measured on Roland's D-50 VST: the attenuation
+            // is 2 * u^2 chip units (0.755 dB * u^2, u = range - 7), a
+            // positive range resting fully attenuated and lifted linearly
+            // by the pressure (range 10: -6.8 dB at rest, range 14: -37;
+            // pressure 64 halves it), a negative range resting at unity
+            // and ducking with the pressure. The "3 dB" reading of the ROM
+            // transform at 0x11A9 was off by an order of magnitude.
             const float g = spec_.tva_at[i];
             if (g != 0.0f) {
-                const float x = (g > 0.0f ? g * (at_ - 1.0f) : g * at_) * 0.5f;
-                tgt_amp *= fast_exp2(x);
+                const float u2 = 49.0f * g * g;
+                const float w = g > 0.0f ? (1.0f - at_) : at_;
+                tgt_amp *= fast_exp2(-0.755f * u2 * w * (1.0f / 6.0206f));
             }
             if (tgt_amp < 0.0f) tgt_amp = 0.0f;
             dpitch_[i] = (tgt_pitch - mod_[i].pitch) * (1.0f / kModPeriod);

--- a/instruments/PicoFaceD5/include/d5_engine/d5_voice.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_voice.h
@@ -433,7 +433,12 @@ public:
                        + 0.65f * spec_.pw_at[i] * at_;
             mod_[i].cutoff = (kTvfLfoUnits / 100.0f) * spec_.tvf_lfo[i].depth * lfo_value(l, spec_.tvf_lfo[i])
                            + 0.85f * spec_.tvf_at[i] * at_;   // VST: range 14 at full pressure lifts the centroid 583 -> 1018 Hz
-            const float tva_d = std::fabs(spec_.tva_lfo[i].depth);
+            // A PCM partial has no TVA modulation at all in Roland's D-50
+            // VST: LFO depth 100 on either route and an aftertouch range of
+            // 14 leave it exactly where it is (pitch LFO and bias do act).
+            // Like the TVF, the modulation block belongs to the synth path.
+            const bool pcm_partial = ((i == 0) ? st.p1 : st.p2) == PartialType::kPcm;
+            const float tva_d = pcm_partial ? 0.0f : std::fabs(spec_.tva_lfo[i].depth);
             const float tva_l = spec_.tva_lfo[i].depth < 0.0f ? -lfo_value(l, spec_.tva_lfo[i])
                                                               : lfo_value(l, spec_.tva_lfo[i]);
             // The VST's tremolo (select byte 1, our negative route) starts fully
@@ -447,7 +452,7 @@ public:
             // pressure 64 halves it), a negative range resting at unity
             // and ducking with the pressure. The "3 dB" reading of the ROM
             // transform at 0x11A9 was off by an order of magnitude.
-            const float g = spec_.tva_at[i];
+            const float g = pcm_partial ? 0.0f : spec_.tva_at[i];
             if (g != 0.0f) {
                 const float u2 = 49.0f * g * g;
                 const float w = g > 0.0f ? (1.0f - at_) : at_;


### PR DESCRIPTION
Second round of single-partial probes against Roland's D-50 VST, on the 20 patches still more than 6 dB off after #154. Each outlier partial was bisected by byte group, then the responsible law probed directly.

| law | VST | ours before | ours now |
|---|---|---|---|
| TVA aftertouch, range 14, no pressure | −37 dB | −3 dB | −37 |
| TVA aftertouch, range 10, no pressure / pressure 64 | −6.8 / −3.4 dB | −1.3 / −0.7 | −6.8 / −3.4 |
| TVA aftertouch, range 0, pressure 127 | −37 dB | −3 | −37 |
| TVF aftertouch, range 14, pressure 127 (centroid) | 583 → 1018 Hz | 961 | 961 (ceiling) / range 10: 801 exact |
| synced triangle LFO at note-on | starts at the top, falls | started at the bottom | top |
| square / random LFO amplitude | ±0.5 / ±0.5, random redrawn every half period | ±1 / ±1 per period | ±0.5 / ±0.5 |
| free-running tremolo right after patch load | open | fully ducked | open |
| attack T1 40 / 50 / 60 / 70, time to −1 dB | 0.070 / 0.160 / 0.380 / 0.885 s, log-domain rise | 0.110 / 0.265 / 0.630 / 1.150, linear rise | 0.070 / 0.160 / 0.380 / 0.905, log-domain |

The quadratic aftertouch law (2·u² chip units) explains Taj Mahal, Harmonic E-Piano and Tines; the free-running LFO phase explains Ham and Organ, Good and Old Days and Slap Bass n Brass (LFO 3 at rate 0 as a static tremolo). The attack shape closes the long-open "T1 at velocity 64 too slow" item: the VST's attack is a constant-dB/s rise from the floor, so it sounds shorter than a linear-amplitude ramp of the same length.

**Probed and found right:** TVA level, sustain and velocity laws (exact to 0.1 dB), falls to zero. **Open:** with a fast T2 (0–20) the VST's fall to a non-zero level stops short of its target and later segments do not finish it (T2 0 → L2 48 covers 6.8 of 19.6 dB, ours 12.5); a few dB on percussive decays.

Host tests 18/18, stress finite and none at full scale, firmware builds (RAM 53 %).

**Hearing test:** Ham and Organ 3-49, Good and Old Days 3-52, Slap Bass n Brass 1-51 (tremolo now open at patch load), Taj Mahal 3-48, Harmonic E-Piano 4-11, Tines 4-13 (quieter at rest, rising under aftertouch), any slow-attack pad (attacks now start softer and land sooner), and anything with aftertouch from your keyboard — PressureMe Strings 1-20, Pressure Me Lead 1-30, Afterthought 1-60.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Second commit:** a PCM partial has no TVA modulation in the VST — LFO depth 100 on either route and an aftertouch range of 14, at rest or under full pressure, leave it where it is (pitch LFO and bias do act). Ham and Organ 3-49 and Good and Old Days 3-52 are PCM organs with a rate-0 tremolo and sat 15 dB under the VST on ours; now within the global offset.

**Dry bank sweep (384 patches):** per-patch level spread after removing the median: std 4.2 dB (before #154) → 3.2 (#154) → **3.0 dB**; patches more than 6 dB off 44 → 20 → 18; more than 3 dB off 131 → 91 → 83. Largest remaining: F-1 Grand Prix 6-59 (−13), Breeze Pipe 5-36 (−12), SlapBass-SynBrass 4-48 (−12), Harmonic E-Piano 4-11 (−11), Slap Bass n Brass 1-51 (−10), PCM E-Piano 1-64 (+10) — the fast-T2 fall quirk and per-patch bisections still to do.

**Third commit:** the TVA chip level caps at 142 (VST: level 100 and 90 with velocity sensitivity 100 both +4.2 dB over neutral at velocity 127; ours ran to +9), a narrowing square keeps its level (VST within 0.5 dB down to the 1/16 floor; ours lost 6.4 dB — Picked Guitar Duo, Pianissimo, Breeze Pipe), and a TVA segment to level 0 ramps to chip zero in its time and then coasts at that rate to −90 dB (VST: 48 → 0 at T4 68 runs at 25 dB/s, 100 → 0 at 52, both straight past −40 to −80 dB). The fast-T2 observation above was an artefact of the old linear attack and is gone.

**Dry bank sweep, per-patch level spread after removing the median:** std 4.2 dB (before #154) → 3.2 (#154) → 3.0 (round 2) → **2.0 dB** (round 3); patches more than 6 dB off 44 → 20 → 18 → **8**; more than 3 dB off 131 → 91 → 83 → **35**. Largest remaining: Tines 4-13 (+11, a ring structure), F-1 Grand Prix 6-59 (−9), PCM E-Piano 1-64 (+8), Breeze Pipe 5-36 (−7), Harmonic E-Piano 4-11 (−6).