### PR TITLE
PicoFaceJ6: the remaining outliers against the plugin

### DIFF
--- a/instruments/PicoFaceJ6/README.md
+++ b/instruments/PicoFaceJ6/README.md
@@ -196,14 +196,14 @@ A Juno-60 stores 56 of its own, eight per bank across seven banks, and the
 factory set is not in the service notes. The 48 here come from the patch table
 of junox, which uses the same parameters and supplied the names.
 
-Three values depart from that set, each because the sound and the name
+Two values depart from the chart, each because the sound and the name
 disagreed:
 
 | Patch | | |
 |---|---|---|
 | Piano I | DCO LFO 0.4 → 0 | forty cents of vibrato at five hertz, on a piano |
 | Clavichord I | DCO LFO 0.4 → 0 | the same, and the same reason |
-| Brass | VCA level 0.7 → 1.0 | the timbre was right and the level sat six decibels under everything else |
+| ~~Brass~~ | ~~VCA level 0.7 → 1.0~~ | withdrawn: the chart's level column reads +2, which is 0.7 |
 
 The other fourteen patches that use the DCO LFO keep it: ten to twenty cents on
 a violin, a clarinet or an oboe is what those instruments do.
@@ -493,6 +493,26 @@ The navigation helpers live in `tools/host_tests/j6/j6_ui_harness.h` and address
 number — sections and pages by name, the cursor by reading back where it is.
 Four separate test bugs in this project were miscounted encoder steps, and each
 one looked like a firmware fault first.
+
+## The last column of the chart
+
+The owner's manual chart prints one column that every transcription of it has
+given up on: the VCA level. It is not a slider position but a signed offset
+from the middle of one — `E +2`, `G −1`, `E 0` — with the letter carrying the
+ENV/GATE selector beside it. The slider is `5 + LEVEL`.
+
+junox has had that column all along, and this project's import dropped it:
+every patch here carried the same placeholder 0.700. Against a
+higher-resolution scan, **32 of the 32 rows on the two pages that could be read
+match junox cell for cell**, over a range from −3 to +4 — so junox's column is
+the chart's, and it is taken wholesale. The bank's loudness spread narrows from
+11.1 to 10.5 dB and its span from 51 to 48; the organs lose 3.7 dB and
+Glockenspiel gains 5.3. The headroom constant carries the rest, since the
+column centres on 0.5 where the placeholder sat at 0.7.
+
+The same scan settles the chorus column, which sits at the page edge and had to
+come from the Patch Book's LED graphics: **Celesta is OFF**, not I. That was the
+single cell where this transcription and junox's disagreed, out of 1344.
 
 ## Measured against Roland's JUNO-60 plugin
 

--- a/instruments/PicoFaceJ6/README.md
+++ b/instruments/PicoFaceJ6/README.md
@@ -525,6 +525,10 @@ What it has settled so far:
 | The VCA gate was being overwritten | Its rise and fall shared the contour's coefficients, and the panel writes the mode before the sliders — so every gate patch ran on its contour. |
 | A contour heading for silence carries on | Decay and release ran their segment to −40 dB and snapped. The plugin holds the same rate past −110. Synth Drum, whose only sound source is the filter singing at a sustain of zero, went silent under a held key. |
 | Both LFO depths are curves, not lines | The pitch depth is the square of the setting reaching 3.9 semitones; the filter depth is an S-curve reaching 3.6 octaves. Taken straight, the bottom third of either slider is three to ten times too deep — and that is where nearly every patch that uses them sits. |
+| The VCA switch sits in front of the amplifier | Gate mode was folded into the single contour and forced its sustain to full, so it opened the filter as well. Four of the six worst patches in the comparison were gate-mode ones. |
+| The contour depth shares the LFO's taper | One slider design, two destinations, the same curve to a hundredth — only the full scale differs, 3.6 octaves against 11.0. |
+| The cutoff slider is a table, and its bottom is not clamped | The corner keeps falling to 12.3 Hz where the clamp held it at 20, and the first sixth of the travel is exactly where the patches that let the contour do the work start from. |
+| The attack slider is a table | Nearly three times slow over the first third of the travel, a sixth fast at the top. |
 
 Where the two still disagree, and the service notes win: the LFO reaches 22 Hz
 at the top of its slider, which is factory adjustment 7 and Fig. 29 of the
@@ -549,6 +553,13 @@ between a third and half of the slider and 10–15 % slow between two thirds and
 four fifths, and the chorus rates differ by 10 % on II and 5 % on I+II. The
 specification sheet and the instrument that was measured for it are 12 s and
 19.8 s apart on the same decay, so a fifth either way settles nothing.
+
+Recorded and left alone because the service notes are more specific than the
+plugin: **the LFO runs 0.3 … 22 Hz here and 0.049 … 67 Hz in the plugin.** The
+top is factory adjustment 7 and Fig. 29, a 45 ms period; the bottom is the
+specifications page. It is the one visible difference left in the bank
+comparison — Surf sets the LFO rate to zero and the filter depth to 0.6, so in
+the plugin its filter takes twenty seconds to sweep and here it takes three.
 
 ## Deliberate deviations from the original
 

--- a/instruments/PicoFaceJ6/include/juno/juno_defs.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_defs.h
@@ -313,9 +313,13 @@
 /*   attack at slider 10 reaches 0.224 after half a second of a 3.25 s rise,  */
 /*   where a straight line would be at 0.154. Juno60 fits (1-e^-x)/0.632.     */
 /* ------------------------------------------------------------------------   */
+/*
+ * The specifications page's own figures, kept for the record. The slider is a
+ * measured table now -- kJunoAttackTime in juno_dsp.h -- and it comes out at
+ * 1.25 ms and 3.6 s at the two ends.
+ */
 #define JUNO_ATTACK_MIN_S    0.001f
 #define JUNO_ATTACK_MAX_S    3.000f   /* adjustment 10: ENV TIME VR6 */
-#define JUNO_ATTACK_CURVE    0.5f     /* exponent of the slider mapping      */
 #define JUNO_ATTACK_SHAPE    0.632f   /* 1 - 1/e; normalises (1-e^-x)        */
 
 #define JUNO_DECAY_MIN_S     0.002f

--- a/instruments/PicoFaceJ6/include/juno/juno_defs.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_defs.h
@@ -252,16 +252,15 @@
  * sloppily.
  */
 #ifndef JUNO_CONTOUR_OCTAVES
-#define JUNO_CONTOUR_OCTAVES   10.0f
+#define JUNO_CONTOUR_OCTAVES   10.96f
 #endif
 
 /*
- * How far the LFO moves the cutoff is no longer a single number: measured
- * against Roland's plugin the slider follows a strong S-curve, from a
- * fortieth of an octave at 0.1 to 3.6 either side at full. kJunoVcfLfoOct in
- * juno_dsp.h carries the measured points. Three octaves, taken as a straight
- * line, stood here.
+ * Full scale of the LFO route into the cutoff, either side. The slider reaches
+ * it along kJunoVcfDepth in juno_dsp.h, which the contour route shares. Three
+ * octaves, taken as a straight line, stood here.
  */
+#define JUNO_LFO_VCF_OCTAVES    3.597f
 
 /* ------------------------------------------------------------------------   */
 /* HPF                                                                        */

--- a/instruments/PicoFaceJ6/include/juno/juno_defs.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_defs.h
@@ -228,7 +228,14 @@
  * settled level from there on -- so the threshold belongs at 0.8.
  */
 #define JUNO_RESONANCE_MAX      1.35f
-#define JUNO_VCF_GCOMP          0.85f   /* Moog ladder uses 0.5; see above  */
+/*
+ * The resonance compensation is a measured curve now, kJunoVcfGComp in
+ * juno_dsp.h -- near the Moog ladder's 0.5 at the bottom of the resonance
+ * travel and a third at the top. A flat 0.85 stood here on the reasoning that
+ * an OTA cascade with its own feedback amplifier does not lose its low end.
+ * Roland's plugin says it loses 7.2 dB of it, where that reasoning kept all
+ * but 1.9.
+ */
 
 /*
  * How far the contour can open the filter, at Env fully up.

--- a/instruments/PicoFaceJ6/include/juno/juno_defs.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_defs.h
@@ -182,17 +182,12 @@
 #define JUNO_CUTOFF_MAX_HZ  18000.0f
 
 /*
- * How that range is laid out along the slider, measured off Roland's plugin
- * by reading the corner as the resonant peak: 17.0 octaves per unit of
- * travel, so 20 Hz falls at 0.158 and 18 kHz at 0.735, and the ends are flat.
- *
- * Spreading the range evenly over the whole travel, which is what this did
- * before, puts the middle of the slider an octave low and its upper third
- * two to three octaves low. The specification's range is not in question --
- * only where on the slider it sits, and the specification does not say.
+ * How that range is laid out along the slider is a measured table, not a
+ * formula: kJunoCutoffOct in juno_dsp.h. Spreading the range evenly over the
+ * whole travel puts the middle of the slider an octave low, and clamping the
+ * bottom at 20 Hz holds back the first sixth of it by half an octave -- which
+ * is exactly where the patches that let the contour do the work start from.
  */
