### PR TITLE
PicoFaceD5: control tick from the firmware timer (97.66 Hz), LFO shapes, lower-tone lag, ring product, low shelf

### DIFF
--- a/instruments/PicoFaceD5/include/d5_engine/d5_effects.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_effects.h
@@ -40,18 +40,21 @@ namespace d5 {
 
 class Biquad {
 public:
+    // Roland's D-50 VST plays the low EQ as a FIRST-order shelf: pole at
+    // the table frequency, zero at freq * 10^(gain/20), unity above -- so
+    // +12 dB at 250 Hz is still +9.6 at 262 Hz and +2.2 at 1 kHz, a 3 dB
+    // per octave slope across four octaves (measured per harmonic at three
+    // notes; a -12 dB cut mirrors it, -6 dB at 131 Hz for lf 8). A second-
+    // order shelf at the same corner was a full octave narrower and lost
+    // 2-6 dB of level on every boosted patch.
     void set_low_shelf(float freq, float gain_db, float sr) {
-        const float A = std::pow(10.0f, gain_db / 40.0f);
-        const float w = 2.0f * kPi * freq / sr;
-        const float cs = std::cos(w), sn = std::sin(w);
-        const float beta = std::sqrt(A) / 0.9f;      // shelf slope ~1
-        const float b0 = A * ((A + 1) - (A - 1) * cs + beta * sn);
-        const float b1 = 2 * A * ((A - 1) - (A + 1) * cs);
-        const float b2 = A * ((A + 1) - (A - 1) * cs - beta * sn);
-        const float a0 = (A + 1) + (A - 1) * cs + beta * sn;
-        const float a1 = -2 * ((A - 1) + (A + 1) * cs);
-        const float a2 = (A + 1) + (A - 1) * cs - beta * sn;
-        set(b0, b1, b2, a0, a1, a2);
+        const float g = std::pow(10.0f, gain_db / 20.0f);
+        const float wp = std::tan(kPi * freq / sr);
+        float fz = freq * g;
+        if (fz > 0.45f * sr) fz = 0.45f * sr;
+        const float wz = std::tan(kPi * fz / sr);
+        // H(s) = (s + wz) / (s + wp), bilinear with s = (1 - z^-1)/(1 + z^-1)
+        set(1.0f + wz, wz - 1.0f, 0.0f, 1.0f + wp, wp - 1.0f, 0.0f);
     }
 
     void set_peaking(float freq, float q, float gain_db, float sr) {

--- a/instruments/PicoFaceD5/include/d5_engine/d5_lfo.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_lfo.h
@@ -121,13 +121,18 @@ public:
     // Returns the gated value; raw() and gate() expose the parts.
     float next_n(int32_t n) {
         float v;
-        // Shapes as the VST plays them on the pitch route: the triangle
+        // Shapes as the VST plays them, measured on all three routes at
+        // rate 80 (pitch, TVA and TVF, hundreds of periods): the triangle
         // starts at +1 and falls, the sawtooth falls from +1 to -1, the
-        // square is +/-0.5 (half the triangle's swing, high first), the
-        // random value is drawn from +/-0.5 and holds for HALF a period.
+        // square sits in the UPPER half of the triangle's swing (+1 for
+        // the first half period, 0 for the second: on the TVA and TVF
+        // routes it moves between the triangle's floor and its middle,
+        // never reaching the static level), the random value is uniform
+        // over the full +/-1 and holds for HALF a period (its spread
+        // equals the triangle's on every route).
         switch (spec_.wave) {
             case LfoWave::kSawtooth: v = 1.0f - 2.0f * phase_; break;
-            case LfoWave::kSquare:   v = phase_ < 0.5f ? 0.5f : -0.5f; break;
+            case LfoWave::kSquare:   v = phase_ < 0.5f ? 1.0f : 0.0f; break;
             case LfoWave::kRandom:   v = sample_; break;
             case LfoWave::kTriangle:
             default: v = phase_ < 0.5f ? (1.0f - 4.0f * phase_)
@@ -173,7 +178,7 @@ private:
         rng_ ^= rng_ << 13;
         rng_ ^= rng_ >> 17;
         rng_ ^= rng_ << 5;
-        return (rng_ >> 8) * (1.0f / 16777216.0f) - 0.5f;   // +/-0.5, the VST's random swing
+        return (rng_ >> 8) * (1.0f / 8388608.0f) - 1.0f;    // uniform +/-1, the VST's random swing
     }
 
     LfoSpec spec_{};

--- a/instruments/PicoFaceD5/include/d5_engine/d5_lfo.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_lfo.h
@@ -33,39 +33,35 @@ struct LfoSpec {
 };
 
 // The engine's control tick, the rate at which the D-50's CPU walks its
-// LFO and envelope counters. Not read from a register: pinned by the
-// service notes' P-ENV span against the tick tables below -- 1 tick and
-// 1020 ticks against "9 ms .. 9 s" both land at ~112 Hz.
-inline constexpr float kTickHz = 112.0f;
+// LFO and envelope counters. Read from the firmware's own timer setup:
+// the sound-engine init on EPROM page 3 (CPU 0x81AC, reached from the
+// reset path via 0x2815) writes STBC = 0 (uPD78312A full speed, fCLK =
+// 12 MHz / 2 = 6 MHz -- the same init sets BRG = 48, which is exactly
+// 31250 baud at that clock), then TM1 = MD1 = 0x2800 and starts TM1 on
+// fCLK/6 (TMC1 TCLK1 = 0). TM1's underflow is TMF1, vector 0x0010 ->
+// 0x2018 -> 0x27F0, the LFO/envelope/portamento tick. So one tick is
+// 10240 us: 6 MHz / 6 / 10240 = 97.65625 Hz. The earlier 112 Hz came
+// from the D-05's rate table top (a different machine); Roland's D-50
+// VST plays 25 Hz at rate 100, i.e. an idealised 100-Hz tick.
+inline constexpr float kTickHz = 6.0e6f / 6.0f / 10240.0f;
 
 // Panel 0..100 to Hz, the firmware's own law end to end: the tick engine
-// subtracts table 0x0213[2k] from a 16-bit phase per tick, the table is
-// exactly 16 * 2^(k/10) (byte-verified), so a full cycle at panel 100
-// takes 65536/16384 = 4 ticks. The absolute anchor is the tick: the
-// D-05 remake's rate table tops out at 27.9847 Hz, which against the
-// 4-tick cycle pins the tick at 111.94 Hz -- the same ~112 the service
-// notes' P-ENV span demands. One clock, three independent anchors. The
-// 5.6 Hz once measured in the Living Calliope reference does not fit it
-// (byte 74 lands at 4.62) -- but that recording's vibrato runs through
-// the player's lever, and the firmware is the master template.
-inline constexpr float kLfoRateHz[101] = {
-    0.0273288f, 0.0292903f, 0.0313926f, 0.0336457f, 0.0360606f, 0.0386488f,
-    0.0414227f, 0.0443958f, 0.0475822f, 0.0509974f, 0.0546576f, 0.0585806f,
-    0.0627851f, 0.0672914f, 0.0721212f, 0.0772975f, 0.0828455f, 0.0887916f,
-    0.0951644f, 0.101995f, 0.109315f, 0.117161f, 0.12557f, 0.134583f,
-    0.144242f, 0.154595f, 0.165691f, 0.177583f, 0.190329f, 0.203989f,
-    0.21863f, 0.234322f, 0.25114f, 0.269166f, 0.288485f, 0.30919f,
-    0.331382f, 0.355166f, 0.380658f, 0.407979f, 0.437261f, 0.468645f,
-    0.502281f, 0.538331f, 0.576969f, 0.61838f, 0.662764f, 0.710332f,
-    0.761316f, 0.815958f, 0.874522f, 0.937289f, 1.00456f, 1.07666f,
-    1.15394f, 1.23676f, 1.32553f, 1.42066f, 1.52263f, 1.63192f,
-    1.74904f, 1.87458f, 2.00912f, 2.15333f, 2.30788f, 2.47352f,
-    2.65105f, 2.84133f, 3.04526f, 3.26383f, 3.49809f, 3.74916f,
-    4.01825f, 4.30665f, 4.61575f, 4.94704f, 5.30211f, 5.68266f,
-    6.09052f, 6.52766f, 6.99618f, 7.49831f, 8.03649f, 8.6133f,
-    9.23151f, 9.89409f, 10.6042f, 11.3653f, 12.181f, 13.0553f,
-    13.9924f, 14.9966f, 16.073f, 17.2266f, 18.463f, 19.7882f,
-    21.2084f, 22.7306f, 24.3621f, 26.1106f, 27.9847f};
+// subtracts table 0x0213[2k] from a 16-bit phase per tick, so a cycle
+// takes 65536 / T[k] ticks and the rate is T[k] / 65536 * kTickHz. The
+// table is the internal ROM's, byte for byte (IC25 0x0213, 101 words,
+// within 1 of 16 * 2^(k/10)); panel 100 runs at 16383 / 65536 * 97.66 =
+// 24.41 Hz. Roland's D-50 VST plays 25.0 Hz there (an idealised 100-Hz
+// tick), the D-05 remake's table tops out at 27.98 Hz (a 112-Hz tick) --
+// the hardware timer of the D-50 itself decides between them.
+inline constexpr uint16_t kLfoRateInc[101] = {
+    16, 17, 18, 20, 21, 23, 24, 26, 28, 30, 32, 34, 37, 39, 42, 45, 49,
+    52, 56, 60, 64, 69, 74, 79, 84, 91, 97, 104, 111, 119, 128, 137, 147,
+    158, 169, 181, 194, 208, 223, 239, 256, 274, 294, 315, 338, 362, 388,
+    416, 446, 478, 512, 549, 588, 630, 676, 724, 776, 832, 891, 955, 1024,
+    1097, 1176, 1261, 1351, 1448, 1552, 1663, 1783, 1911, 2048, 2195, 2353,
+    2521, 2702, 2896, 3104, 3327, 3566, 3822, 4096, 4390, 4705, 5043, 5405,
+    5793, 6208, 6654, 7132, 7643, 8192, 8780, 9410, 10086, 10809, 11585,
+    12417, 13308, 14263, 15287, 16383};
 
 // The fade-in after the delay: the firmware waits out the silence, then
 // walks an 8-bit ramp by this table's value per tick, indexed by the delay
@@ -77,7 +73,7 @@ inline constexpr uint8_t kLfoFadeStep[13] = {
 inline float lfo_rate_hz(float v) {
     if (v < 0.0f) v = 0.0f;
     if (v > 1.0f) v = 1.0f;
-    return kLfoRateHz[static_cast<int>(v * 100.0f + 0.5f)];
+    return kLfoRateInc[static_cast<int>(v * 100.0f + 0.5f)] * (kTickHz / 65536.0f);
 }
 
 class Lfo {
@@ -160,7 +156,7 @@ public:
     float raw() const { return raw_; }
     float gate() const { return delay_left_ > 0.0f ? 0.0f : gate_; }
 
-    // The D-50's LFOs are tone-global: the 112-Hz tick walks exactly one
+    // The D-50's LFOs are tone-global: the 97.66-Hz tick walks exactly one
     // phase word per LFO per tone (IC25 0x1508-0x160D), and every sounding
     // voice reads the same words from the CD40 merge area. So the tone owns
     // the LFOs and steps them once per sample...

--- a/instruments/PicoFaceD5/include/d5_engine/d5_lfo.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_lfo.h
@@ -254,17 +254,29 @@ public:
         for (int i = 0; i < 4; ++i) {
             int idx = static_cast<int>(spec_.t_idx[i]) + off;
             idx = idx < 0 ? 0 : (idx > 50 ? 50 : idx);
-            t_[i] = idx == 0 ? 0.0f : kPEnvTicks[idx] * (1.0f / kTickHz);
+            // Index 0 jumps to the target at its tick -- and the next
+            // segment only moves at the tick after that, so the jump holds
+            // for one tick (the VST: jump at ~14 ms, plateau until ~26 ms).
+            t_[i] = (idx == 0 ? 1.0f : static_cast<float>(kPEnvTicks[idx])) * (1.0f / kTickHz);
+            jump_[i] = idx == 0;
         }
         level_ = spec_.l0;
         seg_ = 0;
         held_ = true;
-        arm(0, spec_.l1);
+        // The envelope is stepped by the tick engine, and Roland's D-50 VST
+        // makes its first move about 1.4 ticks (14 ms) after the note-on:
+        // an instant first segment to +1200 cents lands between 12 and 16
+        // ms, every time, while the TVA is already 2 ms in. Until then the
+        // pitch rests on L0. (Two partials on opposite P-ENV modes owe
+        // their later phase relation to exactly this area.)
+        pre_ = static_cast<int32_t>(kPEnvStartTicks * sr_ / kTickHz);
+        if (pre_ <= 0) arm(0, spec_.l1);
     }
 
     void release() {
         if (held_) {
             held_ = false;
+            pre_ = 0;
             arm(3, spec_.end);
         }
     }
@@ -272,7 +284,12 @@ public:
     // Pitch factor, advanced n samples at once (control rate).
     float next_n(int32_t n) {
         while (n > 0) {
-            if (remaining_ > 0) {
+            if (pre_ > 0) {
+                const int32_t k = pre_ < n ? pre_ : n;
+                pre_ -= k;
+                n -= k;
+                if (pre_ == 0) arm(0, spec_.l1);
+            } else if (remaining_ > 0) {
                 const int32_t k = remaining_ < n ? remaining_ : n;
                 level_ += step_ * k;
                 remaining_ -= k;
@@ -292,7 +309,9 @@ public:
 
     // Pitch factor to multiply the playback rate / frequency by.
     float next() {
-        if (remaining_ > 0) {
+        if (pre_ > 0) {
+            if (--pre_ == 0) arm(0, spec_.l1);
+        } else if (remaining_ > 0) {
             level_ += step_;
             --remaining_;
         } else if (held_ && seg_ < 2) {
@@ -310,19 +329,27 @@ private:
     void arm(int seg, float target) {
         seg_ = seg;
         remaining_ = static_cast<int32_t>(t_[seg] * sr_);
+        if (jump_[seg]) {
+            level_ = target;          // instant, then hold the tick out
+            step_ = 0.0f;
+            return;
+        }
         step_ = remaining_ > 0 ? (target - level_) / remaining_ : 0.0f;
         if (remaining_ <= 0) level_ = target;
     }
 
     PitchEnvSpec spec_{};
     float t_[4] = {0.0f, 0.0f, 0.0f, 0.0f};   // seconds, resolved per note
+    bool jump_[4] = {false, false, false, false};
     float depth_cents_ = 0.0f;
     float sr_ = 32000.0f;
     float level_ = 0.0f;
     float step_ = 0.0f;
     int32_t remaining_ = 0;
+    int32_t pre_ = 0;             // samples until the tick engine first moves
     int seg_ = 0;
     bool held_ = false;
+    static constexpr float kPEnvStartTicks = 1.4f;
 };
 
 }  // namespace d5

--- a/instruments/PicoFaceD5/include/d5_engine/d5_patch.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_patch.h
@@ -365,6 +365,7 @@ public:
     void silence() {
         upper_.silence();
         lower_.silence();
+        pend_head_ = pend_count_ = 0;
         reverb_.configure(spec_.reverb, sr_);
         solo_note_[0] = solo_note_[1] = -1;
     }
@@ -391,20 +392,24 @@ public:
         bool sounded = false;
         switch (spec_.key_mode) {
             case KeyMode::kDual: {
-                if (spec_.solo) solo_cut(0, note), solo_cut(1, note);
+                if (spec_.solo) solo_cut(0, note);
                 const bool u = upper_.note_on(note, velocity);
-                const bool l = lower_.note_on(note, velocity);
-                sounded = u || l;
-                if (spec_.solo) solo_note_[0] = solo_note_[1] = note;
+                if (spec_.solo) solo_note_[0] = note;
+                lower_later(note, velocity, true, spec_.solo);
+                sounded = u || true;
                 break;
             }
             case KeyMode::kSplit: {
                 const int side = note >= spec_.split_point ? 0 : 1;
                 const bool solo = side == 0 ? spec_.solo_upper : spec_.solo_lower;
-                if (solo) solo_cut(side, note);
-                sounded = side == 0 ? upper_.note_on(note, velocity)
-                                    : lower_.note_on(note, velocity);
-                if (solo) solo_note_[side] = note;
+                if (side == 0) {
+                    if (solo) solo_cut(0, note);
+                    sounded = upper_.note_on(note, velocity);
+                    if (solo) solo_note_[0] = note;
+                } else {
+                    lower_later(note, velocity, true, solo);
+                    sounded = true;
+                }
                 break;
             }
             case KeyMode::kWhole:
@@ -422,9 +427,8 @@ public:
 
     void note_off(int note) {
         upper_.note_off(note);
-        lower_.note_off(note);
-        for (int i = 0; i < 2; ++i)
-            if (note == solo_note_[i]) solo_note_[i] = -1;
+        if (note == solo_note_[0]) solo_note_[0] = -1;
+        lower_later(note, 0.0f, false, false);
     }
 
     // Mono fold is the L/MONO jack again: the left side as it ships. In the
@@ -442,6 +446,8 @@ public:
     // each -- the chorus width of a tone survives into the room. The laws
     // themselves are unchanged from the mono path.
     void D5_HOT(next_stereo)(float& l, float& r) {
+        ++clock_;
+        if (pend_count_ != 0 && pending_[pend_head_].due == clock_) service_lower();
         // Tone balance per the firmware's mixer (bank code 0xB397): each
         // tone's factor is min(4*b, 255)/200 of its side, so the center
         // is 1.0 each and a full tilt reaches +2.1 dB on the loud side --
@@ -590,6 +596,57 @@ private:
     Reverb reverb_{};
     float sr_ = 32000.0f;
     int solo_note_[2] = {-1, -1}; // the solo modes' held note per tone (0 upper, 1 lower)
+
+    // The lower tone runs 128 samples (4.0 ms) behind the upper: Roland's
+    // D-50 VST starts it exactly that much later on every note, key and
+    // waveform tried (cross-correlation +128 at 32 kHz, corr 1.000; onsets
+    // 64 against 192). Two identical tones therefore never sum coherently
+    // -- a Tines or Warm Strings dual patch came out 6 dB louder here than
+    // there -- and a dual patch carries a 4-ms doubling. Note-ons and
+    // note-offs for the lower tone queue here, in order, and fire from the
+    // sample loop.
+    static constexpr uint32_t kLowerLag = 128;
+    static constexpr int kPendingMax = 32;
+    struct PendingLower {
+        uint32_t due;
+        float velocity;
+        int16_t note;
+        bool on;
+        bool solo;
+    };
+    PendingLower pending_[kPendingMax];
+    int pend_head_ = 0;
+    int pend_count_ = 0;
+    uint32_t clock_ = 0;
+
+    void lower_later(int note, float velocity, bool on, bool solo) {
+        if (pend_count_ >= kPendingMax) { lower_now(note, velocity, on, solo); return; }
+        PendingLower& e = pending_[(pend_head_ + pend_count_) % kPendingMax];
+        e.due = clock_ + kLowerLag + 1;   // +1: the upper already sounds in the next sample
+        e.velocity = velocity;
+        e.note = static_cast<int16_t>(note);
+        e.on = on;
+        e.solo = solo;
+        ++pend_count_;
+    }
+    void lower_now(int note, float velocity, bool on, bool solo) {
+        if (on) {
+            if (solo) solo_cut(1, note);
+            lower_.note_on(note, velocity);
+            if (solo) solo_note_[1] = note;
+        } else {
+            lower_.note_off(note);
+            if (note == solo_note_[1]) solo_note_[1] = -1;
+        }
+    }
+    void service_lower() {
+        while (pend_count_ != 0 && pending_[pend_head_].due == clock_) {
+            const PendingLower e = pending_[pend_head_];
+            pend_head_ = (pend_head_ + 1) % kPendingMax;
+            --pend_count_;
+            lower_now(e.note, e.velocity, e.on, e.solo);
+        }
+    }
 
     // A solo side ends its previous note when a new one arrives.
     void solo_cut(int side, int note) {

--- a/instruments/PicoFaceD5/include/d5_engine/d5_patch.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_patch.h
@@ -45,7 +45,7 @@ public:
         eq_.configure(spec.eq, sample_rate);
         chorus_.configure(spec.chorus, sample_rate);
         // The tone's three LFOs are single shared instances -- the D-50's
-        // 112-Hz tick walks one phase word per LFO per tone (IC25
+        // 97.66-Hz tick walks one phase word per LFO per tone (IC25
         // 0x1508-0x160D), so a chord vibrates coherently and a legato note
         // joins the running wobble. They free-run from here on.
         for (int i = 0; i < 3; ++i) {

--- a/instruments/PicoFaceD5/include/d5_engine/d5_synth_voice.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_synth_voice.h
@@ -227,8 +227,16 @@ public:
         const float env = tvf_.next_n(kModPeriod);
         // mod.cutoff arrives on the old 0..1 scale from the LFO routes;
         // 100 units span that scale, same as the panel byte.
-        float cv = base_cv_ + env_units_ * 100.0f * env + mod.cutoff * 100.0f;
+        // The ceiling clamps the composed static cutoff (base + envelope,
+        // the register the firmware writes); the LFO and aftertouch travel
+        // through the chip's own modulation registers (E500..) and add on
+        // top of it: Roland's VST lifts a cutoff-50 sawtooth's centroid to
+        // 1018 Hz under full pressure at range 14, past the 961 Hz the
+        // ceiling alone allows. The final clamp is the register's range.
+        float cv = base_cv_ + env_units_ * 100.0f * env;
         if (cv > kCutoffCeiling) cv = kCutoffCeiling;       // the chip's clamp
+        cv += mod.cutoff * 100.0f;
+        if (cv > kCutoffMax) cv = kCutoffMax;
         edge_frac_ = 0.5f;
         inv_edge_ = 2.0f;
         atten_ = 1.0f;
@@ -441,6 +449,7 @@ private:
 #define D5_CUTOFF_CEILING 218.0f
 #endif
     static constexpr float kCutoffCeiling = D5_CUTOFF_CEILING;
+    static constexpr float kCutoffMax = 240.0f;   // munt's LA32 cutoff range
     float edge_frac_ = 0.5f;       // cosine edge as fraction of the period
     float inv_edge_ = 2.0f;        // 1/edge_frac_, a block constant
     float pulse_frac_ = 0.5f;

--- a/instruments/PicoFaceD5/include/d5_engine/d5_voice.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_voice.h
@@ -452,7 +452,11 @@ public:
             // pressure 64 halves it), a negative range resting at unity
             // and ducking with the pressure. The "3 dB" reading of the ROM
             // transform at 0x11A9 was off by an order of magnitude.
-            const float g = pcm_partial ? 0.0f : spec_.tva_at[i];
+            // In a ring structure the pair shares partial 1's aftertouch
+            // range: Roland's VST attenuates the product twice by P1's
+            // range and not at all by P2's (P2's byte is dead there), in a
+            // mix structure each partial follows its own byte.
+            const float g = pcm_partial ? 0.0f : spec_.tva_at[st.ring ? 0 : i];
             if (g != 0.0f) {
                 const float u2 = 49.0f * g * g;
                 const float w = g > 0.0f ? (1.0f - at_) : at_;
@@ -503,13 +507,29 @@ public:
 
         // The chip multiplies in the log domain, which is an ordinary product
         // once decoded: sum and difference frequencies, and silence whenever
-        // either side is silent. The product uses the raw partials -- the
+        // either side is silent. Muting partial 1 keeps the product -- the
         // bank forces this reading: Glockenspiel (bank 4) mutes partial 1 of
         // a ring structure, a dead preset if the mute reached the product,
         // whereas gating only the direct path is exactly the classic trick
-        // of hiding the carrier and keeping the metallic product.
-        const float second = st.ring ? a_raw * b_raw - dca_raw * dcb_raw
-                                     : b - dcb;
+        // of hiding the carrier and keeping the metallic product. Muting
+        // partial 2 kills it (Roland's VST: P1 alone has no sidebands).
+        // The product is formed from DC-free partials: the VST's product of
+        // a narrow pulse with a sawtooth is 3 dB QUIETER than a square's,
+        // where the DC leak term (dc * saw, a copy of the other partial)
+        // made ours 3 dB louder. And its level sits above the plain
+        // product of our 0.5-scaled partials: +3.3 dB with two synth
+        // partials, +2.5 with one, +0.2 for PCM x PCM, on every pitch pair,
+        // velocity and envelope level tried (the ratio to P1's direct
+        // output is what was measured, so it tracks both TVAs).
+        float second;
+        if (st.ring) {
+            const int ns = (st.p1 == PartialType::kSynth) + (st.p2 == PartialType::kSynth);
+            const float rg = ns == 2 ? 1.46f : (ns == 1 ? 1.33f : 1.0f);
+            second = (spec_.partials_on & 0x2)
+                         ? rg * (a_raw - dca_raw) * (b_raw - dcb_raw) : 0.0f;
+        } else {
+            second = b - dcb;
+        }
 
         // The firmware's balance curve (EPROM bank code 0xB450): the
         // quieter side falls linearly to zero, the louder side RISES from

--- a/instruments/PicoFaceD5/include/d5_engine/d5_voice.h
+++ b/instruments/PicoFaceD5/include/d5_engine/d5_voice.h
@@ -213,7 +213,7 @@ public:
         sr_ = sample_rate;
         const Structure& st = structure();
         const PartialType types[2] = {st.p1, st.p2};
-        // The LFOs belong to the TONE: the 112-Hz tick walks one phase word
+        // The LFOs belong to the TONE: the 97.66-Hz tick walks one phase word
         // per LFO per tone (IC25 0x1508-0x160D) and every voice reads the
         // shared words from the CD40 merge area -- notes in a chord vibrate
         // together. bind_lfos() hands a real voice the tone's three
@@ -382,7 +382,7 @@ public:
 
         for (int i = 0; i < 2; ++i) {
             // Advance the glide by one block, then fold its offset into the
-            // pitch factor: T/64 semitones per 112-Hz tick, scaled to this
+            // pitch factor: T/64 semitones per 97.66-Hz tick, scaled to this
             // block. The walk is linear in pitch space, so its octave rate
             // is constant -- the D-50's portamento is tempo-based, not the
             // per-distance kind the envelopes are.
@@ -567,7 +567,7 @@ private:
     }
 
     // Semitones per control block at the panel time: the ROM's 4 * T[time]
-    // units of 1/256 semitone per 112-Hz tick, pre-multiplied for the
+    // units of 1/256 semitone per 97.66-Hz tick, pre-multiplied for the
     // block. T[0] is never reached (time 0 snaps at note_on), so indexing
     // is safe for any byte.
     static float porta_step(int time, float sr) {


### PR DESCRIPTION
## Summary

Five laws, four of them behind the remaining per-patch level outliers of the VST sweep, one behind the 16 % LFO-rate mismatch.

- **The control tick is 97.65625 Hz, read from the firmware's own timer setup.** The sound-engine init on EPROM page 3 (CPU 0x81AC, reached from the reset path via 0x2815 → 0x8000) sets STBC = 0 (uPD78312A full speed, fCLK = 6 MHz — the same routine sets BRG = 48, which is exactly 31250 baud at that clock), then TM1 = MD1 = 0x2800 on fCLK/6 and starts it. TM1's underflow is TMF1 → vector 0x0010 → 0x27F0, the LFO/envelope/portamento tick: one tick every 10240 µs. The 112 Hz came from the D-05's rate table. The LFO rate table is now the internal ROM's increment table 0x0213 scaled by that tick; Roland's VST agrees to 0.2–0.8 % from panel 40 to 100 (rate 100: 24.37 Hz measured, 24.41 here, 27.98 before). LFO delays and P-ENV times get 14.7 % longer, portamento 12.8 % slower.
- **Square and random LFO shapes**, measured on all three routes at rate 80: the square sits in the upper half of the triangle's swing (+1 / 0), the random value is uniform over ±1. Both were ±0.5.
- **Aftertouch past the cutoff ceiling**: the ceiling clamps only base + envelope; LFO and aftertouch add on top (range 14 at full pressure: VST 1018 Hz, ours 961 → 1007).
- **The lower tone starts 128 samples (4 ms) after the upper** — cross-correlation of identical tones on separate outputs peaks at +128 with corr 1.000 on every key and waveform. Two identical tones never sum coherently; Tines, Warm Strings and Slow to Fast Rotor came out 6 dB too loud here.
- **Ring product**: formed from DC-free partials, +3.3 dB with two synth partials (+2.5 with one, 0 for PCM × PCM), dies when partial 2 is muted, and both partials share partial 1's TVA aftertouch range (P2's byte is dead in a ring structure — Tines and Harmonic E-Piano rested 7 dB too quiet).
- **The low EQ is a first-order shelf**: pole at the table frequency, zero at f·10^(gain/20). Our second-order shelf was an octave narrower and cost boosted patches 2–6 dB (Breeze Pipe). Cuts now match within 0.3 dB.

## Bank sweep (dry, note 60, vel 127, per-patch deviation after median removal)

| | before | after |
|---|---|---|
| std | 2.05 dB | 1.69 dB |
| patches > 6 dB | 8 | 2 |
| patches > 3 dB | 37 | 27 |

Tines +10.7 → −0.3, Harmonic E-Piano −6.3 → +0.2, Slow to Fast Rotor +6.1 → +1.7, Warm Strings +6.0 → −0.8. Not solvable: PCM E-Piano (+8, the VST's two PCM partials cancel by a phase accident our loop phases don't share). Newly visible because the tones no longer sum coherently: JX Horns-Strings, Warm Strings Pad, Acoustic Bass, Rich Brass — their isolated partials are all within ±1 dB; what differs is the phase relation of near-identical partial pairs (opposite P-ENV modes, 1–6 cent detunes) — phase accidents, not laws. A sixth commit adds the P-ENV timing the VST shows (first move 1.4 ticks after note-on, instant segments hold one tick), which moved JX Horns-Strings from −9 to −6 dB.

## Hearing test candidates

Any dual patch with identical tones (Tines 4-13, Warm Strings 3-04, the string patches: slight 4-ms doubling, less loud), ring patches (Tines, Harmonic E-Piano 4-11, Glockenspiel bank 4), Breeze Pipe 5-36 (low EQ), every LFO patch (rates 12.8 % slower: Arco Strings byte 68 now 2.66 Hz instead of 3.05; delays longer), square/random LFO patches, aftertouch patches with TVF range 14.

Host checks: pcm_pitch / tvf_cutoff / pulse_width host tests green, stress384 0 non-finite, solo cut intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)