### PR TITLE
Core: a USB MIDI queue the host never empties must not freeze the display (#161)

### DIFF
--- a/core/include/midi_output_usb.h
+++ b/core/include/midi_output_usb.h
@@ -44,7 +44,22 @@ public:
     uint16_t pending() const { return _count; }
     uint32_t dropped() const { return _dropped; }   // messages, not bytes
 
+    // True while the host is not taking what is queued: the device is mounted,
+    // bytes are pending, and TinyUSB has accepted nothing for kStallMs. That is
+    // what a PC looks like when it has enumerated the device but no program
+    // holds the MIDI port open (Windows and Linux do not poll the IN endpoint
+    // then; macOS always does). Whoever waits for this queue to empty - the
+    // display flush does - must stop waiting in that state, because it never
+    // will: the reface ports send active sensing every 200 ms, and 16 of those
+    // fill the 64-byte FIFO, so such a host froze the display and the encoders
+    // of DX, YC and CP about three seconds after boot (#161). Clears as soon
+    // as the host takes bytes again.
+    bool     stalled() const { return _stalled; }
+
 private:
+    // A host that is reading drains a full FIFO within a USB frame or two.
+    static constexpr uint32_t kStallMs = 50;
+
     // Room for a full reface DX voice dump (241 bytes) several times over, so a
     // burst of dump requests queues rather than drops. 1 KB of RAM against a
     // silently lost patch transfer is a trade worth making.
@@ -54,6 +69,8 @@ private:
     uint16_t _head    = 0;   // read position
     uint16_t _count   = 0;   // bytes queued
     uint32_t _dropped = 0;
+    uint32_t _stallSinceMs = 0;   // 0 = making progress
+    bool     _stalled = false;
 };
 
 MIDIOutputUSB& usbMidiOut();

--- a/core/src/midi_output_usb.cpp
+++ b/core/src/midi_output_usb.cpp
@@ -46,12 +46,15 @@ void MIDIOutputUSB::process()
     if (!tud_midi_mounted()) {
         _head  = 0;
         _count = 0;
+        _stallSinceMs = 0;
+        _stalled = false;
         return;
     }
 
     // One pass per main loop iteration. tud_midi_stream_write() stops at the
     // FIFO boundary and reports how far it got; whatever is left stays queued
     // for the next round, once tud_task() has freed the endpoint again.
+    bool progress = false;
     while (_count > 0) {
         const uint16_t contiguous = (uint16_t)((_head + _count > kBufSize)
                                              ? (kBufSize - _head)
@@ -60,7 +63,22 @@ void MIDIOutputUSB::process()
         if (written == 0) {
             break;                      // FIFO full - resume after tud_task()
         }
+        progress = true;
         _head  = (uint16_t)((_head + written) % kBufSize);
         _count = (uint16_t)(_count - written);
+    }
+
+    // Stall detection, see stalled() in the header. A FIFO that stays full
+    // across kStallMs of tud_task() calls is one the host is not emptying.
+    if (progress) {
+        _stallSinceMs = 0;
+        _stalled = false;
+    } else if (_count > 0) {
+        const uint32_t now = to_ms_since_boot(get_absolute_time());
+        if (_stallSinceMs == 0) {
+            _stallSinceMs = now ? now : 1u;
+        } else if ((now - _stallSinceMs) >= kStallMs) {
+            _stalled = true;
+        }
     }
 }

--- a/core/src/picoface_main.cpp
+++ b/core/src/picoface_main.cpp
@@ -437,7 +437,13 @@ int main(void)
         // voice takes about six of those, some 9 ms, where USB itself would be
         // done in four 1 ms frames. An editor reading a voice sees the gaps; the
         // display catches up a few milliseconds later and nobody sees that.
-        if (picoface_ui_flush_mask != 0 && usbMidiOut().empty()) {
+        //
+        // Not while the queue is stalled, though: a host that has enumerated
+        // the device but reads nothing (a PC with no MIDI program open) never
+        // empties it, and waiting for that froze display and encoders of the
+        // reface ports three seconds after boot - the UI tick below only runs
+        // once the flush is done (#161).
+        if (picoface_ui_flush_mask != 0 && (usbMidiOut().empty() || usbMidiOut().stalled())) {
             const unsigned row = (unsigned) __builtin_ctz(picoface_ui_flush_mask);   // lowest pending
             u8g2_UpdateDisplayArea(&g_u8g2, (row & 1) ? 8 : 0, (uint8_t)(row >> 1), 8, 1);
             picoface_ui_flush_mask &= (uint16_t) ~(1u << row);


### PR DESCRIPTION
The reporter of #161 sees **DX and YC freeze a few seconds after boot** on a plain Pico 2, every release. Found by reading, not by reproducing — it cannot be reproduced on a Mac, and that is part of the diagnosis.

### Mechanism

- The reface ports (DX, YC, CP) send **active sensing, one `0xFE` every 200 ms**, through `usbMidiOut()` (`RefaceMidi::tick()`, called from `uiTick`).
- The core drains that queue into TinyUSB after each `tud_task()`; TinyUSB's **64-byte TX FIFO** reaches the host only when the host polls the bulk IN endpoint. A PC that has enumerated the device but has **no program holding the MIDI port open never polls** — Windows and Linux behave like that. macOS reads every USB MIDI endpoint from the moment the device appears, which is why it never showed here.
- 16 packets fill the FIFO: **16 × 200 ms = 3.2 s** after boot the queue stops draining and is never empty again.
- The display flush waits for that queue to be empty (`picoface_main.cpp`, deliberately: an I2C block must not pace a SysEx dump), and the **UI tick runs only once the flush is done**. So: display frozen, encoders dead, three-button gesture dead; audio and MIDI input keep running. Exactly a "freeze", and only on the three instruments that transmit on their own — D5, J6, MD, OB, SM send nothing unasked and are fine, which matches the report (the reporter runs D5 happily). CP was never testable on 4 MB before v1.20.0; it has the same code and would have shown the same.

### Fix

`MIDIOutputUSB::stalled()`: bytes pending, device mounted, nothing accepted for 50 ms (a host that reads drains a full FIFO within a frame or two). The flush no longer waits while stalled; the flag clears as soon as the host takes bytes again. Queueing for a reading host and dropping for an unmounted one are unchanged. +112 bytes per image; DX, YC, CP and MD build.

### Testing

On the Mac this cannot reproduce (CoreMIDI drains), so the hardware test here is regression only: DX/YC panel, encoders, Soundmondo dump. The real check is the reporter's setup — the CI artifacts of this PR's run carry `PicoFaceDX.uf2` / `PicoFaceYC.uf2` with the fix. A Windows or Linux box with the board plugged in and no MIDI program open should show the freeze on v1.20.0 at ~3 s and not with these.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
