### PR TITLE
PicoFaceJ6 against Roland's JUNO-60 plugin

### DIFF
--- a/instruments/PicoFaceJ6/README.md
+++ b/instruments/PicoFaceJ6/README.md
@@ -46,7 +46,7 @@ the value in `include/juno/juno_defs.h`:
 | File | Original circuit | Contents |
 |---|---|---|
 | `juno_dco.h` | the DCO | sawtooth, pulse, sub and noise from one phase, polyBLEP on every edge |
-| `juno_filter.h` | IR3109 and the switched HPF | four OTA sections in a feedback loop; the high-pass as four fixed positions |
+| `juno_filter.h` | IR3109 and the switched HPF | four OTA sections in a feedback loop, solved for the current sample; the high-pass as four fixed positions |
 | `juno_env.h` | IR3201, and the LFO | fixed-duration segments with measured curves; LFO with delay and fade-in |
 | `juno_arp.h` | the arpeggio clock | pattern, range, gate per step |
 | `juno_fx.{h,cpp}` | the chorus board | two bucket-brigade lines, one triangle LFO, right channel inverted |
@@ -80,6 +80,16 @@ transistor ladder takes its feedback from inside the ladder, so the low end
 drains away as the resonance comes up, and an OTA cascade with a separate
 feedback amplifier does not. That is the `gComp` term, set to 0.85 here against
 0.5 for the Model D. A Juno with the resonance up is never thin.
+
+The four one-poles were Huovilainen's polynomial fit to begin with, and that
+fit is only good to about one radian per sample — past that its resonance term
+crosses zero and the feedback turns positive, so the filter had to carry a
+ceiling at `sr/2π`. At 44.1 kHz that is 7.0 kHz nominal and a resonant peak
+that in practice stopped at 3.8 kHz, well under the instrument's own 18 kHz.
+They are topology-preserving transforms now, with the loop around them solved
+for the current sample: correct at every frequency up to Nyquist, no ceiling,
+and the tangent tabulated against the cutoff in octaves so it costs no more
+than the polynomial did.
 
 ## Polyphony
 
@@ -484,6 +494,38 @@ number — sections and pages by name, the cursor by reading back where it is.
 Four separate test bugs in this project were miscounted encoder steps, and each
 one looked like a firmware fault first.
 
+## Measured against Roland's JUNO-60 plugin
+
+Roland's Roland Cloud JUNO-60 puts its whole panel on its VST3 parameter list,
+so both it and this engine can be given the same front panel and played against
+each other. `tools/j6_vst/` does that automatically over all 56 factory
+patches; its README records what the plugin's parameters turned out to mean,
+none of which is documented and four of which do the opposite of what their
+names say.
+
+The plugin is a model rather than an instrument, so it ranks below the service
+notes and above everything else: where the notes give a number, the number
+stands; where they are silent — how a range is laid out along a slider, what
+curve a taper follows — the plugin decides.
+
+What it has settled so far:
+
+| | |
+|---|---|
+| The sawtooth falls | It rises in a ramp of `-sin` and the pulse is `+sin`, so the eleven patches with both waveforms on lost 14 dB of every odd harmonic. |
+| The filter opens to 18 kHz | The polynomial fit capped the resonant peak at 3.8 kHz. |
+| Resonance sings from 0.75 | It sang only above 0.94, so bank 7 — whose sound source the manual says is the filter oscillating — barely spoke. |
+| The cutoff range sits between 0.16 and 0.74 of the slider | Spread evenly it put the middle of the travel an octave low. |
+| The VCA level is squared | Linear is 6 dB out at the middle of the slider. |
+
+Where the two still disagree, and the service notes win: the LFO reaches 22 Hz
+at the top of its slider, which is factory adjustment 7 and Fig. 29 of the
+service notes (a 45 ms period); the plugin runs to something above 40 Hz.
+
+Confirmed rather than changed: pitch and the octave switch, the contour's ten
+octaves, the release curve at every setting of its slider, and the attack
+within 10–20 % across the travel.
+
 ## Deliberate deviations from the original
 
 1. **The keyboard spans the full MIDI range** rather than the instrument's 61
@@ -499,15 +541,20 @@ one looked like a firmware fault first.
    which is quiet, dull and nothing like brass. The cutoff range itself spans
    log2(18000/20) = 9.8 octaves and on the instrument the contour at full can
    take the filter from shut to open, so it has to cover essentially that whole
-   range.
-5. **The DCO LFO is worth one semitone at full depth.** Seven was a guess and
-   badly wrong: "Piano I" has the slider at 0.4, which at seven semitones is a
-   wobble of nearly three — a ghost, not a piano. junox settles it by
-   construction, applying `2^(freqMod/12)` with `freqMod` running to 1.
-6. **The VCA level is linear, not squared.** A squared taper looked like the
-   more slider-ish choice and cost every patch up to 3 dB; the 48 patches were
-   authored against a linear mapping, so bending the curve underneath them
-   misrepresents all of them at once.
+   range. Measured against Roland's plugin afterwards, its contour is worth
+   about 10.8 octaves at full — the guess was a good one.
+5. **The DCO LFO is worth three semitones at full depth.** Seven was a guess
+   and badly wrong: "Piano 1" has the slider at 0.4, which at seven semitones
+   is a wobble of nearly three — a ghost, not a piano. Roland's plugin puts
+   full deflection at 379 cents, so three is where it belongs.
+6. **The VCA level is squared.** It was linear, because the imported junox
+   patch set was authored against a linear mapping. That argument lapsed with
+   the transcription from the owner's manual, whose level column cannot be
+   read at all — every patch now carries the same 0.700 and none is authored
+   against either curve. Roland's plugin follows the square of the setting to
+   within a decibel over the top two thirds of the travel and eases off below
+   0.3, where it runs up to 3 dB above it; the square is taken and the easing
+   is not.
 7. **No delay-dependent loss in the bucket-brigade lines.** An MN3009 has 256
    stages, so the measured 1.66 … 5.35 ms delay puts its clock between roughly
    24 and 77 kHz and its own Nyquist limit never drops below about 12 kHz — high

--- a/instruments/PicoFaceJ6/README.md
+++ b/instruments/PicoFaceJ6/README.md
@@ -517,14 +517,28 @@ What it has settled so far:
 | Resonance sings from 0.75 | It sang only above 0.94, so bank 7 — whose sound source the manual says is the filter oscillating — barely spoke. |
 | The cutoff range sits between 0.16 and 0.74 of the slider | Spread evenly it put the middle of the travel an octave low. |
 | The VCA level is squared | Linear is 6 dB out at the middle of the slider. |
+| The sustain slider is not the sustain level | It holds `1-(1-s)^1.6`, so a third on the slider holds at 0.45. Reading it straight made every patch that sustains below full about an octave too dark on a positive contour and most of an octave too bright on a negative one. |
+| A narrowing pulse loses level | A compensation term used to hold it up by 3.3 dB. The width control really does double as a volume control, which is what PWM sounds like. |
+| The pulse width is a raised cosine | A straight line was five points of duty out in the middle, which is 7 dB on the second harmonic. |
+| The sub and noise sliders are a fader taper | Two halves with a knee at the middle, linear at 0.406 below it. Reading them straight put the sub 8 dB high through the middle of its travel. |
+| The mixer trims what it sums | A ±1 square sits 4.77 dB over a plain ramp; the plugin holds them 3.35 dB apart. |
+| The VCA gate was being overwritten | Its rise and fall shared the contour's coefficients, and the panel writes the mode before the sliders — so every gate patch ran on its contour. |
 
 Where the two still disagree, and the service notes win: the LFO reaches 22 Hz
 at the top of its slider, which is factory adjustment 7 and Fig. 29 of the
 service notes (a 45 ms period); the plugin runs to something above 40 Hz.
 
-Confirmed rather than changed: pitch and the octave switch, the contour's ten
-octaves, the release curve at every setting of its slider, and the attack
-within 10–20 % across the travel.
+Confirmed rather than changed: pitch and the octave switch across the keyboard,
+the contour's ten octaves, the release curve at every setting of its slider,
+the attack within 10–20 % across the travel, and the whole chorus — rate, delay
+range and which channel is inverted, on all three settings, agreeing with the
+Juno60 measurements it was built from.
+
+Two things worth knowing before trusting any measurement against this plugin.
+It runs hot enough to clip at the top of its own level slider, so a reference
+taken there flatters everything compared against it. And its chorus modulates
+its output amplitude at twice the rate of its delay, which reads as a chorus
+running at double speed unless the delay itself is tracked.
 
 ## Deliberate deviations from the original
 

--- a/instruments/PicoFaceJ6/README.md
+++ b/instruments/PicoFaceJ6/README.md
@@ -523,13 +523,16 @@ What it has settled so far:
 | The sub and noise sliders are a fader taper | Two halves with a knee at the middle, linear at 0.406 below it. Reading them straight put the sub 8 dB high through the middle of its travel. |
 | The mixer trims what it sums | A ±1 square sits 4.77 dB over a plain ramp; the plugin holds them 3.35 dB apart. |
 | The VCA gate was being overwritten | Its rise and fall shared the contour's coefficients, and the panel writes the mode before the sliders — so every gate patch ran on its contour. |
+| A contour heading for silence carries on | Decay and release ran their segment to −40 dB and snapped. The plugin holds the same rate past −110. Synth Drum, whose only sound source is the filter singing at a sustain of zero, went silent under a held key. |
+| Both LFO depths are curves, not lines | The pitch depth is the square of the setting reaching 3.9 semitones; the filter depth is an S-curve reaching 3.6 octaves. Taken straight, the bottom third of either slider is three to ten times too deep — and that is where nearly every patch that uses them sits. |
 
 Where the two still disagree, and the service notes win: the LFO reaches 22 Hz
 at the top of its slider, which is factory adjustment 7 and Fig. 29 of the
 service notes (a 45 ms period); the plugin runs to something above 40 Hz.
 
 Confirmed rather than changed: pitch and the octave switch across the keyboard,
-the contour's ten octaves, the release curve at every setting of its slider,
+the contour's ten octaves, the shape of the release at every setting of its
+slider,
 the attack within 10–20 % across the travel, and the whole chorus — rate, delay
 range and which channel is inverted, on all three settings, agreeing with the
 Juno60 measurements it was built from.
@@ -539,6 +542,13 @@ It runs hot enough to clip at the top of its own level slider, so a reference
 taken there flatters everything compared against it. And its chorus modulates
 its output amplitude at twice the rate of its delay, which reads as a chorus
 running at double speed unless the delay itself is tracked.
