### PR TITLE
Patch name as a marquee, one face, and a flush that pushes only what moved

### DIFF
--- a/core/include/picoface/ui.h
+++ b/core/include/picoface/ui.h
@@ -96,7 +96,13 @@ public:
     DisplayHandle raw() const;  // escape hatch for special cases
 
     void clear();                        // clear the back buffer
-    void flush();                        // send the back buffer to the display
+    void flush();                        // send the whole back buffer to the display
+    // Send only the rows y0..y1 (inclusive, in pixels). The transport works in
+    // half tile rows of 8 px, so the range is widened to the tiles it touches.
+    // For the one thing on the panel that moves on its own - the scrolling
+    // patch name - this is the difference between 6 ms and 24 ms of I2C per
+    // frame, on the core that also renders the audio.
+    void flush(int16_t y0, int16_t y1);
     void setFont(const uint8_t* font);   // u8g2 font, e.g. u8g2_font_6x10_tf
 
     void drawText(int16_t x, int16_t y, const char* text);

--- a/core/include/picoface/ui_kit.h
+++ b/core/include/picoface/ui_kit.h
@@ -93,11 +93,30 @@ void header(Display& d, const char* title, int page = 0, int pageCount = 0);
 void panelDuo(Display& d, const Param& a, const Param& b);
 
 // A page whose main value is a name rather than a number: a patch, a preset,
-// an instrument. The name gets the full width - "1-12 Nightfall" does not fit
-// in half of it at any legible size - with an optional second line under it
-// for what the name belongs to (a bank, a structure), and one parameter for
-// the right-hand encoder below that.
-void panelName(Display& d, const char* text, const char* sub, const Param& b);
+// an instrument. The number stays put on the left, the name gets the rest of
+// the width - and where it does not fit, it scrolls, the way an LVGL label in
+// LV_LABEL_LONG_SCROLL_CIRCULAR does: it holds still for a moment when a new
+// name appears, then runs to the left and comes round again. The face never
+// changes size. The first version of this page picked the largest face the
+// name happened to fit into, so the type jumped between three sizes as one
+// stepped through a bank - that was the complaint.
+//
+// 'nowMs' drives the scroll. Returns true while the name is scrolling; the
+// instrument then keeps calling marqueeTick() every 40 ms or so until it
+// returns false or the page changes.
+bool panelName(Display& d, const char* number, const char* name, const char* sub,
+               const Param& b, uint32_t nowMs);
+
+// Advances the scrolling name by one frame: redraws only the band the name
+// lives in and flushes only that band - two tile rows, about 6 ms of I2C
+// instead of the 24 a whole screen costs. Returns false once there is nothing
+// to scroll. Safe to call when panelName() last returned false; it does
+// nothing then.
+bool marqueeTick(Display& d, uint32_t nowMs);
+
+// The rows the marquee redraws, published for the host test.
+constexpr int16_t kNameBandTop    = 16;
+constexpr int16_t kNameBandBottom = 31;
 
 // Single column, full width: a section menu or a preset list. Four rows fit
 // between the header and the footer, one more than the old three-row list, and

--- a/core/src/picoface_main.cpp
+++ b/core/src/picoface_main.cpp
@@ -54,10 +54,11 @@ static MIDIInputUSB g_usbmidi;
 static volatile uint32_t g_pio_stall_count = 0;
 picoface::ui::Display g_display(&g_u8g2);   // facade, holds only the u8g2 pointer
 