-#define JUNO_CUTOFF_OCT_PER_UNIT 17.0f
-#define JUNO_CUTOFF_OCT_ZERO      2.69f
 
 /*
  * Ceiling on the cutoff the filter itself will accept, as a fraction of the

--- a/instruments/PicoFaceJ6/include/juno/juno_dsp.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_dsp.h
@@ -238,12 +238,36 @@ static inline float junoNoteToHz(float note)
  * Attack: measured 0.001 / 0.03 / 0.24 / 0.65 / 3.25 s at slider positions
  * 0 / 2.5 / 5 / 7.5 / 10.
  */
+/*
+ * The attack slider against the time it takes, measured off Roland's plugin at
+ * 0.05 steps as the time to half amplitude (with a Hilbert envelope on a
+ * filtered tone, because a boxcar over a raw sawtooth quantises the reading
+ * badly at the short end) and divided by the 0.400 of a segment that our own
+ * attack curve needs to get there.
+ *
+ * The shape it replaces was junox's, and only the range under it came from the
+ * specifications page. It ran nearly three times slow over the first third of
+ * the travel and a sixth fast at the top.
+ *
+ * Both ends against the specification page's 1 ms .. 3 s: the bottom comes out
+ * at 1.25 ms, and the top at 3.6 s -- 20 % over. That is well inside how
+ * approximate these figures are; the same page puts the decay at 12 s where a
+ * measured instrument gave 19.8.
+ */
+static const float kJunoAttackTime[21] = {
+    0.00125f, 0.0030f, 0.0050f, 0.0095f, 0.0168f, 0.0283f, 0.0455f,
+    0.0720f,  0.1098f, 0.1610f, 0.2275f, 0.3063f, 0.4125f, 0.5470f,
+    0.7008f,  0.9125f, 1.1838f, 1.5440f, 2.0285f, 2.6445f, 3.5985f
+};
+
 static inline float junoAttackTime(float v)
 {
     v = junoClamp(v, 0.0f, 1.0f);
-    const float k = JUNO_ATTACK_CURVE * 10.0f;
-    return JUNO_ATTACK_MIN_S +
-           (expf(v * k) - 1.0f) / (expf(k) - 1.0f) * JUNO_ATTACK_MAX_S;
+    const float x = v * 20.0f;
+    const int   i = (int) x;
+    if (i >= 20) return kJunoAttackTime[20];
+    const float f = x - (float) i;
+    return kJunoAttackTime[i] + f * (kJunoAttackTime[i + 1] - kJunoAttackTime[i]);
 }
 
 /*

--- a/instruments/PicoFaceJ6/include/juno/juno_dsp.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_dsp.h
@@ -164,6 +164,43 @@ static inline float junoCutoffOct(float v)
     return kJunoCutoffOct[i] + f * (kJunoCutoffOct[i + 1] - kJunoCutoffOct[i]);
 }
 
+/*
+ * The resonance compensation, against the panel's resonance setting.
+ *
+ * A transistor ladder takes its feedback from inside the ladder, so the low
+ * end drains away as the resonance comes up; an OTA cascade with a separate
+ * feedback amplifier does not, and this term is how much of the input is fed
+ * forward to hold it. It stood at a flat 0.85 on that reasoning -- "a Juno
+ * with the resonance up is never thin" -- and the reasoning was never
+ * measured.
+ *
+ * Roland's plugin says a Juno does get thinner: its passband loses 7.2 dB
+ * between no resonance and full, where ours lost 1.9. Measured at 0.05 steps
+ * on a fundamental well inside the passband, and turned into the term this
+ * topology needs by (1 + k*g)/(1 + k). It comes out near the Model D's 0.5 at
+ * the bottom of the travel and falls to a third at the top.
+ *
+ * Left as it was, a resonant patch carried about 4.4 dB too much gain across
+ * the whole band and a bass bump the plugin does not have -- which is most of
+ * what was left on the organs once the VCA switch stopped opening their
+ * filter.
+ */
+static const float kJunoVcfGComp[21] = {
+    0.4899f, 0.4899f, 0.4805f, 0.4814f, 0.4728f, 0.4661f, 0.4635f,
+    0.4577f, 0.4525f, 0.4476f, 0.4429f, 0.4396f, 0.4349f, 0.4301f,
+    0.4259f, 0.4175f, 0.3995f, 0.3810f, 0.3632f, 0.3488f, 0.3347f
+};
+
+static inline float junoVcfGComp(float res01)
+{
+    if (res01 <= 0.0f) return kJunoVcfGComp[0];
+    if (res01 >= 1.0f) return kJunoVcfGComp[20];
+    const float x = res01 * 20.0f;
+    const int   i = (int) x;
+    const float f = x - (float) i;
+    return kJunoVcfGComp[i] + f * (kJunoVcfGComp[i + 1] - kJunoVcfGComp[i]);
+}
+
 static const float kJunoDcoLevel[21] = {
     0.0000f, 0.0206f, 0.0412f, 0.0602f, 0.0808f, 0.1014f, 0.1204f,
     0.1410f, 0.1616f, 0.1822f, 0.2028f, 0.2311f, 0.2861f, 0.3613f,

--- a/instruments/PicoFaceJ6/include/juno/juno_dsp.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_dsp.h
@@ -321,14 +321,30 @@ static inline float junoDecayTime(float v)
 }
 
 /*
- * LFO rate. Reproduces the specified 0.3 .. 20 Hz and puts the middle of the
- * slider at 3.5 Hz, which is junox's mapping and matches the panel.
+ * LFO rate against the slider: 0.3, 0.85, 3.39, 11.49 and 22.22 Hz at the
+ * quarters, straight lines between.
+ *
+ * These are Hera's (jpcima, GPL-3), which carries the Juno60 project's
+ * measurements off a real instrument -- the same series our envelope times
+ * already rest on, and its ends are the specifications page's own 0.3 Hz and
+ * the factory adjustment's 22 Hz. junox's mapping stood here, and it is slow
+ * over the upper half of the travel: 5.2 Hz where this gives 6.6 at 0.6, and
+ * 11.0 against 13.6 at 0.8.
+ *
+ * Two independent sources put it where this does. Roland's plugin reads 7.8
+ * and 22.9 Hz at those two settings -- further still, but its LFO spans
+ * 0.049 .. 67 Hz against the specification's 0.3 .. 22, so its curve cannot be
+ * transplanted whole. Hera agrees with the plugin's shape while keeping the
+ * service notes' ends, and that is what is taken.
  */
+static const float kJunoLfoRate[5] = { 0.3f, 0.85f, 3.39f, 11.49f, 22.22f };
+
 static inline float junoLfoRate(float v)
 {
-    v = junoClamp(v, 0.0f, 1.0f);
-    return 0.3f * powf(1.53f, v * 10.0f) *
-           (1.0f + sinf(3.14159265f * v) * 0.39f);
+    v = junoClamp(v, 0.0f, 1.0f) * 4.0f;
+    const int   i = (v >= 4.0f) ? 3 : (int) v;
+    const float f = v - (float) i;
+    return kJunoLfoRate[i] + f * (kJunoLfoRate[i + 1] - kJunoLfoRate[i]);
 }
 
 /* ------------------------------------------------------------------------ */

--- a/instruments/PicoFaceJ6/include/juno/juno_dsp.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_dsp.h
@@ -100,31 +100,36 @@ static inline float junoLimit(float x)
  * the factory patches that use it sit exactly there.
  */
 /*
- * The VCF LFO slider against how far it actually moves the corner, in octaves
- * either side of it, measured off Roland's plugin at 0.05 steps by tracking a
- * resonant peak under a very slow LFO.
+ * What a VCF modulation-depth slider is worth, as a fraction of its full
+ * scale. Measured off Roland's plugin at 0.05 steps by tracking a resonant
+ * peak -- once with a very slow LFO driving the corner and once with the
+ * contour holding it -- and the two came out the same curve to within a
+ * hundredth at every point. One taper, one slider design, two destinations.
  *
- * It is nothing like the straight line this used to be. The bottom third of
- * the travel barely moves the filter at all -- a fortieth of an octave at 0.1,
- * an eighth at 0.2 -- and the top reaches 3.6 octaves rather than 3. Thirteen
- * of the fifteen factory patches that use it sit between 0.10 and 0.30, where
- * the straight line was three to ten times too deep: a wobble where the
- * instrument has a hint of one.
+ * It is nothing like the straight line these used to be. The bottom third of
+ * the travel barely moves the filter at all: a hundredth of full scale at 0.1,
+ * a twentieth at 0.2. Thirteen of the fifteen factory patches that use the LFO
+ * route sit between 0.10 and 0.30, and the contour route is on nearly every
+ * patch in the bank -- so the straight line was wrong where it mattered most,
+ * by three to ten times.
+ *
+ * The two full scales differ: 3.6 octaves either side for the LFO,
+ * JUNO_CONTOUR_OCTAVES for the contour.
  */