+
+Recorded and left alone, because the difference is smaller than the one between
+the sources already on the shelf: the decay and release times run 15–20 % fast
+between a third and half of the slider and 10–15 % slow between two thirds and
+four fifths, and the chorus rates differ by 10 % on II and 5 % on I+II. The
+specification sheet and the instrument that was measured for it are 12 s and
+19.8 s apart on the same decay, so a fifth either way settles nothing.
 
 ## Deliberate deviations from the original
 
@@ -557,10 +567,13 @@ running at double speed unless the delay itself is tracked.
    take the filter from shut to open, so it has to cover essentially that whole
    range. Measured against Roland's plugin afterwards, its contour is worth
    about 10.8 octaves at full — the guess was a good one.
-5. **The DCO LFO is worth three semitones at full depth.** Seven was a guess
-   and badly wrong: "Piano 1" has the slider at 0.4, which at seven semitones
-   is a wobble of nearly three — a ghost, not a piano. Roland's plugin puts
-   full deflection at 379 cents, so three is where it belongs.
+5. **The DCO LFO is worth 3.9 semitones at full depth, and the slider reaches
+   it as a square.** Seven was a guess and badly wrong; three was closer but
+   still straight. Measured against Roland's plugin at 0.1 steps, the pitch is
+   384 cents times the square of the setting, and the square fits all ten
+   points to a hundredth. The slider at a tenth is three cents, not
+   twenty-nine — the difference between a hint of vibrato and a wobble, and
+   nearly all of the sixteen patches that use it sit down at that end.
 6. **The VCA level is squared.** It was linear, because the imported junox
    patch set was authored against a linear mapping. That argument lapsed with
    the transcription from the owner's manual, whose level column cannot be

--- a/instruments/PicoFaceJ6/include/juno/juno_dco.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_dco.h
@@ -149,7 +149,7 @@ public:
             float t2 = t - pw_;
             if (t2 < 0.0f) t2 += 1.0f;
             p -= junoPolyBlep(t2, dt);
-            out += p;
+            out += p * JUNO_PULSE_TRIM;
         }
 
         if (sub_ > 0.0f) {
@@ -159,7 +159,7 @@ public:
             float t3 = subPhase_ - 0.5f;
             if (t3 < 0.0f) t3 += 1.0f;
             s -= junoPolyBlep(t3, dts);
-            out += s * sub_;
+            out += s * sub_ * JUNO_SUB_TRIM;
 
             subPhase_ += dts;
             if (subPhase_ >= 1.0f) subPhase_ -= 1.0f;
@@ -174,7 +174,7 @@ public:
             /* Low-passed at 5 kHz -- the note on the AR80017A filter clone
              * says the instrument's noise source is, and without it the noise
              * sits on top of the tone instead of inside it. */
-            out += noiseLp_.process(noise_.white()) * nz_ * 1.6f;
+            out += noiseLp_.process(noise_.white()) * nz_ * (1.6f * JUNO_NOISE_TRIM);
         }
 
         phase_ += dt;

--- a/instruments/PicoFaceJ6/include/juno/juno_dco.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_dco.h
@@ -91,6 +91,28 @@ public:
         pw_ = junoClamp(pw, JUNO_PW_MIN, JUNO_PW_MAX);
     }
 