-// 16 = idle, 0..15 = next half tile row. Display::flush() sets this to 0 and
-// the main loop pushes the buffer out row by row instead of calling a blocking
-// SendBuffer. Deliberately not static: core/src/ui/display.cpp refers to it.
-uint8_t picoface_ui_flush_row = 16;
+// One bit per half tile row, 16 in all; a set bit is a row still to be
+// pushed out, 0 means idle. Display::flush() sets all of them, its ranged
+// overload only the rows that changed, and the main loop pushes one row per
+// pass instead of calling a blocking SendBuffer. Deliberately not static: core/src/ui/display.cpp refers to it.
+uint16_t picoface_ui_flush_mask = 0;
 
 extern "C" void __not_in_flash_func(i2s_callback_func)()
 {
@@ -436,9 +437,10 @@ int main(void)
         // voice takes about six of those, some 9 ms, where USB itself would be
         // done in four 1 ms frames. An editor reading a voice sees the gaps; the
         // display catches up a few milliseconds later and nobody sees that.
-        if (picoface_ui_flush_row < 16 && usbMidiOut().empty()) {
-            u8g2_UpdateDisplayArea(&g_u8g2, (picoface_ui_flush_row & 1) ? 8 : 0, (uint8_t)(picoface_ui_flush_row >> 1), 8, 1);
-            picoface_ui_flush_row++;
+        if (picoface_ui_flush_mask != 0 && usbMidiOut().empty()) {
+            const unsigned row = (unsigned) __builtin_ctz(picoface_ui_flush_mask);   // lowest pending
+            u8g2_UpdateDisplayArea(&g_u8g2, (row & 1) ? 8 : 0, (uint8_t)(row >> 1), 8, 1);
+            picoface_ui_flush_mask &= (uint16_t) ~(1u << row);
         }
 
         // 3. USB and DIN MIDI
@@ -463,7 +465,7 @@ int main(void)
 
         // 4. UI tick, at most every 20 ms and only while the display is not being pushed out
         // uiTick draws into the u8g2 buffer only; Display::flush() just arms the incremental push.
-        if (picoface_ui_flush_row >= 16 && (now - last_ui_ms) >= 20) {
+        if (picoface_ui_flush_mask == 0 && (now - last_ui_ms) >= 20) {
             pf_build_input(input, now);
             const bool edited = input.encoderDelta[0] || input.encoderDelta[1] || input.encoderDelta[2] || input.buttonPressed[0] || input.buttonPressed[1] || input.buttonPressed[2];
             // The three-button gesture owns the screen while it is held, so the

--- a/core/src/ui/display.cpp
+++ b/core/src/ui/display.cpp
@@ -5,8 +5,11 @@
 
 #include "u8g2.h"
 
-// Owned by core/src/picoface_main.cpp; 16 = idle, 0 arms the incremental push.
-extern uint8_t picoface_ui_flush_row;
+// Owned by core/src/picoface_main.cpp. One bit per half tile row (16 of them:
+// 8 tile rows, left and right half); a set bit is a row still to be pushed,
+// 0 means idle. Display::flush() sets bits, the main loop clears them one push
+// at a time.
+extern uint16_t picoface_ui_flush_mask;
 
 namespace picoface {
 namespace ui {
@@ -25,7 +28,17 @@ void Display::flush() {
   // Does NOT call u8g2_SendBuffer. A blocking full-buffer transfer takes far
   // too long and would starve the audio producer; the main loop pushes the
   // buffer out in half tile rows instead.
-  picoface_ui_flush_row = 0;
+  picoface_ui_flush_mask = 0xFFFFu;
+}
+
+void Display::flush(int16_t y0, int16_t y1) {
+  if (y0 < 0) y0 = 0;
+  if (y1 > kHeight - 1) y1 = kHeight - 1;
+  if (y1 < y0) return;
+  // Both halves of every tile row the range touches.
+  for (int ty = y0 / 8; ty <= y1 / 8; ++ty) {
+    picoface_ui_flush_mask |= static_cast<uint16_t>(3u << (ty * 2));
+  }
 }
 
 void Display::setFont(const uint8_t* font) {

--- a/core/src/ui/kit.cpp
+++ b/core/src/ui/kit.cpp
@@ -36,6 +36,13 @@ namespace {
 const uint8_t* const kFontTitle = u8g2_font_7x13B_tf;
 const uint8_t* const kFontLabel = u8g2_font_6x12_tf;
 const uint8_t* const kFontValue = u8g2_font_helvB14_tf;
+// One size under the value face, for the patch name on the name page. Not a
+// concession: the name's band is two tile rows, 16..31, and helvB14 with its
+// ascenders and descenders is 18 rows tall - at any baseline two of them fall
+// outside the band and the marquee clips them off ("Nighttall"). helvB12 is
+// 16 rows exactly, measured on the host by scanning the buffer, and a name
+// in it fits the width beside the number more often, so it scrolls less.
+const uint8_t* const kFontName  = u8g2_font_helvB12_tf;
 const uint8_t* const kFontList  = u8g2_font_7x13B_tf;
 const uint8_t* const kFontSmall = u8g2_font_4x6_tf;
 
@@ -330,7 +337,7 @@ void drawMarqueeBand(u8g2_t* u, int16_t off)
                        static_cast<u8g2_uint_t>(g_marquee.x + g_marquee.width),
                        static_cast<u8g2_uint_t>(kNameBandBottom + 1));
     u8g2_SetDrawColor(u, 1);
-    u8g2_SetFont(u, kFontValue);
+    u8g2_SetFont(u, kFontName);
     const int16_t x0 = static_cast<int16_t>(g_marquee.x - off);
     u8g2_DrawStr(u, static_cast<u8g2_uint_t>(x0), static_cast<u8g2_uint_t>(kNameBase), g_marquee.text);
     u8g2_DrawStr(u, static_cast<u8g2_uint_t>(static_cast<int16_t>(x0 + period)),
@@ -348,16 +355,20 @@ bool panelName(Display& d, const char* number, const char* name, const char* sub
     resetState(u);
     u8g2_SetFont(u, kFontValue);
 
-    // The number first, and the name starts a little to its right. Nothing
-    // here ever changes face: the number is short by construction, the name
-    // scrolls when it has to.
+    // The number first, in the value face, and the name a little to its
+    // right in the name face, both on one baseline. Nothing here ever changes
+    // size: the number is short by construction, the name scrolls when it has
+    // to. The name region runs to the screen's edge - a marquee is clipped
+    // there anyway, and a static name gains four pixels before it has to
+    // scroll.
     int16_t nameX = 4;
     if (number != nullptr && number[0] != 0) {
         u8g2_DrawStr(u, 4, static_cast<u8g2_uint_t>(kNameBase), number);
         nameX = static_cast<int16_t>(4 + u8g2_GetStrWidth(u, number) + 6);
     }
-    const int16_t width = static_cast<int16_t>(kW - 4 - nameX);
+    const int16_t width = static_cast<int16_t>(kW - nameX);
     if (name == nullptr) name = "";
+    u8g2_SetFont(u, kFontName);
 
     bool scrolling = false;
     if (static_cast<int16_t>(u8g2_GetStrWidth(u, name)) <= width) {

--- a/core/src/ui/kit.cpp
+++ b/core/src/ui/kit.cpp
@@ -398,7 +398,13 @@ bool panelName(Display& d, const char* number, const char* name, const char* sub
         u8g2_DrawStr(u, 4, 41, sub);
     }
 
+    // Which encoder owns the top half: the patch is encoder A's, always, on
+    // this page. Same corner as the B tag on the row below - the right edge,
+    // last line of its half - so the two read as a pair.
     u8g2_SetDrawColor(u, 1);
+    u8g2_SetFont(u, kFontSmall);
+    u8g2_DrawStr(u, kW - 6, 41, "A");
+
     u8g2_DrawHLine(u, 0, 44, kW);
 
     // The right-hand encoder's parameter, laid out along the line rather than

--- a/core/src/ui/kit.cpp
+++ b/core/src/ui/kit.cpp
@@ -9,6 +9,8 @@
 
 #include "picoface/ui_kit.h"
 
+#include <cstring>
+
 #include "u8g2.h"
 
 namespace picoface {
@@ -280,23 +282,104 @@ void panelDuo(Display& d, const Param& a, const Param& b)
 // Body: a name across the full width, one parameter below
 // ---------------------------------------------------------------------------
 
-void panelName(Display& d, const char* text, const char* sub, const Param& b)
+namespace {
+
+// The one marquee the panel can show. Its state lives here rather than in the
+// instruments because the animation is the kit's: an instrument only has to
+// keep calling marqueeTick() while panelName() said the name scrolls.
+struct Marquee {
+    char     text[48];
+    int16_t  x;         // left edge of the name region
+    int16_t  width;     // region width, up to the right margin
+    int16_t  textW;     // the name's width in the value face
+    int16_t  lastOff;   // offset last drawn, so a frame that changes nothing is not pushed
+    uint32_t startMs;   // when this name first appeared
+    uint32_t seenMs;    // when panelName() last drew it
+    bool     active;
+};
+Marquee g_marquee = {};
+
+constexpr int16_t  kNameBase = 28;     // baseline of number and name, inside the band
+constexpr uint32_t kHoldMs   = 1200;   // a new name stays put this long before it moves
+constexpr int16_t  kSpeedPxS = 48;     // then it moves at this rate
+constexpr int16_t  kGapPx    = 24;     // between the end of the name and its next copy
+
+// A page that was away and comes back gets its hold again: panelName() is
+// called at least every 500 ms while its page is up, so a longer gap means
+// the page was somewhere else in between.
+constexpr uint32_t kAwayMs = 800;
+
+int16_t marqueeOffset(uint32_t nowMs)
+{
+    const uint32_t elapsed = nowMs - g_marquee.startMs;
+    if (elapsed < kHoldMs) return 0;
+    const uint32_t period = static_cast<uint32_t>(g_marquee.textW + kGapPx);
+    // 64-bit: a patch page left up for a day would otherwise wrap the product.
+    const uint64_t px = static_cast<uint64_t>(elapsed - kHoldMs) * static_cast<uint64_t>(kSpeedPxS) / 1000u;
+    return static_cast<int16_t>(px % period);
+}
+
+// The name and its next copy one period to the right, both clipped to the
+// region. u8g2 carries 16-bit signed intermediate coordinates in every 32-bit
+// build (U8G2_16BIT), so a copy that starts left of the region is clipped
+// rather than wrapped - checked on the host renderer before relying on it.
+void drawMarqueeBand(u8g2_t* u, int16_t off)
+{
+    const int16_t period = static_cast<int16_t>(g_marquee.textW + kGapPx);
+    u8g2_SetClipWindow(u, static_cast<u8g2_uint_t>(g_marquee.x), static_cast<u8g2_uint_t>(kNameBandTop),
+                       static_cast<u8g2_uint_t>(g_marquee.x + g_marquee.width),
+                       static_cast<u8g2_uint_t>(kNameBandBottom + 1));
+    u8g2_SetDrawColor(u, 1);
+    u8g2_SetFont(u, kFontValue);
+    const int16_t x0 = static_cast<int16_t>(g_marquee.x - off);
+    u8g2_DrawStr(u, static_cast<u8g2_uint_t>(x0), static_cast<u8g2_uint_t>(kNameBase), g_marquee.text);
+    u8g2_DrawStr(u, static_cast<u8g2_uint_t>(static_cast<int16_t>(x0 + period)),
+                 static_cast<u8g2_uint_t>(kNameBase), g_marquee.text);
+    u8g2_SetMaxClipWindow(u);
+    g_marquee.lastOff = off;
+}
+
+} // namespace
+
+bool panelName(Display& d, const char* number, const char* name, const char* sub,
+               const Param& b, uint32_t nowMs)
 {
     u8g2_t* u = d.raw();
     resetState(u);
+    u8g2_SetFont(u, kFontValue);
 
-    // The name, in the largest face it fits into. A patch name is what the
-    // player is looking for on this page, so it gets the width and the size
-    // before anything else on it does.
-    if (text != nullptr && text[0] != 0) {
-        u8g2_SetFont(u, kFontValue);
-        if (u8g2_GetStrWidth(u, text) > kW - 8) {
-            u8g2_SetFont(u, kFontList);
-            if (u8g2_GetStrWidth(u, text) > kW - 8) {
-                u8g2_SetFont(u, kFontLabel);
-            }
+    // The number first, and the name starts a little to its right. Nothing
+    // here ever changes face: the number is short by construction, the name
+    // scrolls when it has to.
+    int16_t nameX = 4;
+    if (number != nullptr && number[0] != 0) {
+        u8g2_DrawStr(u, 4, static_cast<u8g2_uint_t>(kNameBase), number);
+        nameX = static_cast<int16_t>(4 + u8g2_GetStrWidth(u, number) + 6);
+    }
+    const int16_t width = static_cast<int16_t>(kW - 4 - nameX);
+    if (name == nullptr) name = "";
+
+    bool scrolling = false;
+    if (static_cast<int16_t>(u8g2_GetStrWidth(u, name)) <= width) {
+        u8g2_DrawStr(u, static_cast<u8g2_uint_t>(nameX), static_cast<u8g2_uint_t>(kNameBase), name);
+        g_marquee.active = false;
+    } else {
+        const bool fresh = !g_marquee.active
+                        || std::strcmp(name, g_marquee.text) != 0
+                        || nameX != g_marquee.x
+                        || (nowMs - g_marquee.seenMs) > kAwayMs;
+        if (fresh) {
+            std::strncpy(g_marquee.text, name, sizeof(g_marquee.text) - 1);
+            g_marquee.text[sizeof(g_marquee.text) - 1] = 0;
+            g_marquee.x       = nameX;
+            g_marquee.width   = width;
+            g_marquee.textW   = static_cast<int16_t>(u8g2_GetStrWidth(u, g_marquee.text));
+            g_marquee.startMs = nowMs;
+            g_marquee.active  = true;
         }
-        u8g2_DrawStr(u, 4, 29, text);
+        g_marquee.seenMs = nowMs;
+        drawMarqueeBand(u, marqueeOffset(nowMs));
+        scrolling = true;
     }
 
     if (sub != nullptr && sub[0] != 0) {
@@ -304,18 +387,19 @@ void panelName(Display& d, const char* text, const char* sub, const Param& b)
         u8g2_DrawStr(u, 4, 41, sub);
     }
 
+    u8g2_SetDrawColor(u, 1);
     u8g2_DrawHLine(u, 0, 44, kW);
 
     // The right-hand encoder's parameter, laid out along the line rather than
     // stacked: there is one of them and a whole width to put it in.
     if (b.name != nullptr && b.name[0] != 0) {
-        int16_t nameX = 4;
+        int16_t bx = 4;
         if (b.norm >= 0.0f) {
             drawKnob(u, 13, 55, 7, b.norm);
-            nameX = 26;
+            bx = 26;
         }
         u8g2_SetFont(u, kFontLabel);
-        u8g2_DrawStr(u, static_cast<u8g2_uint_t>(nameX), 59, b.name);
+        u8g2_DrawStr(u, static_cast<u8g2_uint_t>(bx), 59, b.name);
 
         const char* bt = (b.text != nullptr) ? b.text : "";
         u8g2_SetFont(u, kFontValue);
@@ -327,6 +411,28 @@ void panelName(Display& d, const char* text, const char* sub, const Param& b)
     }
 
     resetState(u);
+    return scrolling;
+}
+
+bool marqueeTick(Display& d, uint32_t nowMs)
+{
+    if (!g_marquee.active) return false;
+
+    const int16_t off = marqueeOffset(nowMs);
+    if (off == g_marquee.lastOff) return true;   // still holding, or between pixels: nothing to push
+
+    u8g2_t* u = d.raw();
+    // Clear the band from the name's left edge - the number to its left stays
+    // in the buffer untouched - and redraw the name where it is now.
+    u8g2_SetDrawColor(u, 0);
+    u8g2_DrawBox(u, static_cast<u8g2_uint_t>(g_marquee.x), static_cast<u8g2_uint_t>(kNameBandTop),
+                 static_cast<u8g2_uint_t>(kW - g_marquee.x),
+                 static_cast<u8g2_uint_t>(kNameBandBottom - kNameBandTop + 1));
+    drawMarqueeBand(u, off);
+    resetState(u);
+    g_marquee.seenMs = nowMs;
+    d.flush(kNameBandTop, kNameBandBottom);
+    return true;
 }
 
 // ---------------------------------------------------------------------------

--- a/instruments/PicoFaceD5/include/D5_Controller.h
+++ b/instruments/PicoFaceD5/include/D5_Controller.h
@@ -36,9 +36,12 @@ public:
     Value valueA() const;
     Value valueB() const;
 
-    // The patch page shows a name, not a number, and needs the whole width for
-    // it; the kit has its own body for that.
+    // The patch page shows a name, not a number, and the kit has its own body
+    // for that: the number stays put on the left, the name takes the rest of
+    // the width and scrolls when it is longer than that.
     bool        isPatchPage() const { return page_ == kPagePatch; }
+    void        patchNumber(char* out, size_t n) const;   // "2-37", or "12" with one bank
+    const char* patchName() const;
     bool        isDiagPage()  const { return page_ == kPageDiag; }
     const char* patchStructure() const;  // second line under the patch name
 

--- a/instruments/PicoFaceD5/src/D5_Controller.cpp
+++ b/instruments/PicoFaceD5/src/D5_Controller.cpp
@@ -106,6 +106,16 @@ const char* D5_Controller::pageName() const {
 }
 
 const char* D5_Controller::patchStructure() const { return bridge_.structureName(); }
+const char* D5_Controller::patchName() const      { return bridge_.patchName(); }
+
+// With one bank aboard the plain number stays (a D-50 owns 64); with the
+// D-05's six banks the panel convention bank-patch tells "2-37" from "5-37".
+void D5_Controller::patchNumber(char* out, size_t n) const {
+    if (bridge_.patchCount() > 64)
+        snprintf(out, n, "%d-%d", bridge_.patch() / 64 + 1, bridge_.patch() % 64 + 1);
+    else
+        snprintf(out, n, "%d", bridge_.patch() + 1);
+}
 
 // The two encoders, each as one value the kit can lay out. Normalisation is
 // per page because each range is its own: the panel numbers are 0..100 for the
@@ -114,18 +124,14 @@ const char* D5_Controller::patchStructure() const { return bridge_.structureName
 D5_Controller::Value D5_Controller::valueA() const {
     Value v{"", {0}, -1.0f};
     switch (page_) {
-        case kPagePatch:
-            // The value names itself, and the patch page gives it the width.
-            // With one bank aboard the plain number stays (a D-50 owns 64);
-            // with the D-05's six banks the panel convention bank-patch tells
-            // "2-37 Nightfall" from "5-37".
-            if (bridge_.patchCount() > 64)
-                snprintf(v.text, sizeof v.text, "%d-%d %s", bridge_.patch() / 64 + 1,
-                         bridge_.patch() % 64 + 1, bridge_.patchName());
-            else
-                snprintf(v.text, sizeof v.text, "%d %s", bridge_.patch() + 1,
-                         bridge_.patchName());
+        case kPagePatch: {
+            // The value names itself. The page itself draws number and name
+            // apart (patchNumber/patchName); this is the one-line form.
+            char num[12];
+            patchNumber(num, sizeof num);
+            snprintf(v.text, sizeof v.text, "%s %s", num, bridge_.patchName());
             break;
+        }
         case kPageMix:
             v.name = "Volume";
             snprintf(v.text, sizeof v.text, "%d", volume_);

--- a/instruments/PicoFaceD5/src/D5_Instrument.cpp
+++ b/instruments/PicoFaceD5/src/D5_Instrument.cpp
@@ -104,9 +104,14 @@ public:
         if (da) { controller_.onEncoderA(da); dirty_ = true; }
         if (db) { controller_.onEncoderB(db); dirty_ = true; }
         if ((dirty_ && (in.nowMs - lastDrawMs_) > 50u) || (in.nowMs - lastDrawMs_) > 500u) {
-            draw(d);
+            draw(d, in.nowMs);
             dirty_ = false;
             lastDrawMs_ = in.nowMs;
+        } else if (marquee_ && (in.nowMs - lastMarqueeMs_) >= 40u) {
+            // The scrolling patch name: one band redrawn, one band flushed,
+            // nothing else on the screen moves.
+            marquee_ = picoface::ui::kit::marqueeTick(d, in.nowMs);
+            lastMarqueeMs_ = in.nowMs;
         }
     }
 
@@ -130,8 +135,9 @@ public:
     }
 
 private:
-    void draw(picoface::ui::Display& d) {
+    void draw(picoface::ui::Display& d, uint32_t nowMs = 0) {
         namespace kit = picoface::ui::kit;
+        marquee_ = false;
 
         // The developer's numbers went from a strip at the bottom of every page
         // to a page of their own (#161: that strip cost the body nine rows on
@@ -167,17 +173,20 @@ private:
         kit::header(d, controller_.pageName(), controller_.pageIndex(),
                     controller_.pageTotal());
         if (controller_.isPatchPage()) {
-            // A patch name does not fit in half the width at a size worth
-            // reading, so it gets all of it, with the structure under it.
-            kit::panelName(d, a.text, controller_.patchStructure(),
-                           { b.name, b.text, b.norm });
+            // Number and name apart: the number stays put, the name takes the
+            // rest of the width and scrolls when it is longer than that. The
+            // structure sits under it.
+            char num[12];
+            controller_.patchNumber(num, sizeof num);
+            marquee_ = kit::panelName(d, num, controller_.patchName(), controller_.patchStructure(),
+                                      { b.name, b.text, b.norm }, nowMs);
         } else {
             kit::panelDuo(d, { a.name, a.text, a.norm },
                              { b.name, b.text, b.norm });
         }
 
-        // Arms the incremental push: the main loop only streams the buffer
-        // while picoface_ui_flush_row < 16, and flush() resets that counter.
+        // Arms the incremental push: the main loop streams out the rows whose
+        // bit in the flush mask is set, and flush() sets all sixteen.
         d.flush();
     }
 
@@ -190,6 +199,8 @@ private:
     D5_Midi midi_;
     bool dirty_ = true;
     uint32_t lastDrawMs_ = 0;
+    bool marquee_ = false;           // the patch name is scrolling; keep ticking it
+    uint32_t lastMarqueeMs_ = 0;
     uint32_t lastUnderrun_ = 0;
     uint32_t lastUnderrunMs_ = 0;
 };

--- a/instruments/PicoFaceJV/src/JV_Instrument.cpp
+++ b/instruments/PicoFaceJV/src/JV_Instrument.cpp
@@ -98,9 +98,14 @@ public:
         // Redraw soon after input, and at least twice a second as a keep-alive
         // so the footer's live counters stay current.
         if ((dirty_ && (in.nowMs - lastDrawMs_) > 50u) || (in.nowMs - lastDrawMs_) > 500u) {
-            draw(d);
+            draw(d, in.nowMs);
             dirty_ = false;
             lastDrawMs_ = in.nowMs;
+        } else if (marquee_ && (in.nowMs - lastMarqueeMs_) >= 40u) {
+            // The scrolling patch name: one band redrawn, one band flushed,
+            // nothing else on the screen moves.
+            marquee_ = picoface::ui::kit::marqueeTick(d, in.nowMs);
+            lastMarqueeMs_ = in.nowMs;
         }
     }
 
@@ -124,8 +129,9 @@ public:
     }
 
 private:
-    void draw(picoface::ui::Display& d) {
+    void draw(picoface::ui::Display& d, uint32_t nowMs = 0) {
         namespace kit = picoface::ui::kit;
+        marquee_ = false;
 
         // The developer's numbers went from a strip at the bottom of every page
         // to a page of their own (#161: that strip cost the body nine rows on
@@ -152,17 +158,17 @@ private:
         kit::header(d, controller_.pageName(), controller_.pageIndex(),
                     controller_.pageTotal());
         if (controller_.isPatchPage()) {
-            // A patch name does not fit in half the width at a size worth
-            // reading, so it gets all of it, with the bank under it.
-            kit::panelName(d, a.text, b.text, {});
+            // The name gets the whole width and scrolls if it is longer than
+            // that; the bank sits under it.
+            marquee_ = kit::panelName(d, "", a.text, b.text, {}, nowMs);
         } else {
             kit::panelDuo(d, { a.name, a.text, a.norm },
                              { b.name, b.text, b.norm });
         }
 
         // Arms the incremental push. Painting the buffer is not enough: the main
-        // loop only streams it out while picoface_ui_flush_row < 16, and flush()
-        // is what resets that counter. Without this the display keeps showing
+        // loop only streams out rows whose bit in the flush mask is set, and
+        // flush() is what sets them. Without this the display keeps showing
         // whatever was pushed last -- the boot splash -- while everything else
         // runs normally.
         d.flush();
@@ -175,6 +181,8 @@ private:
     JV_Midi midi_;
     bool dirty_ = true;
     uint32_t lastDrawMs_ = 0;
+    bool marquee_ = false;           // the patch name is scrolling; keep ticking it
+    uint32_t lastMarqueeMs_ = 0;
     uint32_t lastUnderrun_ = 0;
     uint32_t lastUnderrunMs_ = 0;
 };

--- a/instruments/PicoFaceRD/src/RD_Instrument.cpp
+++ b/instruments/PicoFaceRD/src/RD_Instrument.cpp
@@ -110,9 +110,14 @@ public:
         if (d3) { controller_.onEncoder3(d3); dirty_ = true; }
         // Refresh quickly after user input, but at least every 500 ms as a keep-alive.
         if ((dirty_ && (in.nowMs - lastDrawMs_) > 50u) || (in.nowMs - lastDrawMs_) > 500u) {
-            draw(d);
+            draw(d, in.nowMs);
             dirty_ = false;
             lastDrawMs_ = in.nowMs;
+        } else if (marquee_ && (in.nowMs - lastMarqueeMs_) >= 40u) {
+            // The scrolling patch name: one band redrawn, one band flushed,
+            // nothing else on the screen moves.
+            marquee_ = picoface::ui::kit::marqueeTick(d, in.nowMs);
+            lastMarqueeMs_ = in.nowMs;
         }
     }
 
@@ -173,9 +178,10 @@ private:
         }
     }
 
-    void draw(picoface::ui::Display& d)
+    void draw(picoface::ui::Display& d, uint32_t nowMs = 0)
     {
         namespace kit = picoface::ui::kit;
+        marquee_ = false;
 
         // The developer's numbers went from a strip at the bottom of every page
         // to a page of their own (#161: that strip cost the body nine rows on
@@ -237,11 +243,12 @@ private:
 
         switch (controller_.currentPage()) {
         case RdPage::PATCH:
-            // The instrument name gets the full width, with its bank under it.
-            snprintf(va, sizeof(va), "%02d %s", (int) shown + 1, bareName);
+            // Number and name apart: the number stays put, the name takes the
+            // rest of the width and scrolls when it is longer; bank under it.
+            snprintf(va, sizeof(va), "%02d", (int) shown + 1);
             snprintf(vb, sizeof(vb), "%d%%", (int) controller_.param3Value());
-            kit::panelName(d, va, bankName,
-                           { "Volume", vb, controller_.param3Value() / 100.0f });
+            marquee_ = kit::panelName(d, va, bareName, bankName,
+                                      { "Volume", vb, controller_.param3Value() / 100.0f }, nowMs);
             break;
 
         case RdPage::VOICES: {
@@ -324,6 +331,8 @@ private:
     RD_Controller   controller_;   // declared after midi_: taken by reference in the constructor
     bool            dirty_ = false;
     uint32_t        lastDrawMs_ = 0;
+    bool            marquee_ = false;      // the patch name is scrolling; keep ticking it
+    uint32_t        lastMarqueeMs_ = 0;
 };
 
 } // namespace

--- a/instruments/PicoFaceSM/include/SM_Controller.h
+++ b/instruments/PicoFaceSM/include/SM_Controller.h
@@ -52,6 +52,11 @@ public:
      * kit::diagnostics; neither encoder acts there. */
     bool        isDiagPage() const;
 
+    /* The preset page draws number and name apart through the kit's name
+     * page, so the name can scroll instead of shrinking. */
+    bool        isPresetPage() const;
+    int         program() const { return (int) program_; }
+
     const char* paramAName() const;
     const char* paramBName() const;
     /* 0..1 for a value that has a position on a dial, negative for one that

--- a/instruments/PicoFaceSM/src/SM_Controller.cpp
+++ b/instruments/PicoFaceSM/src/SM_Controller.cpp
@@ -91,6 +91,7 @@ int SM_Controller::pageCount() const { return kPageCount; }
 
 const char* SM_Controller::pageName() const { return kPages[page_].name; }
 bool        SM_Controller::isDiagPage() const { return kPages[page_].a == SM_UI_DIAG; }
+bool        SM_Controller::isPresetPage() const { return kPages[page_].a == SM_UI_PROGRAM; }
 
 int SM_Controller::paramIdOf(int slot) const
 {

--- a/instruments/PicoFaceSM/src/SM_Instrument.cpp
+++ b/instruments/PicoFaceSM/src/SM_Instrument.cpp
@@ -78,9 +78,15 @@ public:
         // footer statistics stay alive even without user input.
         if ((dirty_ && (in.nowMs - lastDrawMs_) > 50u) || (in.nowMs - lastDrawMs_) > 500u)
         {
-            draw(d);
+            draw(d, in.nowMs);
             dirty_     = false;
             lastDrawMs_ = in.nowMs;
+        }
+        else if (marquee_ && (in.nowMs - lastMarqueeMs_) >= 40u)
+        {
+            // The scrolling preset name: one band redrawn, one band flushed.
+            marquee_ = picoface::ui::kit::marqueeTick(d, in.nowMs);
+            lastMarqueeMs_ = in.nowMs;
         }
     }
 
@@ -154,9 +160,10 @@ private:
     }
 
     // The Solina has only a page view, no list.
-    void draw(picoface::ui::Display& d)
+    void draw(picoface::ui::Display& d, uint32_t nowMs = 0)
     {
         namespace kit = picoface::ui::kit;
+        marquee_ = false;
 
         // The developer's numbers went from a strip at the bottom of every page
         // to a page of their own (#161: that strip cost the body nine rows on
@@ -183,10 +190,18 @@ private:
         d.clear();
         kit::header(d, controller_.pageName(), controller_.currentPage(),
                     controller_.pageCount());
-        // An empty name means the value describes itself (the preset does).
-        kit::panelDuo(d,
-            { controller_.paramAName(), va, controller_.paramANorm() },
-            { controller_.paramBName(), vb, controller_.paramBNorm() });
+        if (controller_.isPresetPage()) {
+            // Number and name apart: the number stays put, the name takes the
+            // rest of the width and scrolls when it is longer than that.
+            char num[8];
+            snprintf(num, sizeof num, "%d", controller_.program() + 1);
+            marquee_ = kit::panelName(d, num, solinaPrograms[controller_.program()].name, "",
+                                      { controller_.paramBName(), vb, controller_.paramBNorm() }, nowMs);
+        } else {
+            kit::panelDuo(d,
+                { controller_.paramAName(), va, controller_.paramANorm() },
+                { controller_.paramBName(), vb, controller_.paramBNorm() });
+        }
 
         d.flush();   // arms the incremental push
     }
@@ -196,6 +211,8 @@ private:
     SM_Controller   controller_;   // declared after midi_: taken by reference in the constructor
     bool            dirty_      = false;
     uint32_t        lastDrawMs_ = 0;
+    bool            marquee_    = false;   // the preset name is scrolling; keep ticking it
+    uint32_t        lastMarqueeMs_ = 0;
 };
 
 } // namespace

--- a/tools/host_tests/ui/ui_kit_shots.cpp
+++ b/tools/host_tests/ui/ui_kit_shots.cpp
@@ -126,14 +126,29 @@ void customBody()
     shot("custom_body");
 }
 
-// --- A page whose value is a name: D5, JV and RD all have one -------------
+// --- A page whose value is a name: D5, JV, RD and SM all have one ----------
+// Three frames: a name that fits, a long one the moment it appears (held),
+// and the same one 2.6 s later, scrolled. The face is the same in all three.
 void namePage()
 {
-    uishot::begin();
     Display& d = uishot::display();
+    uishot::begin();
     kit::header(d, "Patch", 0, 9);
-    kit::panelName(d, "2-37 Nightfall", "S+S Ring", {"Voices", "8", 0.5f});
+    kit::panelName(d, "2-37", "Nightfall", "S+S Ring", {"Voices", "8", 0.5f}, 0);
     shot("panel_name");
+
+    uishot::begin();
+    kit::header(d, "Patch", 0, 9);
+    kit::panelName(d, "2-37", "Nightfall Dreams II", "S+S Ring", {"Voices", "8", 0.5f}, 1000);
+    shot("panel_name_hold");
+
+    // The device ticks the marquee every 40 ms between full redraws; the
+    // scrolled frame is reached the same way here, through marqueeTick(), so
+    // this exercises the band redraw and not just the full-page path.
+    for (uint32_t t = 1040; t <= 3600; t += 40) {
+        if (!kit::marqueeTick(d, t)) { std::printf("marquee stopped early at %u ms\n", (unsigned) t); break; }
+    }
+    shot("panel_name_scroll");
 }
 
 // --- The developer's numbers, on a screen of their own -------------------

--- a/tools/host_tests/ui/ui_shot.h
+++ b/tools/host_tests/ui/ui_shot.h
@@ -21,7 +21,7 @@
 
 // Owned by core/src/picoface_main.cpp on the target; the facade writes it to
 // arm the staged flush, so the host build has to provide it.
-uint8_t picoface_ui_flush_row = 16;
+uint16_t picoface_ui_flush_mask = 0;
 
 namespace uishot {
 


### PR DESCRIPTION
The patch page changed its type size with almost every step through a
bank: `panelName()` picked the largest face the name happened to fit
into. Michael's word for it was *unruhig*.

## One face, and a name that scrolls

The number stays put on the left; the name gets the rest of the width,
and where it does not fit it scrolls the way an LVGL label in
`LV_LABEL_LONG_SCROLL_CIRCULAR` does - holds still for 1.2 s when a new
name appears so its start can be read, then runs left at 48 px/s and
comes round again after a gap. The face never changes.

The animation is the kit's: `panelName()` reports whether the name
scrolls, the instrument calls `marqueeTick()` every 40 ms until it says
no. The tick redraws only the band the name lives in and flushes only
that band.

## The flush pushes only what moved

That needed a change in the core. The main loop pushed the whole screen
as sixteen half tile rows of ~1.5 ms blocking I2C each, on the core that
renders the audio - a marquee at 25 fps would have spent most of its
time in I2C. The counter `picoface_ui_flush_row` is a 16-bit mask now:
`Display::flush()` sets every row, `Display::flush(y0, y1)` only the
rows a pixel range touches, and the loop pushes the lowest pending row
per pass. A marquee frame is two tile rows: 6 ms instead of 24, and
nothing at all during the hold. For comparison, turning an encoder
today pushes a full screen every 50 ms.

## On the instruments

D5, JV, RD and SM. SM's preset page moves from the two-value body to
the name page for this, number and name apart.

## Verified

- text beginning left of its clip window is clipped, not wrapped - u8g2
  carries 16-bit signed coordinates in every 32-bit build; checked on
  the host renderer, not read in a manual
- the three frames of the name page rendered on the host, the scrolled
  one reached through `marqueeTick()` exactly as the device reaches it
- all ten build clean with `-Wall -Wextra`

Hardware test pending - the one question the host cannot answer is
whether the D5 at its load limit minds the extra 6 ms of I2C per frame
while a long name scrolls.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