-static const float kJunoVcfLfoOct[21] = {
-    0.000f, 0.008f, 0.023f, 0.061f, 0.137f, 0.280f, 0.441f,
-    0.651f, 0.920f, 1.175f, 1.481f, 1.755f, 1.992f, 2.260f,
-    2.481f, 2.662f, 2.859f, 2.991f, 3.131f, 3.385f, 3.597f
+static const float kJunoVcfDepth[21] = {
+    0.0000f, 0.0022f, 0.0064f, 0.0170f, 0.0381f, 0.0778f, 0.1226f,
+    0.1810f, 0.2558f, 0.3267f, 0.4117f, 0.4879f, 0.5538f, 0.6283f,
+    0.6897f, 0.7401f, 0.7948f, 0.8315f, 0.8704f, 0.9411f, 1.0000f
 };
 
-static inline float junoVcfLfoOctaves(float v)
+static inline float junoVcfDepth(float v)
 {
     if (v <= 0.0f) return 0.0f;
-    if (v >= 1.0f) return kJunoVcfLfoOct[20];
+    if (v >= 1.0f) return 1.0f;
     const float x = v * 20.0f;
     const int   i = (int) x;
     const float f = x - (float) i;
-    return kJunoVcfLfoOct[i] + f * (kJunoVcfLfoOct[i + 1] - kJunoVcfLfoOct[i]);
+    return kJunoVcfDepth[i] + f * (kJunoVcfDepth[i + 1] - kJunoVcfDepth[i]);
 }
 
 static const float kJunoDcoLevel[21] = {

--- a/instruments/PicoFaceJ6/include/juno/juno_dsp.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_dsp.h
@@ -132,6 +132,38 @@ static inline float junoVcfDepth(float v)
     return kJunoVcfDepth[i] + f * (kJunoVcfDepth[i + 1] - kJunoVcfDepth[i]);
 }
 
+/*
+ * The cutoff slider against the corner it produces, in octaves above
+ * JUNO_CUTOFF_MIN_HZ, measured off Roland's plugin at 0.05 steps by reading
+ * the self-oscillation.
+ *
+ * It was a straight line in octaves with the ends clamped, which is right from
+ * a third of the travel upward and wrong below it: the plugin's corner keeps
+ * falling to 12.3 Hz at the bottom of the slider where the clamp held it at
+ * 20, and the clamped stretch reached a sixth of the way up. That is half an
+ * octave, and it does not stay quiet -- a Juno patch routinely leaves the
+ * cutoff near zero and lets the contour do the work, so the whole contour
+ * rides on it. UFO, Clavichord 1 and Reed 1 all sit there.
+ *
+ * The top is held at the specification's 18 kHz from 0.75 up, which is where
+ * the plugin's own reading passes it and stops being measurable.
+ */
+static const float kJunoCutoffOct[21] = {
+    -0.697f, -0.515f, -0.179f,  0.263f,  0.861f,  1.561f,  2.288f,
+     3.132f,  4.027f,  4.950f,  5.881f,  6.734f,  7.632f,  8.485f,
+     9.215f,  9.813f,  9.813f,  9.813f,  9.813f,  9.813f,  9.813f
+};
+
+static inline float junoCutoffOct(float v)
+{
+    if (v <= 0.0f) return kJunoCutoffOct[0];
+    if (v >= 1.0f) return kJunoCutoffOct[20];
+    const float x = v * 20.0f;
+    const int   i = (int) x;
+    const float f = x - (float) i;
+    return kJunoCutoffOct[i] + f * (kJunoCutoffOct[i + 1] - kJunoCutoffOct[i]);
+}
+
 static const float kJunoDcoLevel[21] = {
     0.0000f, 0.0206f, 0.0412f, 0.0602f, 0.0808f, 0.1014f, 0.1204f,
     0.1410f, 0.1616f, 0.1822f, 0.2028f, 0.2311f, 0.2861f, 0.3613f,

--- a/instruments/PicoFaceJ6/include/juno/juno_env.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_env.h
@@ -139,24 +139,30 @@ public:
     }
 
     /*
-     * Gate mode. The VCA can be driven by the contour or by a plain gate; the
-     * gate is not a square, it has a 3 ms rise and a 6 ms fall (measured) so
-     * that switching it does not click.
+     * Turns this contour into the plain gate the VCA switch can select
+     * instead. The gate is not a square: it has a 3 ms rise and a 6 ms fall
+     * (measured) so that switching it does not click.
+     *
+     * It is a shape a whole contour is set to, once, and not a mode laid over
+     * a running one -- the instrument has a switch in front of the amplifier,
+     * not a second setting on its contour generator, and the voice keeps a
+     * second JunoEnv for it. Laying it over the contour, as this did, forced
+     * the sustain to full for the filter as well.
      */
-    void setGateMode(bool on)
+    void setGateShape()
     {
-        gate_ = on;
+        gate_ = true;
         updateAttack();
         updateRelease();
     }
 
     /*
-     * A gate holds at full level for as long as the key is down, so the
-     * sustain control has no say in it. Forgetting this made every gate-mode
-     * patch with the sustain slider at zero silent -- the contour rose in 3 ms
-     * and then decayed straight back to nothing.
+     * A gate holds at full level for as long as the key is down; the instance
+     * that carries the gate shape is simply given a sustain of one, so there
+     * is no special case here. There used to be, and it reached the filter's
+     * contour too.
      */
-    float effSustain() const { return gate_ ? 1.0f : sustain_; }
+    float effSustain() const { return sustain_; }
 
     void gateOn()
     {

--- a/instruments/PicoFaceJ6/include/juno/juno_filter.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_filter.h
@@ -109,7 +109,7 @@ public:
          * an OTA cascade with its own feedback amplifier and a transistor
          * ladder, and most of why a Juno with the resonance up is never thin.
          */
-        const float x = in * (1.0f + k_ * JUNO_VCF_GCOMP);
+        const float x = in * (1.0f + k_ * gComp_);
 
         /* What the four stages will contribute from their current states, so
          * the loop can be closed on this sample instead of the last one. */
@@ -129,6 +129,10 @@ private:
     void updateCoeffs()
     {
         k_ = 4.0f * res_;
+        /* How much of the input is fed forward to hold the low end up as the
+         * feedback rises. Measured against Roland's plugin -- see
+         * kJunoVcfGComp -- and not the flat 0.85 that used to stand here. */
+        gComp_ = junoVcfGComp(res_ * (1.0f / JUNO_RESONANCE_MAX));
         const float om = 1.0f - g_;
         const float g2 = g_ * g_;
         c0_ = om;
@@ -174,6 +178,7 @@ private:
     float res_  = -1.0f;
     float k_    = 0.0f;      /* loop gain, four at self-oscillation */
     float c0_ = 0.0f, c1_ = 0.0f, c2_ = 0.0f, c3_ = 0.0f;
+    float gComp_  = 0.49f;
     float invDen_ = 1.0f;
 
     float s_[4] = {};

--- a/instruments/PicoFaceJ6/include/juno/juno_voice.h
+++ b/instruments/PicoFaceJ6/include/juno/juno_voice.h
@@ -48,7 +48,6 @@ struct JunoVoiceParams {
     float keyFollow  = 0.0f;
 
     /* ENV / VCA */
-    bool  gateMode   = false;
 
     /* Global pitch: master tune and the bender, in semitones. */
     float pitchSemis = 0.0f;
@@ -65,6 +64,20 @@ public:
         /* Its own seed, so six voices do not hiss in lockstep. */
         hiss_.seed(seed ^ 0x9E3779B9u);
         env_.init(sampleRate);
+        /*
+         * The gate is a second contour rather than a setting on the first.
+         * The instrument has one contour generator, and the VCA switch chooses
+         * between it and a plain gate -- for the amplifier only. Folding the
+         * gate into the contour, as this did, forced the sustain to full for
+         * the filter as well, and a gate-mode patch with the sustain slider
+         * anywhere below the top ran with its filter wide open: three and a
+         * half octaves out on the probe, and four of the six worst patches in
+         * the bank comparison were gate-mode ones. Roland's plugin puts the
+         * filter's corner in the same place whichever way the switch is set.
+         */
+        amp_.init(sampleRate);
+        amp_.setSustain(1.0f);
+        amp_.setGateShape();
         note_   = JUNO_CENTER_NOTE;
         active_ = false;
         invOsSr_ = 1.0f / osSr_;
@@ -74,6 +87,7 @@ public:
     {
         vcf_.reset();
         env_.reset();
+        amp_.reset();
         active_ = false;
         held_   = false;
     }
@@ -86,6 +100,7 @@ public:
         held_   = true;
         updatePitch(p);
         env_.gateOn();
+        if (gateMode_) amp_.gateOn();
     }
 
     /*
@@ -106,6 +121,7 @@ public:
     {
         held_ = false;
         env_.gateOff();
+        if (gateMode_) amp_.gateOff();
     }
 
     bool isHeld() const   { return held_; }
@@ -114,7 +130,7 @@ public:
 
     /* How far through its life the voice is, for the stealing rule: a
      * releasing voice with a quiet contour is the cheapest one to take. */
-    float claim() const   { return env_.value(); }
+    float claim() const   { return gateMode_ ? amp_.value() : env_.value(); }
 
     void setEnvelope(float a, float d, float s, float r)
     {
@@ -124,7 +140,16 @@ public:
         env_.setRelease(r);
     }
 
-    void setGateMode(bool on) { env_.setGateMode(on); }
+    /*
+     * Switching the source under a sounding note has to leave it sounding, so
+     * the gate joins in wherever the key already is.
+     */
+    void setGateMode(bool on)
+    {
+        if (on == gateMode_) return;
+        gateMode_ = on;
+        if (on && active_) { if (held_) amp_.gateOn(); else amp_.gateOff(); }
+    }
 
     /*
      * One output sample. lfo is the shared low-frequency oscillator, already
@@ -135,6 +160,8 @@ public:
     float process(const JunoVoiceParams& p, float lfo)
     {
         const float e = env_.process();
+        /* The filter always gets the contour; only the amplifier is switched. */
+        const float a = gateMode_ ? amp_.process() : e;
 
         if (env_.isIdle()) {
             active_ = false;
@@ -192,19 +219,21 @@ public:
             out = vcf_.process(dco_.process(pitchMul) * 0.4f
                                + hiss_.white() * JUNO_VCF_NOISE_FLOOR);
 
-        return out * e;
+        return out * a;
     }
 
 private:
     JunoDco    dco_;
     JunoFilter vcf_;
     JunoEnv    env_;
+    JunoEnv    amp_;      /* the plain gate, when the VCA switch asks for it */
     JunoNoise  hiss_;          /* the card's own noise, inside the filter */
 
     int   note_    = JUNO_CENTER_NOTE;
     float baseInc_ = 0.0f;
     bool  active_  = false;
     bool  held_    = false;
+    bool       gateMode_ = false;
     float osSr_    = (float) SAMPLING_RATE * JUNO_OVERSAMPLE;
     float invOsSr_ = 1.0f / ((float) SAMPLING_RATE * JUNO_OVERSAMPLE);
 };

--- a/instruments/PicoFaceJ6/src/juno/juno.cpp
+++ b/instruments/PicoFaceJ6/src/juno/juno.cpp
@@ -146,12 +146,19 @@ void Juno::applyParameter(int id)
                                   0.0f, log2f(JUNO_CUTOFF_MAX_HZ / JUNO_CUTOFF_MIN_HZ));
         break;
     case JUNO_VCF_RES:      vp_.resonance = v * JUNO_RESONANCE_MAX; break;
-    case JUNO_VCF_ENV:      vp_.envAmount = v; break;
+    /*
+     * Through the same taper the LFO route uses -- one slider design, and the
+     * plugin gives the two the same curve to a hundredth. Taken straight it
+     * was wrong wherever a patch uses less than half of it, which is most of
+     * them: Whistle sang a fifth of an octave above its base corner in the
+     * plugin and an octave and a half above it here.
+     */
+    case JUNO_VCF_ENV:      vp_.envAmount = junoVcfDepth(v); break;
     case JUNO_VCF_POLARITY:
         vp_.envPolarity = (junoParamStep(v, 2) == 1) ? 1.0f : -1.0f;
         break;
     /* Held in octaves, through the measured curve. */
-    case JUNO_VCF_LFO:      vp_.lfoOct = junoVcfLfoOctaves(v); break;
+    case JUNO_VCF_LFO:      vp_.lfoOct = junoVcfDepth(v) * JUNO_LFO_VCF_OCTAVES; break;
     case JUNO_VCF_KYBD:     vp_.keyFollow = v; break;
 
     /* --- VCA ------------------------------------------------------------ */

--- a/instruments/PicoFaceJ6/src/juno/juno.cpp
+++ b/instruments/PicoFaceJ6/src/juno/juno.cpp
@@ -184,7 +184,6 @@ void Juno::applyParameter(int id)
         break;
     case JUNO_VCA_MODE: {
         const bool gate = (junoParamStep(v, 2) == 1);
-        vp_.gateMode = gate;
         for (int i = 0; i < JUNO_VOICES; ++i) voice_[i].setGateMode(gate);
         break;
     }

--- a/instruments/PicoFaceJ6/src/juno/juno.cpp
+++ b/instruments/PicoFaceJ6/src/juno/juno.cpp
@@ -175,12 +175,14 @@ void Juno::applyParameter(int id)
          * is taken here and the easing is not: it is the bottom of a level
          * control, and no factory patch is anywhere near it.
          *
-         * The 0.700 that the whole bank sits at loses 3.1 dB to the change, so
-         * the headroom constant on the summed voices makes it back (0.35 ->
-         * 0.50) and the bank comes out exactly where it was. This is also the
+         * The headroom constant on the summed voices carries whatever the
+         * bank's levels do to the overall loudness: 0.35 while every patch sat
+         * at the 0.700 placeholder, 0.50 once the level was squared, and 0.64
+         * now that the levels are the chart's own and centre on 0.5 rather
+         * than 0.7. It is set so the loudest four-note chord in the bank peaks
+         * at about 0.73, which is where it has always been. This is also the
          * level that drives the chorus, so it decides how hard the
-         * bucket-brigade lines are pushed -- and that product, too, is
-         * unchanged for the bank.
+         * bucket-brigade lines are pushed.
          */
         volume_ = v * v;
         break;
@@ -545,7 +547,7 @@ void Juno::processFloat(float* out_l, float* out_r, int frames)
 
             /* Six voices at once would otherwise run out of headroom before
              * the filter does. */
-            sum *= 0.50f;
+            sum *= 0.64f;
 
             for (int os = 0; os < JUNO_OVERSAMPLE; ++os)
                 sum = dec_[2].process(dec_[1].process(dec_[0].process(sum)));

--- a/instruments/PicoFaceJ6/src/juno/juno.cpp
+++ b/instruments/PicoFaceJ6/src/juno/juno.cpp
@@ -130,20 +130,15 @@ void Juno::applyParameter(int id)
     /* --- VCF ------------------------------------------------------------ */
     case JUNO_VCF_FREQ:
         /*
-         * Where the 20 Hz .. 18 kHz of the specifications page sits on the
-         * slider. It used to be spread over the whole travel, and it is not:
-         * measured against Roland's plugin the corner climbs 17 octaves per
-         * unit of slider, passing 20 Hz at 0.16 and 18 kHz at 0.74, with the
-         * ends flat. The range is the service notes' and unchanged; only its
-         * placement moves, and that is what the plugin is being asked.
-         *
-         * Below 0.16 the plugin keeps going down to about 13 Hz rather than
-         * stopping, but that is under the specification's own floor and below
-         * anything a note reaches through four poles, so the floor stays where
-         * the service notes put it.
+         * Where the corner sits, from the measured table rather than a line.
+         * The specification's 20 Hz .. 18 kHz is spread over the middle of the
+         * travel, not over all of it; below a sixth of the way up the corner
+         * keeps falling to 12.3 Hz, which is under the specification's own
+         * floor and used to be clamped away. It does not stay quiet down
+         * there: a Juno patch routinely leaves the cutoff near zero and lets
+         * the contour do the work, so the whole contour rides on it.
          */
-        vp_.cutoffOct = junoClamp(v * JUNO_CUTOFF_OCT_PER_UNIT - JUNO_CUTOFF_OCT_ZERO,
-                                  0.0f, log2f(JUNO_CUTOFF_MAX_HZ / JUNO_CUTOFF_MIN_HZ));
+        vp_.cutoffOct = junoCutoffOct(v);
         break;
     case JUNO_VCF_RES:      vp_.resonance = v * JUNO_RESONANCE_MAX; break;
     /*

--- a/instruments/PicoFaceJ6/src/juno/juno_presets.cpp
+++ b/instruments/PicoFaceJ6/src/juno/juno_presets.cpp
@@ -31,22 +31,22 @@
     oscillation." Their chart rows carry no waveform at all and resonance 10
     throughout, so they sound only if the filter really sings.
 
-  Not transcribed: the VCA level column. It is printed as a signed value in a
-  range no 0..10 slider has, and this reading did not resolve it; the Patch
-  Book draws every level slider at the same height. Each patch therefore keeps
-  the level it shipped with -- 47 of the 56 at 0.700 -- and bank 7 takes the
-  same 0.700 the rest mostly use.
+  The VCA level column is transcribed now, and it was the last one missing.
+  It is printed as a signed value -- E or G for the ENV/GATE selector, then a
+  number from -3 to +5 -- which is why earlier readings gave up on it: it is
+  not a slider position but an offset from the middle of one. The slider is
+  5 + LEVEL, so 0 is 0.5 and +5 is 1.0.
 
-  What this note used to say about junox is wrong and is corrected here:
-  junox does carry a level per patch, nine values across 0.2 .. 1.0, and Hera
-  (jpcima) carries the same column from it. Only 8 of our 56 levels coincide
-  with junox's, so what happened is that the import dropped the column rather
-  than that junox never had it. Whether junox's values are a reading of the
-  chart's signed column or its author's own levelling is not known, and the
-  column is worth revisiting the next time anyone has the page in front of
-  them. Adopting it as it stands narrows the bank's loudness spread by less
-  than a decibel (11.1 -> 10.5 dB) and moves the median down by three, so it
-  was measured and left alone rather than taken on trust.
+  junox has had it all along, and this note used to say the opposite. Against a
+  higher-resolution scan of the chart, 32 of the 32 rows on the two pages that
+  could be read match junox cell for cell under that mapping, over a range from
+  -3 to +4 -- so junox's column is the chart's, and it is taken here wholesale.
+  Hera (jpcima) carries the same column from junox.
+
+  What it does: the bank's loudness spread narrows from 11.1 to 10.5 dB and its
+  span from 51 to 48, the organs lose 3.7 dB and Glockenspiel gains 5.3. The
+  headroom constant in juno.cpp carries the rest, since the column centres on
+  0.5 where the placeholder sat at 0.7.
 
   Two values depart from the chart, both kept from a hardware listening test:
 
@@ -60,23 +60,17 @@
         which is still most of a semitone. Worth a listen before it is
         trusted either way.
 
-    Brass         VCA level 0.7 -> 1.0
-        Also from that test, and independently supported: the chart's own level
-        column ranks Brass above the strings, whatever its scale turns out to
-        be.
+  Two values that used to depart and no longer do. Brass was raised from 0.7
+  to 1.0 by ear and Organ 3 likewise; the chart gives Brass +2 and all three
+  organs 0, which is 0.7 and 0.5. Both are back on the chart's figures. The
+  reasoning behind the Brass one still holds -- its level does rank above the
+  strings, which sit at -2 -- it simply did not need the extra.
 
-    Organ 3       VCA level 0.7 -> 1.0, and back again
-        Reverted. It was raised by ear because the patch held 15 dB under its
-        own sibling -- Organ 3 is Organ 2 an octave up and the cutoff does not
-        follow, so at 4' both the pulse and the sub sit above the corner
-        instead of below it -- and because the level column that would have
-        compensated it is the one column of the chart nobody has read.
-
-        Hera (jpcima, GPL-3) has read it, and it puts all three organs at the
-        same 0.5. So the chart does not compensate the octave, and the patch
-        really is that much quieter than its sibling. Two transcriptions of the
-        same chart agreeing on 1343 of 1344 cells is better evidence than one
-        pair of ears, including mine.
+  One value is corrected rather than deviated from: Celesta's chorus is OFF.
+  The chorus column sits at the page edge and the first scan could not resolve
+  it, so it was taken from the Patch Book's LED graphics and came out as I.
+  The better scan reads it directly, and it agrees with junox: off. That was
+  the single cell where the two transcriptions disagreed, out of 1344.
 
   Each entry is a complete front panel, in the order of the enum in
   juno_params.h and grouped by the sections of the instrument. The macros make
@@ -155,7 +149,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         ON , OFF, OFF, 0.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.700f, 0.000f, 0.000f, POL_POS, 0.000f, 1.000f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.500f, VCA_ENV),
     ENV(0.400f, 0.000f, 1.000f, 0.450f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
@@ -166,7 +160,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         ON , ON , OFF, 0.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.700f, 0.000f, 0.000f, POL_POS, 0.000f, 1.000f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.300f, VCA_ENV),
     ENV(0.400f, 0.000f, 1.000f, 0.450f),
     CHOR(CH_II),
     SYS(TRIG_AUTO, OCT0) }},
@@ -177,7 +171,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         ON , ON , ON , 1.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.500f, 0.000f, 0.000f, POL_POS, 0.000f, 1.000f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.300f, VCA_ENV),
     ENV(0.300f, 0.000f, 1.000f, 0.600f),
     CHOR(CH_II),
     SYS(TRIG_MAN , OCT0) }},
@@ -188,7 +182,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, ON , ON , 1.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.400f, 0.600f, 0.450f, POL_POS, 0.000f, 1.000f),
-    VCA(0.700f, VCA_GATE),
+    VCA(0.500f, VCA_GATE),
     ENV(0.000f, 0.000f, 0.000f, 0.000f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
@@ -199,7 +193,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, ON , ON , 0.800f, 0.000f),
     HPF_(R4(0)),
     VCF(0.350f, 0.550f, 0.400f, POL_POS, 0.000f, 1.000f),
-    VCA(0.700f, VCA_GATE),
+    VCA(0.500f, VCA_GATE),
     ENV(0.000f, 0.100f, 0.000f, 0.100f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
@@ -210,7 +204,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, ON , ON , 0.800f, 0.000f),
     HPF_(R4(0)),
     VCF(0.350f, 0.550f, 0.350f, POL_POS, 0.000f, 1.000f),
-    VCA(0.700f, VCA_GATE),
+    VCA(0.500f, VCA_GATE),
     ENV(0.000f, 0.100f, 0.000f, 0.100f),
     CHOR(CH_II),
     SYS(TRIG_AUTO, OCT0) }},
@@ -221,7 +215,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         ON , OFF, OFF, 0.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.000f, 0.000f, 0.850f, POL_POS, 0.000f, 0.400f),
-    VCA(1.000f, VCA_ENV),
+    VCA(0.700f, VCA_ENV),
     ENV(0.250f, 0.400f, 0.600f, 0.200f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
@@ -232,7 +226,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         ON , ON , OFF, 1.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.300f, 0.100f, 0.550f, POL_POS, 0.000f, 1.000f),
-    VCA(0.700f, VCA_GATE),
+    VCA(0.400f, VCA_GATE),
     ENV(0.200f, 0.400f, 0.400f, 0.300f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
@@ -254,7 +248,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, ON , ON , 0.450f, 0.000f),
     HPF_(R4(0)),
     VCF(0.350f, 0.000f, 0.250f, POL_POS, 0.200f, 0.800f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.800f, VCA_ENV),
     ENV(0.000f, 0.750f, 0.000f, 0.350f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
@@ -265,9 +259,9 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         ON , ON , OFF, 1.000f, 0.000f),
     HPF_(R4(1)),
     VCF(0.350f, 0.800f, 0.000f, POL_POS, 0.000f, 1.000f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.600f, VCA_ENV),
     ENV(0.000f, 0.650f, 0.200f, 0.550f),
-    CHOR(CH_I),
+    CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
 
 { "Mellow Piano", {
@@ -287,7 +281,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, ON , ON , 0.700f, 0.000f),
     HPF_(R4(1)),
     VCF(0.300f, 0.000f, 0.500f, POL_POS, 0.000f, 0.700f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.400f, VCA_ENV),
     ENV(0.000f, 0.600f, 0.350f, 0.250f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
@@ -298,7 +292,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, ON , ON , 0.850f, 0.000f),
     HPF_(R4(1)),
     VCF(0.500f, 0.250f, 0.300f, POL_POS, 0.000f, 1.000f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.500f, VCA_ENV),
     ENV(0.000f, 0.500f, 0.150f, 0.500f),
     CHOR(CH_II),
     SYS(TRIG_AUTO, OCT0) }},
@@ -309,7 +303,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, ON , OFF, 1.000f, 0.000f),
     HPF_(R4(2)),
     VCF(0.300f, 0.000f, 0.450f, POL_POS, 0.150f, 0.500f),
-    VCA(0.750f, VCA_ENV),
+    VCA(0.900f, VCA_ENV),
     ENV(0.000f, 0.550f, 0.350f, 0.650f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
@@ -320,7 +314,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         ON , OFF, OFF, 1.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.300f, 0.000f, 0.500f, POL_POS, 0.000f, 0.800f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.600f, VCA_ENV),
     ENV(0.000f, 0.550f, 0.300f, 0.500f),
     CHOR(CH_I),
     SYS(TRIG_MAN , OCT0) }},
@@ -331,7 +325,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         ON , ON , ON , 0.300f, 0.000f),
     HPF_(R4(0)),
     VCF(0.300f, 0.250f, 0.350f, POL_POS, 0.000f, 0.000f),
-    VCA(0.700f, VCA_GATE),
+    VCA(0.500f, VCA_GATE),
     ENV(0.000f, 0.400f, 0.100f, 0.250f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
@@ -342,7 +336,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         ON , ON , OFF, 0.300f, 0.000f),
     HPF_(R4(0)),
     VCF(0.300f, 0.500f, 0.450f, POL_POS, 0.000f, 0.500f),
-    VCA(0.700f, VCA_GATE),
+    VCA(0.400f, VCA_GATE),
     ENV(0.000f, 0.300f, 0.350f, 0.250f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
@@ -364,7 +358,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, ON , OFF, 1.000f, 0.000f),
     HPF_(R4(1)),
     VCF(0.550f, 0.700f, 0.200f, POL_POS, 0.250f, 0.700f),
-    VCA(0.850f, VCA_ENV),
+    VCA(1.000f, VCA_ENV),
     ENV(0.000f, 0.450f, 0.200f, 0.200f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
@@ -375,7 +369,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, ON , OFF, 0.300f, 0.000f),
     HPF_(R4(0)),
     VCF(0.450f, 0.300f, 0.300f, POL_POS, 0.300f, 1.000f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.800f, VCA_ENV),
     ENV(0.000f, 0.200f, 0.350f, 0.550f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
@@ -386,7 +380,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, ON , ON , 0.300f, 0.000f),
     HPF_(R4(0)),
     VCF(0.500f, 0.300f, 0.300f, POL_POS, 0.000f, 1.000f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.600f, VCA_ENV),
     ENV(0.000f, 0.300f, 0.300f, 0.400f),
     CHOR(CH_II),
     SYS(TRIG_AUTO, OCT0) }},
@@ -397,7 +391,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, OFF, ON , 1.000f, 0.000f),
     HPF_(R4(1)),
     VCF(0.400f, 0.500f, 0.300f, POL_POS, 0.000f, 0.600f),
-    VCA(0.850f, VCA_ENV),
+    VCA(1.000f, VCA_ENV),
     ENV(0.000f, 0.350f, 0.000f, 0.350f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
@@ -408,7 +402,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, ON , OFF, 0.000f, 0.000f),
     HPF_(R4(1)),
     VCF(0.450f, 0.500f, 0.300f, POL_POS, 0.000f, 0.600f),
-    VCA(0.750f, VCA_ENV),
+    VCA(0.900f, VCA_ENV),
     ENV(0.000f, 0.300f, 0.250f, 0.500f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
@@ -452,7 +446,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         ON , OFF, OFF, 0.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.150f, 0.000f, 0.600f, POL_POS, 0.000f, 0.400f),
-    VCA(0.850f, VCA_ENV),
+    VCA(1.000f, VCA_ENV),
     ENV(0.300f, 0.400f, 0.400f, 0.300f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
@@ -463,7 +457,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         ON , OFF, OFF, 0.000f, 0.150f),
     HPF_(R4(1)),
     VCF(0.500f, 0.000f, 0.000f, POL_POS, 0.200f, 0.600f),
-    VCA(0.850f, VCA_ENV),
+    VCA(1.000f, VCA_ENV),
     ENV(0.200f, 0.600f, 0.500f, 0.250f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
@@ -474,7 +468,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, ON , OFF, 0.000f, 0.000f),
     HPF_(R4(1)),
     VCF(0.500f, 0.300f, 0.250f, POL_POS, 0.000f, 0.600f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.600f, VCA_ENV),
     ENV(0.250f, 0.600f, 0.600f, 0.250f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
@@ -485,7 +479,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, ON , OFF, 0.000f, 0.000f),
     HPF_(R4(3)),
     VCF(0.450f, 0.500f, 0.250f, POL_POS, 0.000f, 0.500f),
-    VCA(0.850f, VCA_ENV),
+    VCA(1.000f, VCA_ENV),
     ENV(0.200f, 0.600f, 0.600f, 0.250f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
@@ -496,7 +490,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, ON , OFF, 0.000f, 0.000f),
     HPF_(R4(3)),
     VCF(0.500f, 0.700f, 0.000f, POL_POS, 0.150f, 0.500f),
-    VCA(0.850f, VCA_ENV),
+    VCA(1.000f, VCA_ENV),
     ENV(0.200f, 0.600f, 0.600f, 0.250f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
@@ -507,7 +501,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         ON , OFF, OFF, 0.000f, 0.000f),
     HPF_(R4(1)),
     VCF(0.150f, 0.750f, 0.500f, POL_POS, 0.200f, 0.500f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.800f, VCA_ENV),
     ENV(0.250f, 0.400f, 1.000f, 0.100f),
     CHOR(CH_OFF),
     SYS(TRIG_MAN , OCT0) }},
@@ -529,7 +523,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         ON , ON , OFF, 0.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.600f, 0.200f, 0.300f, POL_POS, 0.000f, 0.200f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.300f, VCA_ENV),
     ENV(0.000f, 0.700f, 0.200f, 0.200f),
     CHOR(CH_I),
     SYS(TRIG_MAN , OCT0) }},
@@ -540,7 +534,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, ON , OFF, 0.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.100f, 0.600f, 0.700f, POL_POS, 0.000f, 0.500f),
-    VCA(0.700f, VCA_GATE),
+    VCA(0.600f, VCA_GATE),
     ENV(0.000f, 0.850f, 0.500f, 0.100f),
     CHOR(CH_I),
     SYS(TRIG_MAN , OCT0) }},
@@ -551,7 +545,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, OFF, ON , 1.000f, 0.000f),
     HPF_(R4(1)),
     VCF(0.250f, 0.200f, 0.550f, POL_POS, 0.000f, 1.000f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.800f, VCA_ENV),
     ENV(0.000f, 0.300f, 0.200f, 0.000f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
@@ -562,7 +556,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, OFF, ON , 1.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.200f, 0.000f, 0.600f, POL_POS, 0.000f, 0.800f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.500f, VCA_ENV),
     ENV(0.000f, 0.550f, 0.300f, 0.600f),
     CHOR(CH_I),
     SYS(TRIG_MAN , OCT0) }},
@@ -573,7 +567,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, OFF, ON , 1.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.300f, 0.200f, 0.300f, POL_POS, 0.000f, 1.000f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.600f, VCA_ENV),
     ENV(0.250f, 0.000f, 1.000f, 0.200f),
     CHOR(CH_OFF),
     SYS(TRIG_MAN , OCT0) }},
@@ -584,7 +578,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, ON , ON , 1.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.800f, 0.000f, 0.000f, POL_POS, 0.000f, 1.000f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.200f, VCA_ENV),
     ENV(0.300f, 0.000f, 1.000f, 0.400f),
     CHOR(CH_II),
     SYS(TRIG_MAN , OCT0) }},
@@ -595,7 +589,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, ON , ON , 0.750f, 0.000f),
     HPF_(R4(0)),
     VCF(0.250f, 0.000f, 0.500f, POL_POS, 0.200f, 0.700f),
-    VCA(0.700f, VCA_GATE),
+    VCA(0.500f, VCA_GATE),
     ENV(0.000f, 0.200f, 0.500f, 0.250f),
     CHOR(CH_II),
     SYS(TRIG_AUTO, OCT0) }},
@@ -617,7 +611,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         ON , OFF, ON , 0.650f, 0.000f),
     HPF_(R4(0)),
     VCF(0.650f, 0.300f, 0.400f, POL_NEG, 0.000f, 0.100f),
-    VCA(0.700f, VCA_GATE),
+    VCA(0.400f, VCA_GATE),
     ENV(0.650f, 0.550f, 0.200f, 0.650f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
@@ -628,7 +622,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         ON , OFF, OFF, 0.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.650f, 0.500f, 0.550f, POL_POS, 0.000f, 1.000f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.600f, VCA_ENV),
     ENV(0.000f, 0.800f, 0.800f, 0.900f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
@@ -639,7 +633,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         ON , ON , ON , 1.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.750f, 0.600f, 0.500f, POL_NEG, 0.000f, 0.450f),
-    VCA(0.700f, VCA_GATE),
+    VCA(0.200f, VCA_GATE),
     ENV(0.600f, 0.500f, 0.000f, 0.000f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
@@ -650,7 +644,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, ON , ON , 1.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.650f, 0.700f, 0.550f, POL_NEG, 0.000f, 1.000f),
-    VCA(0.700f, VCA_GATE),
+    VCA(0.300f, VCA_GATE),
     ENV(0.000f, 0.800f, 0.000f, 0.300f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
@@ -661,7 +655,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         ON , ON , OFF, 1.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.800f, 0.700f, 0.600f, POL_NEG, 0.250f, 0.000f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.500f, VCA_ENV),
     ENV(0.000f, 1.000f, 0.000f, 1.000f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
@@ -672,7 +666,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         ON , ON , OFF, 0.800f, 0.000f),
     HPF_(R4(0)),
     VCF(0.200f, 0.850f, 0.600f, POL_POS, 0.000f, 1.000f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.200f, VCA_ENV),
     ENV(1.000f, 1.000f, 1.000f, 1.000f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
@@ -683,7 +677,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, OFF, OFF, 0.000f, 1.000f),
     HPF_(R4(1)),
     VCF(0.400f, 1.000f, 0.150f, POL_POS, 0.000f, 1.000f),
-    VCA(0.700f, VCA_ENV),
+    VCA(1.000f, VCA_ENV),
     ENV(0.000f, 0.300f, 0.000f, 0.400f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
@@ -694,7 +688,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, OFF, OFF, 0.000f, 0.000f),
     HPF_(R4(1)),
     VCF(0.500f, 1.000f, 0.350f, POL_NEG, 0.000f, 1.000f),
-    VCA(0.700f, VCA_ENV),
+    VCA(1.000f, VCA_ENV),
     ENV(0.000f, 0.300f, 0.000f, 0.400f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
@@ -705,7 +699,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, OFF, OFF, 0.000f, 0.200f),
     HPF_(R4(1)),
     VCF(0.350f, 1.000f, 0.150f, POL_POS, 0.200f, 1.000f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.800f, VCA_ENV),
     ENV(0.300f, 0.000f, 1.000f, 0.100f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
@@ -716,7 +710,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, OFF, OFF, 0.000f, 0.000f),
     HPF_(R4(1)),
     VCF(0.350f, 1.000f, 0.000f, POL_POS, 0.200f, 1.000f),
-    VCA(0.700f, VCA_ENV),
+    VCA(1.000f, VCA_ENV),
     ENV(0.000f, 0.400f, 0.550f, 0.700f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
@@ -727,7 +721,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, OFF, OFF, 0.000f, 0.200f),
     HPF_(R4(0)),
     VCF(0.000f, 1.000f, 0.700f, POL_POS, 0.400f, 1.000f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.400f, VCA_ENV),
     ENV(0.000f, 0.600f, 1.000f, 0.800f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
@@ -738,7 +732,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, OFF, OFF, 0.000f, 0.200f),
     HPF_(R4(0)),
     VCF(0.500f, 1.000f, 0.400f, POL_NEG, 0.000f, 1.000f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.500f, VCA_ENV),
     ENV(0.000f, 1.000f, 0.000f, 0.800f),
     CHOR(CH_I),
     SYS(TRIG_AUTO, OCT0) }},
@@ -749,7 +743,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, OFF, OFF, 1.000f, 1.000f),
     HPF_(R4(0)),
     VCF(0.600f, 0.000f, 0.000f, POL_POS, 0.600f, 1.000f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.900f, VCA_ENV),
     ENV(0.000f, 0.400f, 1.000f, 0.800f),
     CHOR(CH_OFF),
     SYS(TRIG_AUTO, OCT0) }},
@@ -760,7 +754,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, OFF, OFF, 0.000f, 0.000f),
     HPF_(R4(0)),
     VCF(0.200f, 1.000f, 0.400f, POL_POS, 0.000f, 1.000f),
-    VCA(0.700f, VCA_ENV),
+    VCA(0.600f, VCA_ENV),
     ENV(0.000f, 0.500f, 0.000f, 0.600f),
     CHOR(CH_OFF),
     SYS(TRIG_MAN , OCT0) }},

--- a/instruments/PicoFaceJ6/src/juno/juno_presets.cpp
+++ b/instruments/PicoFaceJ6/src/juno/juno_presets.cpp
@@ -54,22 +54,18 @@
         column ranks Brass above the strings, whatever its scale turns out to
         be.
 
-    Organ 3       VCA level 0.7 -> 1.0
-        The same missing column, and this time the arithmetic says which way it
-        must go. Organ 3 is Organ 2 an octave up -- the two rows are identical
-        but for the range switch -- and the cutoff sits at 3.5 either way. At
-        4' that puts both the pulse and the sub above the corner instead of
-        below it, which is 15 dB through four poles: the patch held at
-        -42 dBFS against Organ 2's -27, the ninth quietest sound in the bank.
-        Nobody ships an organ fifteen decibels under its own sibling; whoever
-        set that level column moved it, and it is the one column of the chart
-        that cannot be read. The slider's own maximum gives 6.2 dB back, which
-        is all this lever has -- Organ 3 still sits under Organ 1, and that is
-        honest rather than solved.
+    Organ 3       VCA level 0.7 -> 1.0, and back again
+        Reverted. It was raised by ear because the patch held 15 dB under its
+        own sibling -- Organ 3 is Organ 2 an octave up and the cutoff does not
+        follow, so at 4' both the pulse and the sub sit above the corner
+        instead of below it -- and because the level column that would have
+        compensated it is the one column of the chart nobody has read.
 
-        Roland's plugin is no help here and cannot be: it is fed the same
-        placeholder, so it puts Organ 3 sixth from the bottom of its own bank
-        for exactly the same reason.
+        Hera (jpcima, GPL-3) has read it, and it puts all three organs at the
+        same 0.5. So the chart does not compensate the octave, and the patch
+        really is that much quieter than its sibling. Two transcriptions of the
+        same chart agreeing on 1343 of 1344 cells is better evidence than one
+        pair of ears, including mine.
 
   Each entry is a complete front panel, in the order of the enum in
   juno_params.h and grouped by the sections of the instrument. The macros make
@@ -203,7 +199,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, ON , ON , 0.800f, 0.000f),
     HPF_(R4(0)),
     VCF(0.350f, 0.550f, 0.350f, POL_POS, 0.000f, 1.000f),
-    VCA(1.000f, VCA_GATE),   /* level: see the note at the top */
+    VCA(0.700f, VCA_GATE),
     ENV(0.000f, 0.100f, 0.000f, 0.100f),
     CHOR(CH_II),
     SYS(TRIG_AUTO, OCT0) }},