+    /*
+     * The panel's PWM setting as a pulse width. It was a straight line from
+     * JUNO_PW_MIN to JUNO_PW_MAX; measured against Roland's plugin it is a
+     * raised cosine between the same two ends, which is what a sawtooth
+     * compared against a moving threshold gives. The line was up to five
+     * points of duty out in the middle of the travel -- 7 dB on the second
+     * harmonic at a quarter of the way up.
+     *
+     * The modulated modes hand their own effective setting to the same curve;
+     * that they share it is an assumption, not a measurement.
+     *
+     * u*u*(3-2u) stands in for (1-cos(pi*u))/2, which it matches to better
+     * than a hundredth -- under a point of duty, against the two points the
+     * fit itself is worth -- and costs three multiplies instead of a cosine
+     * per voice per sample.
+     */
+    static inline float widthOf(float u)
+    {
+        u = junoClamp(u, 0.0f, 1.0f);
+        return JUNO_PW_MIN + (JUNO_PW_MAX - JUNO_PW_MIN) * u * u * (3.0f - 2.0f * u);
+    }
+
     float process(float pitchMul)
     {
         const float dt = inc_ * pitchMul;
@@ -112,16 +134,22 @@ public:
         }
 
         if (pulse_) {
+            /*
+             * No level compensation. A narrow pulse carries less energy than a
+             * square and is meant to: measured against Roland's plugin, its
+             * level follows 2*sqrt(d(1-d)) all the way down -- 8.6 dB from the
+             * square to the narrowest setting, within a decibel of what the
+             * arithmetic says an uncompensated pulse does. The width control
+             * really does double as a volume control, which is what PWM
+             * sounds like. A compensation term used to stand here and lifted
+             * the narrow end by up to 3.3 dB.
+             */
             float p = (t < pw_) ? 1.0f : -1.0f;
             p += junoPolyBlep(t, dt);
             float t2 = t - pw_;
             if (t2 < 0.0f) t2 += 1.0f;
             p -= junoPolyBlep(t2, dt);
-            /* A narrow pulse carries far less energy than a square. Without
-             * this the pulse-width control would double as a volume
-             * control. */
-            out += p * (0.6f + 0.8f * (pw_ - JUNO_PW_MIN) /
-                                      (JUNO_PW_MAX - JUNO_PW_MIN));
+            out += p;
         }
 
         if (sub_ > 0.0f) {

--- a/instruments/PicoFaceJ6/include/juno/juno_dco.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_dco.h
@@ -99,9 +99,16 @@ public:
         float out = 0.0f;
 
         if (saw_) {
-            /* The Juno sawtooth falls rather than rises, which matters only
-             * for how it sums with the pulse. */
-            out += (2.0f * t - 1.0f) - junoPolyBlep(t, dt);
+            /*
+             * The Juno sawtooth falls rather than rises, and that is not
+             * cosmetic: it decides whether the sawtooth and the pulse add or
+             * subtract. A rising ramp has a fundamental of -sin, the pulse
+             * has +sin, and the eleven factory patches that switch both on
+             * lost 14 dB of every odd harmonic to the cancellation -- their
+             * fundamental first of all. Measured against Roland's plugin,
+             * where the two add.
+             */
+            out += (1.0f - 2.0f * t) + junoPolyBlep(t, dt);
         }
 
         if (pulse_) {

--- a/instruments/PicoFaceJ6/include/juno/juno_defs.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_defs.h
@@ -318,6 +318,12 @@
 
 /* Gate mode, measured: attack 3 ms, release 6 ms. Present to stop clicks
  * rather than to shape anything. */
+/*
+ * The sustain slider against the level it actually holds, measured off
+ * Roland's plugin: 1 - (1-s)^1.6. See JunoEnv::setSustain.
+ */
+#define JUNO_SUSTAIN_CURVE   1.6f
+
 #define JUNO_GATE_ATTACK_S   0.003f
 #define JUNO_GATE_RELEASE_S  0.006f
 

--- a/instruments/PicoFaceJ6/include/juno/juno_defs.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_defs.h
@@ -140,6 +140,19 @@
 /* Sub-oscillator: a square one octave below the DCO.                         */
 #define JUNO_SUB_OCTAVES   (-1.0f)
 
+/*
+ * What the mixer does to each source on its way in, relative to the sawtooth.
+ *
+ * A plain +/-1 square sits 4.77 dB above a plain sawtooth ramp, and that is
+ * what came out of here. Roland's plugin holds them 3.35 dB apart, and its sub
+ * -- also a square -- the same. Measured with the level well down so that
+ * neither side clips, since the plugin runs hot enough at full to do so and a
+ * clipped reference flatters everything measured against it.
+ */
+#define JUNO_PULSE_TRIM     0.861f   /* -1.3 dB */
+#define JUNO_SUB_TRIM       0.861f   /* -1.3 dB */
+#define JUNO_NOISE_TRIM     0.813f   /* -1.8 dB */
+
 /* Noise. A note on the AR80017A filter clone says the noise source is
  * low-passed at 5 kHz, which is what keeps it from sounding like a hiss
  * generator bolted to the side. */

--- a/instruments/PicoFaceJ6/include/juno/juno_defs.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_defs.h
@@ -255,7 +255,13 @@
 #define JUNO_CONTOUR_OCTAVES   10.0f
 #endif
 
-#define JUNO_LFO_VCF_OCTAVES    3.0f
+/*
+ * How far the LFO moves the cutoff is no longer a single number: measured
+ * against Roland's plugin the slider follows a strong S-curve, from a
+ * fortieth of an octave at 0.1 to 3.6 either side at full. kJunoVcfLfoOct in
+ * juno_dsp.h carries the measured points. Three octaves, taken as a straight
+ * line, stood here.
+ */
 
 /* ------------------------------------------------------------------------   */
 /* HPF                                                                        */
@@ -385,7 +391,12 @@
  * a violin or an oboe wants three or four times that. Seven, which it held
  * before that, was a guess and was too much.
  */
-#define JUNO_LFO_DCO_SEMIS   3.0f
+/*
+ * Pitch at full LFO depth, as a half-swing, and the slider reaches it as a
+ * square rather than a straight line -- see JUNO_DCO_LFO in juno.cpp. 3.0
+ * stood here against Roland's plugin's 3.9.
+ */
+#define JUNO_LFO_DCO_SEMIS   3.9f
 
 /* ------------------------------------------------------------------------   */
 /* Chorus -- 2x MN3009 BBD, MN3101 clocks                                     */

--- a/instruments/PicoFaceJ6/include/juno/juno_defs.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_defs.h
@@ -169,6 +169,19 @@
 #define JUNO_CUTOFF_MAX_HZ  18000.0f
 
 /*
+ * How that range is laid out along the slider, measured off Roland's plugin
+ * by reading the corner as the resonant peak: 17.0 octaves per unit of
+ * travel, so 20 Hz falls at 0.158 and 18 kHz at 0.735, and the ends are flat.
+ *
+ * Spreading the range evenly over the whole travel, which is what this did
+ * before, puts the middle of the slider an octave low and its upper third
+ * two to three octaves low. The specification's range is not in question --
+ * only where on the slider it sits, and the specification does not say.
+ */
+#define JUNO_CUTOFF_OCT_PER_UNIT 17.0f
+#define JUNO_CUTOFF_OCT_ZERO      2.69f
+
+/*
  * Ceiling on the cutoff the filter itself will accept, as a fraction of the
  * rate it runs at: one radian per sample, 1/2pi.
  *

--- a/instruments/PicoFaceJ6/include/juno/juno_defs.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_defs.h
@@ -194,7 +194,19 @@
  * the identical reason.
  */
 #define JUNO_FILTER_WC_MAX_OVER_2PI 0.15915f
-#define JUNO_RESONANCE_MAX      1.06f   /* self-oscillates a little above 1 */
+/*
+ * Where the resonance slider puts the loop gain, as a multiple of the gain at
+ * which the ladder sings -- so 1.0 is the threshold and the panel maximum sits
+ * a quarter above it.
+ *
+ * This was 1.06, which put the threshold at slider 0.94 and left the last
+ * sixteenth of the travel to do all of the singing: bank 7, whose eight
+ * patches the owner's manual describes as having "VCF self-oscillation" for a
+ * sound source, only just started to speak and did so 20 dB too quietly.
+ * Roland's plugin crosses over between 0.7 and 0.8 -- sharply, and at a
+ * settled level from there on -- so the threshold belongs at 0.8.
+ */
+#define JUNO_RESONANCE_MAX      1.35f
 #define JUNO_VCF_GCOMP          0.85f   /* Moog ladder uses 0.5; see above  */
 
 /*

--- a/instruments/PicoFaceJ6/include/juno/juno_dsp.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_dsp.h
@@ -86,6 +86,35 @@ static inline float junoLimit(float x)
 /* 2^x for the pitch and cutoff maths. Notes are tracked in semitones and
  * octaves throughout, so this sits on the control path, not on the audio
  * path, and the library version is fine. */
+/*
+ * The DCO's level sliders -- sub-oscillator and noise -- against the level
+ * they actually produce, measured off Roland's plugin at 0.05 steps. Both
+ * sliders follow it to a hundredth of a decibel of each other, so it is one
+ * taper and not two.
+ *
+ * It is a fader taper in two straight-ish halves with an exact knee at the
+ * middle: the lower half is linear at 0.406 of the setting, so the slider at
+ * a half reaches only a fifth of full level, and the upper half covers the
+ * remaining 14 dB. Reading it as linear -- which is what this did -- makes the
+ * sub eight decibels too loud through the middle of its travel, and most of
+ * the factory patches that use it sit exactly there.
+ */
+static const float kJunoDcoLevel[21] = {
+    0.0000f, 0.0206f, 0.0412f, 0.0602f, 0.0808f, 0.1014f, 0.1204f,
+    0.1410f, 0.1616f, 0.1822f, 0.2028f, 0.2311f, 0.2861f, 0.3613f,
+    0.4442f, 0.5436f, 0.6479f, 0.7514f, 0.8487f, 0.9285f, 1.0000f
+};
+
+static inline float junoDcoLevel(float v)
+{
+    if (v <= 0.0f) return 0.0f;
+    if (v >= 1.0f) return 1.0f;
+    const float x = v * 20.0f;
+    const int   i = (int) x;
+    const float f = x - (float) i;
+    return kJunoDcoLevel[i] + f * (kJunoDcoLevel[i + 1] - kJunoDcoLevel[i]);
+}
+
 static inline float junoExp2f(float x) { return exp2f(x); }
 
 /*

--- a/instruments/PicoFaceJ6/include/juno/juno_dsp.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_dsp.h
@@ -99,6 +99,34 @@ static inline float junoLimit(float x)
  * sub eight decibels too loud through the middle of its travel, and most of
  * the factory patches that use it sit exactly there.
  */
+/*
+ * The VCF LFO slider against how far it actually moves the corner, in octaves
+ * either side of it, measured off Roland's plugin at 0.05 steps by tracking a
+ * resonant peak under a very slow LFO.
+ *
+ * It is nothing like the straight line this used to be. The bottom third of
+ * the travel barely moves the filter at all -- a fortieth of an octave at 0.1,
+ * an eighth at 0.2 -- and the top reaches 3.6 octaves rather than 3. Thirteen
+ * of the fifteen factory patches that use it sit between 0.10 and 0.30, where
+ * the straight line was three to ten times too deep: a wobble where the
+ * instrument has a hint of one.
+ */
+static const float kJunoVcfLfoOct[21] = {
+    0.000f, 0.008f, 0.023f, 0.061f, 0.137f, 0.280f, 0.441f,
+    0.651f, 0.920f, 1.175f, 1.481f, 1.755f, 1.992f, 2.260f,
+    2.481f, 2.662f, 2.859f, 2.991f, 3.131f, 3.385f, 3.597f
+};
+
+static inline float junoVcfLfoOctaves(float v)
+{
+    if (v <= 0.0f) return 0.0f;
+    if (v >= 1.0f) return kJunoVcfLfoOct[20];
+    const float x = v * 20.0f;
+    const int   i = (int) x;
+    const float f = x - (float) i;
+    return kJunoVcfLfoOct[i] + f * (kJunoVcfLfoOct[i + 1] - kJunoVcfLfoOct[i]);
+}
+
 static const float kJunoDcoLevel[21] = {
     0.0000f, 0.0206f, 0.0412f, 0.0602f, 0.0808f, 0.1014f, 0.1204f,
     0.1410f, 0.1616f, 0.1822f, 0.2028f, 0.2311f, 0.2861f, 0.3613f,

--- a/instruments/PicoFaceJ6/include/juno/juno_env.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_env.h
@@ -79,8 +79,7 @@ public:
     void setAttack(float v)
     {
         aPanel_ = v;
-        aStep_  = stepFor(junoAttackTime(v));
-        aMul_   = expf(-aStep_);
+        updateAttack();
     }
 
     void setDecay(float v)
@@ -93,11 +92,31 @@ public:
     void setRelease(float v)
     {
         rPanel_ = v;
-        rStep_  = stepFor(junoDecayTime(v));
-        rMul_   = expf(-JUNO_FALL_SHAPE * rStep_);
+        updateRelease();
     }
 
     void setSustain(float v) { sustain_ = junoClamp(v, 0.0f, 1.0f); }
+
+    /*
+     * The gate's own rise and fall, and the contour's, live in the same two
+     * pairs of coefficients, so whichever was written last used to win. The
+     * panel is written in its own order and the VCA switch comes before the
+     * envelope sliders, so selecting a patch always ended by overwriting the
+     * gate with the contour: every gate-mode patch in the bank ran on its
+     * envelope's attack and release, and only the forced sustain still marked
+     * it as a gate. These two put the choice back where it is made.
+     */
+    void updateAttack()
+    {
+        aStep_ = stepFor(gate_ ? JUNO_GATE_ATTACK_S : junoAttackTime(aPanel_));
+        aMul_  = expf(-aStep_);
+    }
+
+    void updateRelease()
+    {
+        rStep_ = stepFor(gate_ ? JUNO_GATE_RELEASE_S : junoDecayTime(rPanel_));
+        rMul_  = expf(-JUNO_FALL_SHAPE * rStep_);
+    }
 
     /*
      * Gate mode. The VCA can be driven by the contour or by a plain gate; the
@@ -107,15 +126,8 @@ public:
     void setGateMode(bool on)
     {
         gate_ = on;
-        if (on) {
-            aStep_ = stepFor(JUNO_GATE_ATTACK_S);
-            aMul_  = expf(-aStep_);
-            rStep_ = stepFor(JUNO_GATE_RELEASE_S);
-            rMul_  = expf(-JUNO_FALL_SHAPE * rStep_);
-        } else {
-            setAttack(aPanel_);
-            setRelease(rPanel_);
-        }
+        updateAttack();
+        updateRelease();
     }
 
     /*

--- a/instruments/PicoFaceJ6/include/juno/juno_env.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_env.h
@@ -95,7 +95,27 @@ public:
         updateRelease();
     }
 
-    void setSustain(float v) { sustain_ = junoClamp(v, 0.0f, 1.0f); }
+    /*
+     * The sustain slider is not the sustain level. Measured against Roland's
+     * plugin on both routes at once -- as a held amplitude with the filter
+     * open, and as the filter's own corner with the contour driving it -- the
+     * level is 1 - (1-s)^1.6, which is well above the setting everywhere in
+     * between: the slider at a third holds at 0.45, not at 0.33.
+     *
+     * Taking the slider for the level made every patch that sustains below
+     * full about an octave too dark on a positive contour and most of an
+     * octave too bright on a negative one, and it was the largest thing left
+     * in the comparison. The fit is inside 0.02 from a fifth of the travel
+     * upward and 0.035 below it.
+     *
+     * The two routes agreeing is what makes this the envelope's law rather
+     * than the filter's, so it belongs here and not at either consumer.
+     */
+    void setSustain(float v)
+    {
+        v = junoClamp(v, 0.0f, 1.0f);
+        sustain_ = 1.0f - powf(1.0f - v, JUNO_SUSTAIN_CURVE);
+    }
 
     /*
      * The gate's own rise and fall, and the contour's, live in the same two

--- a/instruments/PicoFaceJ6/include/juno/juno_env.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_env.h
@@ -223,11 +223,27 @@ public:
                 phase_ += dStep_;
                 curve_ *= dMul_;                    /* e^(-k phase)        */
                 const float s = effSustain();
-                if (phase_ >= 1.0f) {
-                    level_ = s;
-                    stage_ = SUSTAIN;
+                /*
+                 * The segment's nominal length carries the exponential to
+                 * -40 dB, and a decay that is heading for a sustain of zero
+                 * used to be cut off there. Roland's plugin carries the same
+                 * rate on down: a decay of half travel falls at a steady
+                 * 33 dB a second past -110 dB without a kink anywhere. Cutting
+                 * it at -40 turns the tail of every percussive patch into a
+                 * step, and on a patch whose only sound source is the filter
+                 * singing -- Synth Drum, and the rest of bank 7 -- it silences
+                 * the note outright where the plugin holds a clean tone.
+                 *
+                 * So the phase only ends the segment when there is a sustain
+                 * to end it at; heading for silence it runs until it is
+                 * silent.
+                 */
+                if (s > kSilence) {
+                    if (phase_ >= 1.0f) { level_ = s; stage_ = SUSTAIN; }
+                    else                { level_ = s + (1.0f - s) * curve_; }
                 } else {
-                    level_ = s + (1.0f - s) * curve_;
+                    level_ = curve_;
+                    if (level_ <= kSilence) { level_ = 0.0f; stage_ = SUSTAIN; }
                 }
                 break;
             }
@@ -237,14 +253,13 @@ public:
                 break;
 
             case RELEASE:
+                /* Same as the decay: a release always heads for silence, so
+                 * the rate carries it there rather than the segment length
+                 * cutting it off at -40 dB. */
                 phase_ += rStep_;
                 curve_ *= rMul_;
-                if (phase_ >= 1.0f) {
-                    level_ = 0.0f;
-                    stage_ = IDLE;
-                } else {
-                    level_ = relFrom_ * curve_;
-                }
+                level_ = relFrom_ * curve_;
+                if (level_ <= kSilence) { level_ = 0.0f; stage_ = IDLE; }
                 break;
 
             case IDLE:
@@ -256,6 +271,10 @@ public:
     }
 
 private:
+    /* Below this a contour counts as arrived: -120 dB, under the voice's own
+     * noise floor and under anything 16 bits can carry. */
+    static constexpr float kSilence = 1.0e-6f;
+
     /* Phase advance per sample for a segment of the given duration. */
     float stepFor(float seconds) const
     {

--- a/instruments/PicoFaceJ6/include/juno/juno_filter.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_filter.h
@@ -9,9 +9,19 @@
   setting the amount of feedback around each.
 
   That is four OTA integrator sections in series inside a feedback loop -- the
-  same class of circuit as the transistor ladder in a Model D, and modelled the
-  same way: Huovilainen's tuning of the four one-poles, with Krajeski's
-  arrangement of the feedback and one saturating stage at the input.
+  same class of circuit as the transistor ladder in a Model D. The four
+  one-poles are topology-preserving transforms and the loop around them is
+  solved for the current sample rather than delayed, with one saturating stage
+  at the input.
+
+  It was Huovilainen's polynomial fit before, and that fit is only good to
+  about one radian per sample: past that its resonance term crosses zero and
+  the feedback turns positive. The filter therefore carried a ceiling at
+  sr/2pi -- 7.0 kHz at this rate, and in practice a resonant peak that stopped
+  at 3.8 kHz. Every patch with the cutoff slider past the middle was duller
+  than it should be, which is what measuring against Roland's plugin showed.
+  A TPT ladder is tuned correctly at every frequency up to Nyquist, so the
+  ceiling is gone and nothing takes its place.
 
   junox models it as a diode ladder instead. A diode ladder is an EMS and
   TB-303 topology; it is not an IR3109, and it costs about twice as much to
@@ -39,87 +49,138 @@ class JunoFilter
 public:
     void init(float sampleRate)
     {
-        sr_ = sampleRate;
+        setSampleRate(sampleRate);
         reset();
-        setCutoff(1000.0f);
+        setCutoffOct(5.0f);
         setResonance(0.0f);
     }
 
-    void setSampleRate(float sampleRate) { sr_ = sampleRate; }
+    void setSampleRate(float sampleRate)
+    {
+        sr_ = sampleRate;
+        buildTable(sampleRate);
+    }
 
     void reset()
     {
-        for (int i = 0; i < 5; ++i) { state_[i] = 0.0f; delay_[i] = 0.0f; }
+        for (int i = 0; i < 4; ++i) s_[i] = 0.0f;
     }
 
     /*
-     * Cutoff in Hz. wc is the angular frequency normalised to the sample rate;
-     * the polynomial is Huovilainen's fit for the tuning of the one-pole
-     * sections, which keeps the corner where it is asked for instead of
-     * flattening out towards Nyquist as a plain bilinear transform does.
+     * Cutoff in octaves above JUNO_CUTOFF_MIN_HZ, which is the form everything
+     * upstream already has: the panel, the contour, key follow and the LFO all
+     * add in octaves, exactly as their control voltages do in the instrument.
+     * Taking octaves here saves the exponential the voice used to do, and the
+     * table is indexed by them directly.
      */
+    void setCutoffOct(float oct)
+    {
+        float x = (oct - kOctMin) * kPerOct;
+        if (x < 0.0f) x = 0.0f;
+        if (x > (float) (kTableN - 1)) x = (float) (kTableN - 1);
+        const int   i = (int) x;
+        const float f = x - (float) i;
+        g_ = table_[i] + f * (table_[i + 1] - table_[i]);   /* g/(1+g) */
+        updateCoeffs();
+    }
+
+    /* Kept for callers that think in Hz -- the host tests do. */
     void setCutoff(float hz)
     {
-        /* Not Nyquist -- the fits below break long before that. See
-         * JUNO_FILTER_WC_MAX_OVER_2PI. */
-        hz = junoClamp(hz, 5.0f, sr_ * JUNO_FILTER_WC_MAX_OVER_2PI);
-        wc_ = 2.0f * (float) M_PI * hz / sr_;
-
-        const float w2 = wc_ * wc_;
-        const float w3 = w2 * wc_;
-        const float w4 = w3 * wc_;
-
-        g_ = 0.9892f * wc_ - 0.4342f * w2 + 0.1381f * w3 - 0.0202f * w4;
-
-        /* The resonance correction depends on the cutoff, so it has to come
-         * out again here -- otherwise a sweep at a fixed Resonance setting
-         * would change its resonance on the way. */
-        updateRes();
+        setCutoffOct(log2f(junoClamp(hz, 1.0f, 1.0e6f) / JUNO_CUTOFF_MIN_HZ));
     }
 
     /* 0 .. JUNO_RESONANCE_MAX; self-oscillates a little above 1, which is what
-     * the specifications page means by "0 - Self Oscillation". */
+     * the specifications page means by "0 - Self Oscillation". The ladder
+     * sings at a loop gain of four, so the panel value is the loop gain over
+     * four and needs no frequency correction of its own -- that correction
+     * existed only to patch up the polynomial fit. */
     void setResonance(float r)
     {
-        res_ = junoClamp(r, 0.0f, JUNO_RESONANCE_MAX);
-        updateRes();
+        r = junoClamp(r, 0.0f, JUNO_RESONANCE_MAX);
+        if (r != res_) { res_ = r; updateCoeffs(); }
     }
 
     float process(float in)
     {
-        /* Input stage through the saturating pair. gComp feeds part of the
-         * input back into the loop; at 0.85 the low end stays where it is as
-         * the resonance rises, which is the difference between an OTA cascade
-         * and a transistor ladder. */
-        state_[0] = junoTanh(in - 4.0f * gRes_ *
-                                  (state_[4] - JUNO_VCF_GCOMP * in));
+        /*
+         * gComp lifts the input as the feedback rises, so the low end stays
+         * where it is instead of draining away: that is the difference between
+         * an OTA cascade with its own feedback amplifier and a transistor
+         * ladder, and most of why a Juno with the resonance up is never thin.
+         */
+        const float x = in * (1.0f + k_ * JUNO_VCF_GCOMP);
+
+        /* What the four stages will contribute from their current states, so
+         * the loop can be closed on this sample instead of the last one. */
+        const float S = c3_ * s_[0] + c2_ * s_[1] + c1_ * s_[2] + c0_ * s_[3];
+
+        float y = junoTanh((x - k_ * S) * invDen_);
 
         for (int i = 0; i < 4; ++i) {
-            state_[i + 1] += g_ * (0.230769f * state_[i]      /* 0.3/1.3 */
-                                 + 0.769231f * delay_[i]      /* 1.0/1.3 */
-                                 - state_[i + 1]);
-            delay_[i] = state_[i];
+            const float v = (y - s_[i]) * g_;
+            y    = v + s_[i];
+            s_[i] = y + v;
         }
-        return state_[4];
+        return y;
     }
 
 private:
-    void updateRes()
+    void updateCoeffs()
     {
-        const float w2 = wc_ * wc_;
-        const float w3 = w2 * wc_;
-        gRes_ = res_ * (1.0029f + 0.0526f * wc_ - 0.926f * w2 + 0.0218f * w3);
+        k_ = 4.0f * res_;
+        const float om = 1.0f - g_;
+        const float g2 = g_ * g_;
+        c0_ = om;
+        c1_ = g_ * om;
+        c2_ = g2 * om;
+        c3_ = g2 * g_ * om;
+        invDen_ = 1.0f / (1.0f + k_ * g2 * g2);
     }
 
-    float sr_    = (float) SAMPLING_RATE;
-    float wc_    = 0.1f;
-    float g_     = 0.1f;
-    float res_   = 0.0f;
-    float gRes_  = 0.0f;
+    /*
+     * g/(1+g) with g = tan(pi f / sr), tabulated against the cutoff in
+     * octaves. A tangent per voice per sample is the one thing this filter
+     * cannot afford -- setCutoffOct is called six times per sample -- and the
+     * curve is smooth enough that 32 points per octave interpolate to better
+     * than a thousandth. Above Nyquist the entry saturates at 1, which makes
+     * the stage a wire: the right answer for a filter asked to open further
+     * than the sample rate can express.
+     */
+    static constexpr float kOctMin = -3.0f;   /* 2.5 Hz  */
+    static constexpr float kOctMax = 16.0f;   /* 1.3 MHz, clamped to Nyquist */
+    static constexpr int   kPerOct = 32;
+    static constexpr int   kTableN = (int) ((kOctMax - kOctMin) * kPerOct) + 1;
 
-    float state_[5] = {};
-    float delay_[5] = {};
+    static void buildTable(float sr)
+    {
+        if (sr == tableSr_) return;
+        tableSr_ = sr;
+        const float nyq = 0.4995f * sr;
+        for (int i = 0; i < kTableN + 1; ++i) {
+            float hz = JUNO_CUTOFF_MIN_HZ *
+                       exp2f(kOctMin + (float) i / (float) kPerOct);
+            if (hz > nyq) hz = nyq;
+            const float g = tanf((float) M_PI * hz / sr);
+            table_[i] = g / (1.0f + g);
+        }
+    }
+
+    static float table_[kTableN + 1];
+    static float tableSr_;
+
+    float sr_   = (float) SAMPLING_RATE;
+    float g_    = 0.1f;      /* g/(1+g) of one stage */
+    float res_  = -1.0f;
+    float k_    = 0.0f;      /* loop gain, four at self-oscillation */
+    float c0_ = 0.0f, c1_ = 0.0f, c2_ = 0.0f, c3_ = 0.0f;
+    float invDen_ = 1.0f;
+
+    float s_[4] = {};
 };
+
+inline float JunoFilter::table_[JunoFilter::kTableN + 1] = {};
+inline float JunoFilter::tableSr_ = 0.0f;
 
 /* ------------------------------------------------------------------------ */
 /* High-pass                                                                 */

--- a/instruments/PicoFaceJ6/include/juno/juno_voice.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_voice.h
@@ -44,7 +44,7 @@ struct JunoVoiceParams {
     float resonance  = 0.0f;
     float envAmount  = 0.0f;
     float envPolarity= 1.0f;    /* +1 or -1                                 */
-    float lfoAmount  = 0.0f;
+    float lfoOct     = 0.0f;    /* LFO to cutoff, in octaves either side */
     float keyFollow  = 0.0f;
 
     /* ENV / VCA */
@@ -167,7 +167,7 @@ public:
          * in the instrument. Key follow is measured from C4. */
         float oct = p.cutoffOct
                   + p.envAmount * p.envPolarity * e * JUNO_CONTOUR_OCTAVES
-                  + p.lfoAmount * lfo * JUNO_LFO_VCF_OCTAVES
+                  + p.lfoOct * lfo
                   + p.keyFollow * ((float) note_ - (float) JUNO_CENTER_NOTE)
                                 * (1.0f / 12.0f);
 

--- a/instruments/PicoFaceJ6/include/juno/juno_voice.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_voice.h
@@ -150,14 +150,13 @@ public:
         float pw;
         switch (p.pwmMode) {
             case 1:  /* manual */
-                pw = JUNO_PW_MIN + p.pwm * (JUNO_PW_MAX - JUNO_PW_MIN);
+                pw = JunoDco::widthOf(p.pwm);
                 break;
             case 2:  /* contour */
-                pw = JUNO_PW_MIN + p.pwm * e * (JUNO_PW_MAX - JUNO_PW_MIN);
+                pw = JunoDco::widthOf(p.pwm * e);
                 break;
             default: /* LFO -- centred, so the width sweeps both ways */
-                pw = JUNO_PW_MIN + p.pwm * (0.5f + 0.5f * lfo) *
-                                   (JUNO_PW_MAX - JUNO_PW_MIN);
+                pw = JunoDco::widthOf(p.pwm * (0.5f + 0.5f * lfo));
                 break;
         }
         dco_.setPulseWidth(pw);

--- a/instruments/PicoFaceJ6/include/juno/juno_voice.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_voice.h
@@ -172,7 +172,7 @@ public:
                   + p.keyFollow * ((float) note_ - (float) JUNO_CENTER_NOTE)
                                 * (1.0f / 12.0f);
 
-        vcf_.setCutoff(JUNO_CUTOFF_MIN_HZ * junoExp2Wide(oct));
+        vcf_.setCutoffOct(oct);
         vcf_.setResonance(p.resonance);
 
         /* --- Audio ------------------------------------------------------ */

--- a/instruments/PicoFaceJ6/src/juno/juno.cpp
+++ b/instruments/PicoFaceJ6/src/juno/juno.cpp
@@ -108,8 +108,9 @@ void Juno::applyParameter(int id)
     case JUNO_DCO_SAW:       vp_.saw      = junoParamOn(v); break;
     case JUNO_DCO_PULSE:     vp_.pulse    = junoParamOn(v); break;
     case JUNO_DCO_SUB:       vp_.subOn    = junoParamOn(v); break;
-    case JUNO_DCO_SUB_LEVEL: vp_.subLevel = v; break;
-    case JUNO_DCO_NOISE:     vp_.noise    = v; break;
+    /* Through the measured fader taper, once here rather than per sample. */
+    case JUNO_DCO_SUB_LEVEL: vp_.subLevel = junoDcoLevel(v); break;
+    case JUNO_DCO_NOISE:     vp_.noise    = junoDcoLevel(v); break;
 
     /* --- HPF ------------------------------------------------------------ */
     case JUNO_HPF:

--- a/instruments/PicoFaceJ6/src/juno/juno.cpp
+++ b/instruments/PicoFaceJ6/src/juno/juno.cpp
@@ -118,7 +118,21 @@ void Juno::applyParameter(int id)
 
     /* --- VCF ------------------------------------------------------------ */
     case JUNO_VCF_FREQ:
-        vp_.cutoffOct = v * log2f(JUNO_CUTOFF_MAX_HZ / JUNO_CUTOFF_MIN_HZ);
+        /*
+         * Where the 20 Hz .. 18 kHz of the specifications page sits on the
+         * slider. It used to be spread over the whole travel, and it is not:
+         * measured against Roland's plugin the corner climbs 17 octaves per
+         * unit of slider, passing 20 Hz at 0.16 and 18 kHz at 0.74, with the
+         * ends flat. The range is the service notes' and unchanged; only its
+         * placement moves, and that is what the plugin is being asked.
+         *
+         * Below 0.16 the plugin keeps going down to about 13 Hz rather than
+         * stopping, but that is under the specification's own floor and below
+         * anything a note reaches through four poles, so the floor stays where
+         * the service notes put it.
+         */
+        vp_.cutoffOct = junoClamp(v * JUNO_CUTOFF_OCT_PER_UNIT - JUNO_CUTOFF_OCT_ZERO,
+                                  0.0f, log2f(JUNO_CUTOFF_MAX_HZ / JUNO_CUTOFF_MIN_HZ));
         break;
     case JUNO_VCF_RES:      vp_.resonance = v * JUNO_RESONANCE_MAX; break;
     case JUNO_VCF_ENV:      vp_.envAmount = v; break;

--- a/instruments/PicoFaceJ6/src/juno/juno.cpp
+++ b/instruments/PicoFaceJ6/src/juno/juno.cpp
@@ -102,7 +102,17 @@ void Juno::applyParameter(int id)
         vp_.octave = kOct[junoParamStep(v, JUNO_RANGE_COUNT)];
         break;
     }
-    case JUNO_DCO_LFO:       vp_.dcoLfo   = v; break;
+    /*
+     * Squared. Measured against Roland's plugin at 0.1 steps, the pitch it
+     * reaches is 384 cents times the square of the setting, and the square
+     * fits every one of those ten points to a hundredth. Taken straight -- as
+     * it was -- the slider at a tenth gives 29 cents where the instrument
+     * gives three, which is the difference between a hint of vibrato and a
+     * wobble. Sixteen factory patches use it, nearly all of them down at that
+     * end: the violin, the clarinet and the oboe are meant to have a few cents
+     * of it, not tens.
+     */
+    case JUNO_DCO_LFO:       vp_.dcoLfo   = v * v; break;
     case JUNO_DCO_PWM:       vp_.pwm      = v; break;
     case JUNO_DCO_PWM_MODE:  vp_.pwmMode  = junoParamStep(v, 3); break;
     case JUNO_DCO_SAW:       vp_.saw      = junoParamOn(v); break;
@@ -140,7 +150,8 @@ void Juno::applyParameter(int id)
     case JUNO_VCF_POLARITY:
         vp_.envPolarity = (junoParamStep(v, 2) == 1) ? 1.0f : -1.0f;
         break;
-    case JUNO_VCF_LFO:      vp_.lfoAmount = v; break;
+    /* Held in octaves, through the measured curve. */
+    case JUNO_VCF_LFO:      vp_.lfoOct = junoVcfLfoOctaves(v); break;
     case JUNO_VCF_KYBD:     vp_.keyFollow = v; break;
 
     /* --- VCA ------------------------------------------------------------ */

--- a/instruments/PicoFaceJ6/src/juno/juno.cpp
+++ b/instruments/PicoFaceJ6/src/juno/juno.cpp
@@ -145,17 +145,30 @@ void Juno::applyParameter(int id)
     /* --- VCA ------------------------------------------------------------ */
     case JUNO_VCA_LEVEL:
         /*
-         * Linear, not squared.
+         * Squared.
          *
-         * A squared taper looked like the more slider-ish choice and cost
-         * every patch up to 3 dB: the 48 factory settings were authored
-         * against a linear mapping (junox multiplies the output by patch.vca
-         * directly), so bending the curve underneath them misrepresents all of
-         * them at once. This is also the level that drives the chorus, so it
-         * changes how hard the bucket-brigade lines are pushed -- see
-         * juno_fx.h.
+         * It was linear, on the grounds that the imported junox patch set was
+         * authored against a linear mapping and bending the curve underneath
+         * it would misrepresent every patch at once. That argument has since
+         * lapsed: the 56 patches now come from the owner's manual chart, whose
+         * level column could not be read at all, so every one of them carries
+         * the same 0.700 and no patch is authored against either curve.
+         *
+         * Roland's plugin settles it. Its level slider follows the square of
+         * the setting to within a decibel over the top two thirds of the
+         * travel -- 0.5 gives -12.3 dB where linear would give -6 -- and eases
+         * off below 0.3, where it runs up to 3 dB above the square. The square
+         * is taken here and the easing is not: it is the bottom of a level
+         * control, and no factory patch is anywhere near it.
+         *
+         * The 0.700 that the whole bank sits at loses 3.1 dB to the change, so
+         * the headroom constant on the summed voices makes it back (0.35 ->
+         * 0.50) and the bank comes out exactly where it was. This is also the
+         * level that drives the chorus, so it decides how hard the
+         * bucket-brigade lines are pushed -- and that product, too, is
+         * unchanged for the bank.
          */
-        volume_ = v;
+        volume_ = v * v;
         break;
     case JUNO_VCA_MODE: {
         const bool gate = (junoParamStep(v, 2) == 1);
@@ -519,7 +532,7 @@ void Juno::processFloat(float* out_l, float* out_r, int frames)
 
             /* Six voices at once would otherwise run out of headroom before
              * the filter does. */
-            sum *= 0.35f;
+            sum *= 0.50f;
 
             for (int os = 0; os < JUNO_OVERSAMPLE; ++os)
                 sum = dec_[2].process(dec_[1].process(dec_[0].process(sum)));

--- a/instruments/PicoFaceJ6/src/juno/juno_presets.cpp
+++ b/instruments/PicoFaceJ6/src/juno/juno_presets.cpp
@@ -44,8 +44,10 @@
         The chart really does put vibrato on both. Neither instrument has any,
         and with the trigger mode on manual the LFO runs free rather than
         waiting for the button, so it is heard on every note. At the corrected
-        modulation depth of three semitones this would be over a hundred cents
-        on a piano. Worth a listen before it is trusted either way.
+        modulation depth -- 3.9 semitones reached as the square of the
+        setting -- it is 79 cents on the piano and 62 on the clavichord,
+        which is still most of a semitone. Worth a listen before it is
+        trusted either way.
 
     Brass         VCA level 0.7 -> 1.0
         Also from that test, and independently supported: the chart's own level

--- a/tools/j6_vst/.gitignore
+++ b/tools/j6_vst/.gitignore
@@ -1,0 +1,4 @@
+render_note
+__pycache__/
+.venv/
+*.csv

--- a/tools/j6_vst/README.md
+++ b/tools/j6_vst/README.md
@@ -1,0 +1,64 @@
+# J6 against Roland's JUNO-60 VST, automated
+
+Renders the same front panel through Roland's JUNO-60 VST3 (via
+[pedalboard](https://github.com/spotify/pedalboard), no DAW) and through the
+J6 engine on the host, and compares them. Both sides run at 44.1 kHz, the
+engine's own rate, so neither is resampled.
+
+Local only: needs the Roland Cloud JUNO-60 installed and a Python venv.
+
+```bash
+python3 -m venv .venv && .venv/bin/pip install -r tools/j6_vst/requirements.txt
+tools/j6_vst/build_render.sh                       # engine-side renderer
+.venv/bin/python tools/j6_vst/compare.py 0 3 24     # a few patches
+.venv/bin/python tools/j6_vst/compare.py --all --dry --csv all_dry.csv
+```
+
+Per patch: level under the note (V = VST, O = ours), the tail after the key,
+spectral centroid, h2 and h5 re h1, stereo correlation, and how many
+parameters had to be clamped to the plugin's range. `--dry` switches the
+chorus off on both sides, `--keep DIR` keeps the stereo f32 renders.
+
+Unlike the D-50, whose plugin takes the factory patch bytes directly, the
+Juno's two sides share a *panel* rather than a patch: `render_note dumpbank`
+writes the 56 factory patches as 29 normalised parameters each and
+`j6vst.set_patch` puts the same numbers on the plugin.
+
+## What the plugin's parameters mean
+
+Nothing about them is documented, and four of them do the opposite of what
+their names suggest. All of the following was measured against the running
+plugin; the map in `j6vst.py` carries each one at its line.
+
+* **The modulation depths are bipolar with 128 as the centre** — DCO LFO,
+  VCF LFO, VCF contour and VCF key follow all do nothing at 128 and reach
+  full depth at 0 and at 255. Writing 0 for "no modulation" detunes the
+  oscillator by nearly four semitones, which is how this was found.
+* **`env1` is the filter contour and `env2` the amplifier contour.** A
+  Juno-60 has one contour generator for both, so both are written from the
+  same four parameters.
+* **`vca_mode` has three positions and none of them is the obvious one**: 0
+  hangs the amplifier on env1, 1 on env2, and only 2 is the plain gate.
+  Reading 0 as the gate makes every patch whose contour sustains at zero —
+  the three organs among them — die away instead of holding.
+* **`dco_range` is six octaves**, not the instrument's three, with 3 = 8'.
+* `effect_type` 2, 3 and 4 modulate at roughly 0.9, 1.7 and 9.2 Hz and the
+  third is all but mono: Roland's Chorus I, II and I+II. Off is depth 0.
+* `dco_pwm_source` 1 takes the width from the LFO, 2 from the contour, 0
+  holds it still. 3..5 repeat 2 and 0.
+* The plugin renders **silence at 32 kHz** once a patch is set, exactly like
+  the D-50 one. 44.1 kHz is the engine's own rate anyway.
+
+## Roland's own patches
+
+`/Library/Application Support/Roland Cloud/JUNO-60/? Preset.bin` holds three
+banks of 64. The records are 20223 bytes apart, each begins with its name as
+printable ASCII, and the parameter block starts 14 bytes after the name with
+**one nibble per half-byte** in the plugin's own parameter order — so
+`(hi << 4) | lo` per parameter reproduces the plugin's defaults exactly.
+
+That settles a question the comparison rests on: **Roland's presets use the
+whole 0..255 of `vcf_cutoff_freq`** (median 105, 98 distinct values), and the
+same for resonance, the oscillator levels and the high-pass. The plugin's
+byte range really is the panel's travel, so mapping a 0..1 slider straight
+onto 0..255 is right rather than a guess.

--- a/tools/j6_vst/build_render.sh
+++ b/tools/j6_vst/build_render.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Michi71
+# build_render.sh -- the engine side of the Juno-60 VST comparison.
+# Compiles the unmodified src/juno/ sources, no audio device and no PortMidi.
+set -e
+HERE="$(cd "$(dirname "$0")" && pwd)"
+REPO="$(cd "$HERE/../.." && pwd)"
+ROOT="$REPO/instruments/PicoFaceJ6"
+CXX="${CXX:-c++}"
+"$CXX" -std=c++17 -O2 -Wall -ffast-math -DJUNO_HOST_BUILD -I"$ROOT/include" \
+    "$HERE/render_note.cpp" \
+    "$ROOT/src/juno/juno.cpp" "$ROOT/src/juno/juno_params.cpp" \
+    "$ROOT/src/juno/juno_presets.cpp" "$ROOT/src/juno/juno_fx.cpp" \
+    -o "$HERE/render_note"
+echo "[ok]   $HERE/render_note"

--- a/tools/j6_vst/compare.py
+++ b/tools/j6_vst/compare.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python3
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Michi71
+"""Render the same front panel through Roland's JUNO-60 VST and through the
+J6 engine, and compare: level under the note, the tail after the key, the
+harmonic profile, the spectral centroid and the stereo width.
+
+  compare.py [--note 60] [--hold 1.5] [--tail 2.0] [--dry]
+             [--csv out.csv] [--keep DIR] IDX [IDX ...] | --all
+
+Both sides run at 44.1 kHz, the engine's own rate, so neither is resampled.
+--dry switches the chorus off on both sides, which is the form to reach for
+when the question is about the voice rather than about the chorus.
+"""
+import argparse, os, subprocess, sys, tempfile
+import numpy as np
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from j6vst import J6VST, read_bank, NPARAM, CHORUS
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SR = 44100
+
+
+def metrics(x, hold, f0):
+    """x: (n, 2) float32 at 44.1 kHz. Levels in dB, the profile re h1."""
+    def lev(a, b):
+        seg = x[int(a * SR):int(b * SR)]
+        return 10 * np.log10((seg ** 2).mean() + 1e-20) if len(seg) else -200.0
+    t1 = max(0.1, hold - 0.6)
+    seg = x[int(t1 * SR):int(hold * SR)]
+    w = np.hanning(len(seg))[:, None]
+    S = (np.abs(np.fft.rfft(seg * w, axis=0)) ** 2).sum(axis=1)
+    f = np.fft.rfftfreq(len(seg), 1 / SR)
+    prof = [10 * np.log10(S[(f > k * f0 * 0.97) & (f < k * f0 * 1.03)].max() + 1e-20)
+            for k in range(1, 11)]
+    band = (f > 30) & (f < 16000)
+    cent = (f[band] * S[band]).sum() / (S[band].sum() + 1e-20)
+    l, r = x[int(t1 * SR):int(hold * SR), 0], x[int(t1 * SR):int(hold * SR), 1]
+    corr = float(np.corrcoef(l, r)[0, 1]) if l.std() > 0 and r.std() > 0 else 1.0
+    # Attack: how long to within 3 dB of the peak of the first half second.
+    a = np.abs(x[:int(0.5 * SR)]).mean(axis=1)
+    k = 64
+    e = a[:len(a) // k * k].reshape(-1, k).mean(axis=1)
+    pk = e.max() if len(e) else 0.0
+    t_att = (np.argmax(e >= pk * 0.7) * k / SR) if pk > 0 else 0.0
+    env = [lev(t, t + 0.1) for t in np.arange(0.0, hold + 1.5, 0.1)]
+    return dict(hold=lev(t1, hold), attack=lev(0.0, 0.1), t_att=t_att,
+                tail1=lev(hold + 0.3, hold + 0.6), tail2=lev(hold + 1.0, hold + 1.5),
+                centroid=cent, prof=[p - prof[0] for p in prof], corr=corr,
+                peak=float(np.abs(x).max()), env=env)
+
+
+def render_ours(idx, q, note, hold, tail, dry, out):
+    ps = ','.join(f'{v:.6f}' for v in q)
+    subprocess.run([os.path.join(HERE, 'render_note'), out, '--params', ps,
+                    str(note), '100', str(hold), str(tail)] + (['dry'] if dry else []),
+                   check=True)
+    return np.fromfile(out, dtype=np.float32).reshape(-1, 2)
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('idx', nargs='*', type=int)
+    ap.add_argument('--all', action='store_true')
+    ap.add_argument('--note', type=int, default=60)
+    ap.add_argument('--hold', type=float, default=1.5)
+    ap.add_argument('--tail', type=float, default=2.0)
+    ap.add_argument('--dry', action='store_true', help='chorus off on both sides')
+    ap.add_argument('--csv')
+    ap.add_argument('--keep', help='directory to keep the renders (f32 stereo)')
+    a = ap.parse_args()
+
+    tmp = a.keep or tempfile.mkdtemp(prefix='j6vst_')
+    os.makedirs(tmp, exist_ok=True)
+    bankfile = os.path.join(tmp, 'bank.txt')
+    subprocess.run([os.path.join(HERE, 'render_note'), 'dumpbank', bankfile], check=True)
+    bank = read_bank(bankfile)
+    idxs = list(range(len(bank))) if a.all else a.idx
+    if not idxs:
+        ap.error('name some patches, or --all')
+
+    vst = J6VST()
+    f0 = 440.0 * 2 ** ((a.note - 69) / 12)
+    rows = []
+    print(f'{"idx":>3} {"name":16s} {"hold V/O":>13} {"dLev":>6} {"tail V/O":>13} '
+          f'{"dTail":>6} {"cent V/O":>11} {"h2 V/O":>11} {"h5 V/O":>11} {"corr V/O":>11} {"clamp":>5}')
+    for idx in idxs:
+        name, q = bank[idx]
+        if a.dry:
+            q = list(q); q[CHORUS] = 0.0
+        log = vst.set_patch(q, dry=a.dry)
+        x_v = np.ascontiguousarray(vst.render(q, a.note, 100, a.hold, a.tail).T.astype(np.float32))
+        x_o = render_ours(idx, q, a.note, a.hold, a.tail, a.dry,
+                          os.path.join(tmp, f'ours_{idx}.f32'))
+        n = min(len(x_v), len(x_o))
+        x_v, x_o = x_v[:n], x_o[:n]
+        if a.keep:
+            x_v.tofile(os.path.join(tmp, f'vst_{idx}.f32'))
+        mv, mo = metrics(x_v, a.hold, f0), metrics(x_o, a.hold, f0)
+        print(f'{idx:3d} {name:16s} {mv["hold"]:6.1f}/{mo["hold"]:6.1f} {mo["hold"]-mv["hold"]:6.1f} '
+              f'{mv["tail1"]:6.1f}/{mo["tail1"]:6.1f} {mo["tail1"]-mv["tail1"]:6.1f} '
+              f'{mv["centroid"]:5.0f}/{mo["centroid"]:5.0f} {mv["prof"][1]:5.1f}/{mo["prof"][1]:5.1f} '
+              f'{mv["prof"][4]:5.1f}/{mo["prof"][4]:5.1f} {mv["corr"]:5.2f}/{mo["corr"]:5.2f} '
+              f'{len(log):5d}', flush=True)
+        rows.append((idx, name, mv, mo, len(log)))
+
+    if a.csv:
+        with open(a.csv, 'w') as f:
+            f.write('idx,name,hold_vst,hold_ours,tail1_vst,tail1_ours,tail2_vst,tail2_ours,'
+                    'attack_vst,attack_ours,tatt_vst,tatt_ours,centroid_vst,centroid_ours,'
+                    'corr_vst,corr_ours,peak_vst,peak_ours,clamped,'
+                    + ','.join(f'h{k}_vst' for k in range(2, 11)) + ','
+                    + ','.join(f'h{k}_ours' for k in range(2, 11)) + '\n')
+            for idx, name, mv, mo, cl in rows:
+                f.write(f'{idx},"{name}",{mv["hold"]:.2f},{mo["hold"]:.2f},{mv["tail1"]:.2f},'
+                        f'{mo["tail1"]:.2f},{mv["tail2"]:.2f},{mo["tail2"]:.2f},{mv["attack"]:.2f},'
+                        f'{mo["attack"]:.2f},{mv["t_att"]:.3f},{mo["t_att"]:.3f},{mv["centroid"]:.0f},'
+                        f'{mo["centroid"]:.0f},{mv["corr"]:.3f},{mo["corr"]:.3f},{mv["peak"]:.4f},'
+                        f'{mo["peak"]:.4f},{cl},'
+                        + ','.join(f'{v:.1f}' for v in mv['prof'][1:]) + ','
+                        + ','.join(f'{v:.1f}' for v in mo['prof'][1:]) + '\n')
+
+    if len(rows) > 1:
+        d = np.array([mo['hold'] - mv['hold'] for _, _, mv, mo, _ in rows])
+        dt = np.array([mo['tail1'] - mv['tail1'] for _, _, mv, mo, _ in rows])
+        dc = np.array([1200 * np.log2(mo['centroid'] / mv['centroid'])
+                       for _, _, mv, mo, _ in rows if mv['centroid'] > 0 and mo['centroid'] > 0])
+        print(f'\n{len(rows)} patches: level ours-VST median {np.median(d):+.1f} dB '
+              f'(p10 {np.percentile(d,10):+.1f}, p90 {np.percentile(d,90):+.1f}, sd {d.std():.1f}); '
+              f'tail median {np.median(dt):+.1f} dB; '
+              f'centroid median {np.median(dc):+.0f} cents '
+              f'(p10 {np.percentile(dc,10):+.0f}, p90 {np.percentile(dc,90):+.0f})')
+
+
+if __name__ == '__main__':
+    main()

--- a/tools/j6_vst/j6vst.py
+++ b/tools/j6_vst/j6vst.py
@@ -1,0 +1,171 @@
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Michi71
+"""Drive Roland's JUNO-60 VST3 from the J6 engine's 29 patch parameters.
+
+The plugin exposes its whole panel as parameters, so both sides can be given
+the same front panel rather than the same patch number. What the parameters
+mean is not written down anywhere, so every line of the map below was
+measured against the running plugin; the measurement is named at the line.
+The probes live in the session scratchpad, the results in the PicoFaceJ6
+README.
+
+Three findings shape the map and are easy to get wrong:
+
+  * the modulation depths are BIPOLAR with 128 as the centre -- DCO LFO,
+    VCF LFO, VCF ENV and VCF key follow all do nothing at 128 and reach full
+    depth at 0 and 255. Writing 0 for "no modulation" detunes the oscillator
+    by nearly four semitones, which is how this was found.
+  * env1 is the filter contour and env2 the amplifier contour. A Juno-60 has
+    one contour generator for both, so both are written from the same four
+    parameters.
+  * the plugin renders silence at 32 kHz. 44.1 kHz is the engine's own rate
+    anyway, so nothing is resampled on either side.
+"""
+import numpy as np
+from pedalboard import load_plugin
+from mido import Message
+
+PLUGIN = '/Library/Audio/Plug-Ins/VST3/Roland/JUNO-60.vst3'
+SR = 44100.0
+
+# The J6 parameter enum, so the map reads like juno_params.h.
+(LFO_RATE, LFO_DELAY, DCO_RANGE, DCO_LFO, DCO_PWM, DCO_PWM_MODE, DCO_SAW,
+ DCO_PULSE, DCO_SUB, DCO_SUB_LEVEL, DCO_NOISE, HPF, VCF_FREQ, VCF_RES, VCF_ENV,
+ VCF_POLARITY, VCF_LFO, VCF_KYBD, VCA_LEVEL, VCA_MODE, ENV_ATTACK, ENV_DECAY,
+ ENV_SUSTAIN, ENV_RELEASE, CHORUS, TUNE, BEND_RANGE, LFO_TRIG,
+ TRANSPOSE) = range(29)
+NPARAM = 29
+
+
+def _b(v):
+    """A 0..1 panel value as one of the plugin's 0..255 bytes."""
+    return float(min(max(round(v * 255.0), 0), 255))
+
+
+def _bip(v):
+    """A 0..1 unipolar panel value on the plugin's bipolar 0..255 axis."""
+    return float(min(max(round(128.0 + v * 127.0), 0), 255))
+
+
+def _step(v, steps):
+    s = int(v * steps)
+    return min(max(s, 0), steps - 1)
+
+
+class J6VST:
+    def __init__(self, path=PLUGIN):
+        self.p = load_plugin(path)
+        self.ranges = {k: self.p.parameters[k].range for k in self.p.parameters}
+        assert 'dco_saw_level' in self.ranges and 'env2_release' in self.ranges
+
+    def _set(self, name, value, log):
+        lo, hi, _ = self.ranges[name]
+        v = float(value)
+        if v < lo or v > hi:
+            log.append(f'{name}={value:.0f} clamped to [{lo:.0f},{hi:.0f}]')
+            v = min(max(v, lo), hi)
+        setattr(self.p, name, v)
+
+    def set_patch(self, q, dry=False):
+        """q: the 29 normalised J6 patch parameters. Returns the clamp log."""
+        assert len(q) == NPARAM
+        log = []
+        S = lambda n, v: self._set(n, v, log)
+
+        # --- LFO. Rate and delay are straight bytes; the laws behind them are
+        # what the comparison is for.
+        S('lfo_rate', _b(q[LFO_RATE]))
+        S('lfo_delay_time', _b(q[LFO_DELAY]))
+        # TRIG: the panel's Auto is step 0, and it retriggers on a new phrase.
+        S('lfo_key_trig', 1.0 if _step(q[LFO_TRIG], 2) == 0 else 0.0)
+        S('lfo_trig_env', 0.0)
+
+        # --- DCO. dco_range is six octaves with 3 = 8' (measured: note 60
+        # sounds 261.61 Hz there, and each step is an exact octave), so the
+        # Juno's 16'/8'/4' are 2/3/4.
+        S('dco_range', 2 + _step(q[DCO_RANGE], 3))
+        S('dco_lfo_mod', _bip(q[DCO_LFO]))
+        S('dco_pwm_depth', _b(q[DCO_PWM]))
+        # PWM source: 1 modulates from the LFO, 2 from the contour, 0 holds
+        # still. Positions 3..5 repeat 2 and 0.
+        S('dco_pwm_source', (1, 0, 2)[_step(q[DCO_PWM_MODE], 3)])
+        S('dco_saw_level', 255.0 if q[DCO_SAW] >= 0.5 else 0.0)
+        S('dco_pwm_level', 255.0 if q[DCO_PULSE] >= 0.5 else 0.0)
+        S('dco_sub_level', _b(q[DCO_SUB_LEVEL]) if q[DCO_SUB] >= 0.5 else 0.0)
+        S('dco_noise_level', _b(q[DCO_NOISE]))
+
+        # --- HPF. The plugin's high-pass is a continuous 0..255 where the
+        # instrument has four detents, so the four positions are read as the
+        # four ends of that travel. Its corners come out about 1.5x above the
+        # ones the service notes' component values give (see the README).
+        S('hpf_cutoff_freq', (0.0, 85.0, 170.0, 255.0)[_step(q[HPF], 4)])
+        S('hpf_type', 0.0)
+
+        # --- VCF. Contour amount carries its polarity in the sign about 128,
+        # which is exactly what the panel's polarity switch is.
+        S('vcf_cutoff_freq', _b(q[VCF_FREQ]))
+        S('vcf_resonance', _b(q[VCF_RES]))
+        pol = 1.0 if _step(q[VCF_POLARITY], 2) == 1 else -1.0
+        S('vcf_env_mod', min(max(128.0 + pol * q[VCF_ENV] * 127.0, 0), 255))
+        S('vcf_lfo_mod', _bip(q[VCF_LFO]))
+        S('vcf_key_follow', _bip(q[VCF_KYBD]))   # 128 = 0 %, 255 = 100 %
+        S('vcf_velocity_sens', 0.0)              # the keyboard is a gate
+
+        # --- VCA. Three positions, and none of them is what the names
+        # suggest: 0 hangs the amplifier on env1, 1 on env2, and only 2 is the
+        # plain gate. Reading 0 as the gate makes every patch whose contour
+        # sustains at zero -- the three organs among them -- die away instead
+        # of holding.
+        S('vca_level', _b(q[VCA_LEVEL]))
+        S('vca_mode', 1.0 if _step(q[VCA_MODE], 2) == 0 else 2.0)
+        S('vca_velocity_sens', 0.0)
+        S('vca_tone', 128.0)
+
+        # --- ENV. One contour on the instrument, two in the plugin.
+        for pre in ('env1', 'env2'):
+            S(pre + '_attack', _b(q[ENV_ATTACK]))
+            S(pre + '_decay', _b(q[ENV_DECAY]))
+            S(pre + '_sustain', _b(q[ENV_SUSTAIN]))
+            S(pre + '_release', _b(q[ENV_RELEASE]))
+
+        # --- Chorus. Types 2, 3 and 4 modulate at roughly 0.9, 1.7 and 9.2 Hz
+        # and the third is all but mono -- Roland's I, II and I+II. Off is
+        # depth 0, which leaves the dry signal untouched whatever the type.
+        ch = _step(q[CHORUS], 4)
+        S('effect_type', (2, 2, 3, 4)[ch])
+        S('effect_depth', 0.0 if ch == 0 or dry else 255.0)
+        S('reverb_level', 0.0)      # not on a Juno-60
+        S('delay_level', 0.0)
+        S('reverb_direct_level', 255.0)
+        S('delay_direct_level', 255.0)
+
+        # --- Rear panel and things that must not drift into the measurement.
+        cents = (q[TUNE] - 0.5) * 2.0 * 50.0
+        S('master_tune', 100.0 + cents / 0.4)    # 0.4 cents per unit, +/-40
+        S('portamento', 0.0)
+        S('legato', 0.0)
+        S('assign_mode', 0.0)
+        S('condition', 0.0)         # no circuit ageing, so renders repeat
+        S('circuit_mod', 0.0)
+        S('arpeggio_sw', 0.0)
+        S('key_hold', 0.0)
+        S('tempo_sync', 0.0)
+        S('bend_gain', 0.0)
+        return log
+
+    def render(self, q, note=60, vel=100, hold=1.5, tail=2.0):
+        """Note as played; the patch's octave transpose moves the note itself,
+        because the plugin's own octave_shift does nothing."""
+        note += (_step(q[TRANSPOSE], 5) - 2) * 12
+        msgs = [Message('note_on', note=note, velocity=vel, time=0.0),
+                Message('note_off', note=note, velocity=0, time=hold)]
+        return self.p(msgs, duration=hold + tail, sample_rate=SR, reset=True)
+
+
+def read_bank(path):
+    """The bank render_note dumps: (name, [29 floats]) per line."""
+    out = []
+    for line in open(path):
+        f = line.rstrip('\n').split('\t')
+        out.append((f[1], [float(x) for x in f[2:2 + NPARAM]]))
+    return out

--- a/tools/j6_vst/render_note.cpp
+++ b/tools/j6_vst/render_note.cpp
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: GPL-3.0-or-later
+// SPDX-FileCopyrightText: 2026 Michi71
+
+/*
+  render_note.cpp -- the J6 engine's side of the VST comparison
+
+  Renders one note through the unmodified Juno engine and writes interleaved
+  stereo float32 at the engine's own 44.1 kHz, which is also the rate the
+  Roland plugin renders at -- so neither side is resampled.
+
+      render_note out.f32 <idx> <note> <vel> <hold> <tail> [dry]
+      render_note out.f32 --params <p0,p1,...,p28> <note> <vel> <hold> <tail>
+      render_note dumpbank bank.txt
+
+  "dry" turns the chorus off on this side; compare.py does the same to the
+  plugin. dumpbank writes the 56 factory patches as one line of 29 normalised
+  parameters each, which is what the Python side sets on the plugin -- the two
+  sides then play the same panel rather than the same patch number.
+
+  The master volume is an instrument setting and not part of a patch, so it is
+  written explicitly here: a comparison must not depend on where a power-on
+  default happens to sit.
+*/
+
+#include "juno/juno.h"
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+int main(int argc, char** argv)
+{
+    if (argc >= 3 && !strcmp(argv[1], "dumpbank")) {
+        FILE* f = fopen(argv[2], "w");
+        if (!f) { perror(argv[2]); return 1; }
+        for (int i = 0; i < JUNO_NPROGRAMS; ++i) {
+            fprintf(f, "%d\t%s", i, junoPrograms[i].name);
+            for (int k = 0; k < JUNO_PARAM_COUNT; ++k)
+                fprintf(f, "\t%.6f", junoPrograms[i].param[k]);
+            fputc('\n', f);
+        }
+        fclose(f);
+        return 0;
+    }
+
+    if (argc < 7) {
+        fprintf(stderr, "usage: render_note out.f32 <idx|--params list> <note> <vel> <hold> <tail> [dry]\n"
+                        "       render_note dumpbank bank.txt\n");
+        return 1;
+    }
+
+    const char* out   = argv[1];
+    const bool  byPar = !strcmp(argv[2], "--params");
+    int         argi  = byPar ? 4 : 3;
+
+    Juno juno;
+    juno.setSampleRate(44100.0f);
+
+    if (byPar) {
+        std::vector<float> p;
+        for (const char* s = argv[3]; *s; ) {
+            p.push_back(strtof(s, (char**) &s));
+            if (*s == ',') ++s;
+        }
+        if ((int) p.size() != JUNO_PARAM_COUNT) {
+            fprintf(stderr, "--params wants %d values, got %zu\n", JUNO_PARAM_COUNT, p.size());
+            return 1;
+        }
+        for (int k = 0; k < JUNO_PARAM_COUNT; ++k) juno.setParameter(k, p[k]);
+    } else {
+        juno.setProgram(atoi(argv[2]));
+    }
+
+    const int   note = atoi(argv[argi + 0]);
+    const int   vel  = atoi(argv[argi + 1]);
+    const float hold = strtof(argv[argi + 2], nullptr);
+    const float tail = strtof(argv[argi + 3], nullptr);
+    const bool  dry  = (argc > argi + 4) && !strcmp(argv[argi + 4], "dry");
+
+    if (dry) juno.setParameter(JUNO_CHORUS, 0.0f);
+
+    /* Instrument settings: full master, no arpeggio, nothing latched. The
+     * plugin is set the same way. */
+    juno.setParameter(JUNO_MASTER, 1.0f);
+    juno.setParameter(JUNO_ARP_ON, 0.0f);
+    juno.setParameter(JUNO_HOLD,   0.0f);
+
+    const int sr = 44100;
+    const int nh = (int) (hold * sr), nt = (int) (tail * sr);
+    std::vector<float> l(nh + nt), r(nh + nt);
+
+    juno.noteOn(note, vel);
+    juno.processFloat(l.data(), r.data(), nh);
+    juno.noteOff(note);
+    juno.processFloat(l.data() + nh, r.data() + nh, nt);
+
+    FILE* f = fopen(out, "wb");
+    if (!f) { perror(out); return 1; }
+    for (size_t i = 0; i < l.size(); ++i) { fwrite(&l[i], 4, 1, f); fwrite(&r[i], 4, 1, f); }
+    fclose(f);
+    return 0;
+}

--- a/tools/j6_vst/requirements.txt
+++ b/tools/j6_vst/requirements.txt
@@ -1,0 +1,4 @@
+pedalboard>=0.9
+mido>=1.3
+numpy>=1.24
+scipy>=1.10


### PR DESCRIPTION
The same approach the D-50 work runs on, for the Juno. Roland's JUNO-60 VST3
puts its whole panel on its parameter list, so both it and this engine can be
given the same front panel and played against each other — no recordings to
ask anyone for.

## The tool

`tools/j6_vst/`: `render_note.cpp` renders the unmodified `src/juno/` sources,
`j6vst.py` puts the same 29 normalised panel values on the plugin, `compare.py`
walks the 56 factory patches. Both sides run at 44.1 kHz, the engine's own
rate, so neither is resampled.

What the plugin's parameters mean is documented nowhere and four of them do the
opposite of what their names say — the modulation depths are bipolar about 128,
`env1` is the filter contour and `env2` the amplifier's, `vca_mode` 2 rather
than 0 is the gate, and the octave switch has six positions. Each is measured
and recorded at its line in the map.

Roland's three preset banks decode too (`? Preset.bin`, 20223-byte records,
nibble pairs in parameter order). That settles the question the comparison
rests on: their 192 patches use the full 0..255 of the cutoff, so the plugin's
byte range really is the panel's travel.

## What it found

| | |
|---|---|
| **The sawtooth rose** | It should fall. A rising ramp's fundamental is `-sin` and the pulse's is `+sin`, so the eleven patches with both waveforms on lost 14 dB of every odd harmonic, their fundamental first. The comment beside the code already said so; the code did the opposite. |
| **The filter could not open** | Huovilainen's polynomial fit is good to about one radian per sample, so the filter carried a ceiling at `sr/2π` and a resonant peak that stopped at 3.8 kHz — well under its own documented 18 kHz. It is a TPT ladder now: correct to Nyquist, no ceiling, and the tangent tabulated against the cutoff in octaves. |
| **Resonance sang too late** | The threshold sat at slider 0.94. Bank 7, whose sound source the owner's manual says is the filter oscillating, barely spoke. The plugin crosses between 0.7 and 0.8; ours now crosses between 0.70 and 0.75 and sits within 2 dB of it at 0.8. |
| **The cutoff range sat wrong on the slider** | The specification's 20 Hz .. 18 kHz was spread evenly over the whole travel. The plugin climbs 17 octaves per unit with flat ends, putting 20 Hz at 0.16 and 18 kHz at 0.74. The range is unchanged — only its placement, about which the service notes say nothing. |
| **The level slider was linear** | The plugin follows the square to within a decibel over the top two thirds. The bank all sits at 0.700, so the headroom constant makes the 3.1 dB back and the bank comes out where it was. |

Across the 56 factory patches, dry, note 60: patches whose spectral centroid
lands within 300 cents of the plugin's **18 → 29**, within 600 cents **29 → 36**,
centroid spread **1141 → 944** cents, level spread **9.2 → 7.8** dB.

Confirmed rather than changed: pitch and the octave switch, the contour's ten
octaves (the plugin's is 10.8), the release curve at every setting of its
slider, and the attack within 10–20 % across the travel.

Where the two disagree and the service notes win: the LFO reaches 22 Hz at the
top of its slider, which is factory adjustment 7 and Fig. 29 (a 45 ms period);
the plugin runs past 40 Hz.

## Cost

No regression — the host renders 56 patches in 0.70 s against 1.08 s before,
because the per-sample exponential and two polynomial fits are gone and a table
lookup and one division take their place. Firmware builds at 104 kB flash and
6.6 % RAM (the filter table is 2440 bytes of it).

## Testing

`juno_test --selftest` passes: 56 patches, no NaN, nothing clipping, loudest
peak 0.7628 against 0.7629 before. Hardware listening test outstanding.

Note: `j6_ui_test` fails on this branch **and on `main`** — it expects the old
junox patch names ("Piano I") that the owner's-manual transcription replaced.
Unrelated, spun off separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)