--- a/instruments/PicoFaceJ6/src/juno/juno_presets.cpp
+++ b/instruments/PicoFaceJ6/src/juno/juno_presets.cpp
@@ -54,6 +54,23 @@
         column ranks Brass above the strings, whatever its scale turns out to
         be.
 
+    Organ 3       VCA level 0.7 -> 1.0
+        The same missing column, and this time the arithmetic says which way it
+        must go. Organ 3 is Organ 2 an octave up -- the two rows are identical
+        but for the range switch -- and the cutoff sits at 3.5 either way. At
+        4' that puts both the pulse and the sub above the corner instead of
+        below it, which is 15 dB through four poles: the patch held at
+        -42 dBFS against Organ 2's -27, the ninth quietest sound in the bank.
+        Nobody ships an organ fifteen decibels under its own sibling; whoever
+        set that level column moved it, and it is the one column of the chart
+        that cannot be read. The slider's own maximum gives 6.2 dB back, which
+        is all this lever has -- Organ 3 still sits under Organ 1, and that is
+        honest rather than solved.
+
+        Roland's plugin is no help here and cannot be: it is fed the same
+        placeholder, so it puts Organ 3 sixth from the bottom of its own bank
+        for exactly the same reason.
+
   Each entry is a complete front panel, in the order of the enum in
   juno_params.h and grouped by the sections of the instrument. The macros make
   the grouping visible and, more usefully, make a miscounted row a compile
@@ -186,7 +203,7 @@ const JunoProgram junoPrograms[JUNO_NPROGRAMS] = {
         OFF, ON , ON , 0.800f, 0.000f),
     HPF_(R4(0)),
     VCF(0.350f, 0.550f, 0.350f, POL_POS, 0.000f, 1.000f),
-    VCA(0.700f, VCA_GATE),
+    VCA(1.000f, VCA_GATE),   /* level: see the note at the top */
     ENV(0.000f, 0.100f, 0.000f, 0.100f),
     CHOR(CH_II),
     SYS(TRIG_AUTO, OCT0) }},

--- a/instruments/PicoFaceJ6/src/juno/juno_presets.cpp
+++ b/instruments/PicoFaceJ6/src/juno/juno_presets.cpp
@@ -32,10 +32,21 @@
     throughout, so they sound only if the filter really sings.
 
   Not transcribed: the VCA level column. It is printed as a signed value in a
-  range no 0..10 slider has, and it defeated junox (which substituted a
-  constant 7) and the Patch Book author (who drew every level slider at the
-  same height) as well as this reading. Each patch therefore keeps the level it
-  shipped with, and bank 7 takes the same 0.700 the rest mostly use.
+  range no 0..10 slider has, and this reading did not resolve it; the Patch
+  Book draws every level slider at the same height. Each patch therefore keeps
+  the level it shipped with -- 47 of the 56 at 0.700 -- and bank 7 takes the
+  same 0.700 the rest mostly use.
+
+  What this note used to say about junox is wrong and is corrected here:
+  junox does carry a level per patch, nine values across 0.2 .. 1.0, and Hera
+  (jpcima) carries the same column from it. Only 8 of our 56 levels coincide
+  with junox's, so what happened is that the import dropped the column rather
+  than that junox never had it. Whether junox's values are a reading of the
+  chart's signed column or its author's own levelling is not known, and the
+  column is worth revisiting the next time anyone has the page in front of
+  them. Adopting it as it stands narrows the bank's loudness spread by less
+  than a decibel (11.1 -> 10.5 dB) and moves the median down by three, so it
+  was measured and left alone rather than taken on trust.
 
   Two values depart from the chart, both kept from a hardware listening test:
 

--- a/tools/j6_vst/compare.py
+++ b/tools/j6_vst/compare.py
@@ -14,6 +14,7 @@ when the question is about the voice rather than about the chorus.
 """
 import argparse, os, subprocess, sys, tempfile
 import numpy as np
+from scipy.signal import butter, sosfilt
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 from j6vst import J6VST, read_bank, NPARAM, CHORUS
 
@@ -21,8 +22,28 @@ HERE = os.path.dirname(os.path.abspath(__file__))
 SR = 44100
 
 
+_HP = None
+
+
+def subsonic_cut(x):
+    """Drop everything under 20 Hz before measuring anything.
+
+    A pulse whose width the LFO moves carries a wandering DC term, and the
+    plugin has nothing to block it: on Organ 3 that subsonic wobble is 99 % of
+    the total energy, at a few hertz, where neither a speaker nor an ear will
+    ever find it. Measured raw it buries the patch, and comparing two engines
+    that block it differently compares their DC blockers rather than their
+    sound.
+    """
+    global _HP
+    if _HP is None:
+        _HP = butter(2, 20.0, 'highpass', fs=SR, output='sos')
+    return sosfilt(_HP, x, axis=0).astype(np.float32)
+
+
 def metrics(x, hold, f0):
     """x: (n, 2) float32 at 44.1 kHz. Levels in dB, the profile re h1."""
+    x = subsonic_cut(x)
     def lev(a, b):
         seg = x[int(a * SR):int(b * SR)]
         return 10 * np.log10((seg ** 2).mean() + 1e-20) if len(seg) else -200.0
@@ -50,9 +71,12 @@ def metrics(x, hold, f0):
                 peak=float(np.abs(x).max()), env=env)
 
 
+ENGINE = os.path.join(HERE, 'render_note')
+
+
 def render_ours(idx, q, note, hold, tail, dry, out):
     ps = ','.join(f'{v:.6f}' for v in q)
-    subprocess.run([os.path.join(HERE, 'render_note'), out, '--params', ps,
+    subprocess.run([ENGINE, out, '--params', ps,
                     str(note), '100', str(hold), str(tail)] + (['dry'] if dry else []),
                    check=True)
     return np.fromfile(out, dtype=np.float32).reshape(-1, 2)
@@ -68,12 +92,16 @@ def main():
     ap.add_argument('--dry', action='store_true', help='chorus off on both sides')
     ap.add_argument('--csv')
     ap.add_argument('--keep', help='directory to keep the renders (f32 stereo)')
+    ap.add_argument('--engine', help='a different render_note binary, to compare two engine builds')
     a = ap.parse_args()
+    global ENGINE
+    if a.engine:
+        ENGINE = os.path.abspath(a.engine)
 
     tmp = a.keep or tempfile.mkdtemp(prefix='j6vst_')
     os.makedirs(tmp, exist_ok=True)
     bankfile = os.path.join(tmp, 'bank.txt')
-    subprocess.run([os.path.join(HERE, 'render_note'), 'dumpbank', bankfile], check=True)
+    subprocess.run([ENGINE, 'dumpbank', bankfile], check=True)
     bank = read_bank(bankfile)
     idxs = list(range(len(bank))) if a.all else a.idx
     if not idxs:


### PR DESCRIPTION
Bisecting the six patches that were still furthest from Roland's plugin after
[#157](https://github.com/Michi71/PicoVintageSynthCollection/pull/157). Five of
the six shared four causes, none of them about those patches — and then a
second Juno-60 emulation and a better scan of the owner's manual closed the
last two open columns of the factory chart.

## Found by bisection, measured against the plugin

| | |
|---|---|
| **The VCA switch was inside the contour** | A Juno has one contour generator and the switch chooses between it and a plain gate — for the amplifier. Gate mode was folded into the contour and forced its sustain to full, so it opened the filter as well: three and a half octaves out, where the plugin puts the corner in the same place either way. Four of the six worst patches were gate-mode ones. |
| **The contour depth is the LFO's taper** | The filter's two modulation-depth sliders share one curve — measured twice over, the same to within a hundredth at every point. Only the full scale differs: 3.6 octaves against 11.0. |
| **The cutoff slider's bottom was clamped** | The corner keeps falling to 12.3 Hz where the clamp held it at 20, and the clamped stretch reached a sixth of the way up — exactly where the patches that let the contour do the work start from. A measured table now; the two placement constants are gone. |
| **The attack slider was junox's shape** | Nearly three times slow over the first third of the travel, a sixth fast at the top. Also a table now. |
| **A Juno does get thinner with resonance** | The resonance compensation stood at a flat 0.85 on the reasoning that an OTA cascade keeps its low end. The plugin's passband loses 7.2 dB between no resonance and full, where ours lost 1.9. The filter's whole transfer halves its error: 5.0 → 2.4 dB at resonance 0.55. |

## And a fault in the measuring

`compare.py` now drops everything under 20 Hz before it measures anything. A
pulse whose width the LFO moves carries a wandering DC term and the plugin has
nothing to block it — on Organ 3 that subsonic wobble is 99 % of the total
energy, at a few hertz. Measured raw it buries the patch. It also takes
`--engine` now, so two builds can be measured the same way.

With that fixed, this branch against `main`:

| | level sd | > 6 dB | centroid sd | within 300 ct |
|---|---|---|---|---|
| main (after #157) | 5.6 dB | 11 | 842 ct | 31/53 |
| this branch | **3.3 dB** | **7** | **431 ct** | **46/53** |

## The chart's last two columns

Michael found [Hera](https://github.com/jpcima/Hera) (GPL-3), whose presets are
junox's, and then a higher-resolution scan of the owner's manual.

**The VCA level column is not a slider position.** It is a signed offset from
the middle of one — `E +2`, `G −1`, `E 0`, the letter carrying the ENV/GATE
selector — which is why every reading of the chart had given up on it. The
slider is `5 + LEVEL`. junox has had the column all along and this project's
import dropped it: all 56 patches carried the same 0.700 placeholder. **32 of
the 32 rows on the two readable pages match junox cell for cell** under that
mapping, over a range from −3 to +4, so it is taken wholesale. The bank's
loudness spread narrows from 11.1 to 10.5 dB and its span from 51 to 48; the
headroom constant carries the rest and the loudest four-note chord peaks where
it always did.

**Celesta's chorus is OFF**, not I. That column sits at the page edge and had to
come from the Patch Book's LED graphics; the better scan reads it directly and
agrees with junox. It was the single cell where the two transcriptions
disagreed, out of 1344.

Two by-ear deviations fall away with it — Brass and Organ 3 both had their level
raised, and the chart gives 0.7 and 0.5.

**The LFO rate curve** is Hera's: 0.3, 0.85, 3.39, 11.49, 22.22 Hz at the
quarters. Those are the Juno60 project's hardware measurements, the ends are the
specifications page and the factory adjustment, and junox's mapping was slow
over the upper half.

## Cost and testing

110 kB flash, 6.66 % RAM. `juno_test --selftest` passes: 56 patches, no NaN,
loudest four-note chord peak 0.726. Hardware listening test done — the organs
are quieter than before and three sources agree that is what the chart says.

🤖 Generated with [Claude Code](https://claude.com/claude-code)