### PR TITLE
Host tests run in CI: run_all.sh, one job, a release needs it green

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,9 +85,52 @@ jobs:
           path: artifacts/*
           if-no-files-found: error
 
+  # Everything under tools/host_tests that needs neither a sound card, a MIDI
+  # port nor a ROM set: the core's veeprom, the D-50 laws, the OB-X engine
+  # checks, the DX SysEx round trip, the J6 panel and patch store, the YC
+  # engine render, the shared UI kit and the MD panel rendered to frames, and
+  # one note through each CP voice. A release needs this green as much as the
+  # seven firmware builds - a regression in the core shows up here, on a
+  # Linux box, before it shows up on somebody's board.
+  host-tests:
+    name: Host tests
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          # Tags, because the UI kit's About frame names the nearest release.
+          fetch-depth: 0
+
+      # Only u8g2 is needed here, not the whole SDK tree the firmware pulls.
+      - name: Fetch u8g2
+        run: git submodule update --init --depth 1 lib/u8g2/u8g2
+
+      - name: Install host tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends build-essential python3
+
+      - name: Run host tests
+        run: tools/host_tests/run_all.sh
+
+      # The logs, and the rendered panels: a GUI change can be looked at from
+      # the PR without flashing a board.
+      - name: Upload logs and renders
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: host-tests
+          path: |
+            tools/host_tests/_out/*.log
+            tools/host_tests/ui/out/*.pbm
+            tools/host_tests/md/out/*.pbm
+          if-no-files-found: ignore
+
   release:
     name: Publish GitHub Release
-    needs: build
+    needs: [build, host-tests]
     if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-22.04
     permissions:

--- a/.gitignore
+++ b/.gitignore
@@ -67,3 +67,5 @@ tools/cp_sampleprep/FindLoopPoints
 
 # d5_extract WAV renders
 tools/d5_extract/out/
+tools/host_tests/_out/
+tools/host_tests/cp/out/

--- a/tools/host_tests/README.md
+++ b/tools/host_tests/README.md
@@ -8,14 +8,32 @@ scripts build the **unmodified** instrument sources - the only difference is a
 Run them from anywhere; each script locates the repository itself. The binaries
 land next to their script and are gitignored.
 
+**`run_all.sh` runs every test that needs neither a sound card, a MIDI port nor
+a ROM set** - the "nothing" rows of the table plus the three renders below it -
+and exits with the number of failures. CI runs exactly that
+(`.github/workflows/build.yml`, job *Host tests*) on every push and pull
+request, and a release is only published when it is green alongside the seven
+firmware builds. Before opening a PR:
+
+```bash
+tools/host_tests/run_all.sh            # all nine, about 15 s on a Mac
+tools/host_tests/run_all.sh d5 ui_kit  # just these
+```
+
+Logs go to `_out/<name>.log`; the CI job uploads them together with the rendered
+panel frames, so a GUI change can be looked at from the PR without a board.
+
 | Directory | Needs | What it does |
 |---|---|---|
 | [`veeprom/`](veeprom/) | nothing | unit test of the core's virtual EEPROM: wear levelling, CRC, oversize rejection, 1000 saves. Prints PASS/FAIL per case. This one covers `core/`, not an instrument. |
-| [`yc/`](yc/) | nothing | renders the YC organ engine to a WAV file. No audio device involved. |
+| [`yc/`](yc/) | nothing | renders three notes through the YC organ engine to a WAV file next to the binary and fails on NaN/Inf or silence. No audio device involved. |
 | [`d5/`](d5/) | nothing | pins two D-50 laws read from the firmware: the PCM pitch (every sample advances at f/250 words per output sample) with synthetic cycles, and the TVF base cutoff (2 × panel + 54 chip units, capped by the pitch) through the harmonic profile of a sawtooth. Prints pass/FAIL per case. |
 | [`ob/`](ob/) | nothing | regression checks on the OB-X engine - pitch bend ranges, LFO->cutoff without LFO->pitch, mod lever vibrato, all presets finite - plus a WAV render. Prints pass/FAIL per case. |
 | [`dx_sysex/`](dx_sysex/) | nothing | round trip through PicoFaceDX's SysEx layer, both directions: a voice dump requested by an editor is parsed back and compared byte for byte, and a voice sent by an editor is compared against what reaches the engine. Prints pass/FAIL per direction. |
 | [`j6/build_ui.sh`](j6/) | nothing | drives `J6_Controller` and the patch store through a scripted panel session - menu navigation, patch save/load, the free-slot rule. |
+| [`ui/`](ui/README.md) | nothing | renders the shared UI kit's panels to PBM frames through the real u8g2 - the README sheets come from here. `run_all.sh` checks that every frame is written. |
+| [`md/build_md_ui.sh`](md/) | nothing | the same for the real `MD_Controller`: seven of its pages as frames. |
+| [`cp/build_render.sh`](cp/README.md) | nothing | offline render of one note through the mdaEPiano engine; `run_all.sh` plays each of the six voices and fails on a silent one. `ab_compare.py` compares two such renders, which is how a sample-set change is checked. |
 | [`cp/`](cp/README.md) | portmidi | plays the mdaEPiano engine, with or without the reface CP effect chain, over CoreAudio. |
 | [`j6/build_juno.sh`](j6/) | portmidi | plays the Juno engine over CoreAudio. |
 | [`md/`](md/) | portmidi | plays the Minimoog engine over CoreAudio. |

--- a/tools/host_tests/run_all.sh
+++ b/tools/host_tests/run_all.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+# SPDX-License-Identifier: GPL-3.0-or-later
+# SPDX-FileCopyrightText: 2026 Michi71
+#
+# run_all.sh -- every host test that needs neither a sound card, a MIDI port
+# nor a ROM set, in one go, with one exit status. This is what CI runs (the
+# host-tests job in .github/workflows/build.yml) and what to run before a PR.
+#
+#   tools/host_tests/run_all.sh              all of them
+#   tools/host_tests/run_all.sh veeprom d5   only these
+#
+# Each test's output goes to tools/host_tests/_out/<name>.log; the last lines
+# of a failing one are repeated on the terminal. Rendered frames and WAVs land
+# where the individual scripts put them (ui/out, md/out, cp/out, next to the
+# binaries), so a CI run can upload them and a GUI change can be looked at
+# without hardware.
+#
+# The four CoreAudio/PortMidi players (cp/build.sh, cp/build_cp.sh,
+# j6/build_juno.sh, md/build_moog.sh, sm/build_solina.sh) are not here: they
+# need a sound card and a person. Neither are the JV and D5 engine renders,
+# which need a ROM set.
+set -u
+HERE="$(cd "$(dirname "$0")" && pwd)"
+OUT="$HERE/_out"
+mkdir -p "$OUT"
+
+# --- helpers ----------------------------------------------------------------
+
+# At least one PBM frame in the directory, none of them empty.
+frames_ok() {
+    local dir=$1 n=0 f
+    for f in "$dir"/*.pbm; do
+        [ -s "$f" ] || { echo "empty or missing frame: $f"; return 1; }
+        n=$((n + 1))
+    done
+    echo "$n frames in $dir"
+}
+
+# A raw int16 render that is not just zeros. (tr instead of cmp -n: BSD cmp
+# has no -n, and this must run on the Mac as well as in CI.)
+audible() {
+    local f=$1 nz
+    [ -s "$f" ] || { echo "no output: $f"; return 1; }
+    nz=$(tr -d '\000' < "$f" | wc -c | tr -d ' ')
+    [ "$nz" -gt 0 ] || { echo "silent render: $f"; return 1; }
+    echo "$f: $nz non-zero bytes"
+}
+
+# --- the tests --------------------------------------------------------------
+# Each is a function; a non-zero return anywhere in it fails the test.
+
+t_veeprom()  { "$HERE/veeprom/build_veeprom.sh"; }          # builds and runs
+t_d5()       { "$HERE/d5/build_d5.sh"; }                    # builds and runs three
+t_dx_sysex() { "$HERE/dx_sysex/build_dx_sysex.sh"; }        # builds and runs
+t_ob()       { "$HERE/ob/build_ob.sh" && "$HERE/ob/ob_engine_host_test"; }
+t_j6_ui()    { "$HERE/j6/build_ui.sh" && "$HERE/j6/j6_ui_test"; }
+t_yc()       { "$HERE/yc/build_yc.sh" && "$HERE/yc/yc_engine_host_test"; }
+
+t_ui_kit() {
+    "$HERE/ui/build_ui_kit.sh" && mkdir -p "$HERE/ui/out" \
+        && "$HERE/ui/ui_kit_shots" "$HERE/ui/out" && frames_ok "$HERE/ui/out"
+}
+
+# Needs the u8g2 archive that t_ui_kit builds; the order below provides it.
+t_md_ui() {
+    "$HERE/md/build_md_ui.sh" && mkdir -p "$HERE/md/out" \
+        && "$HERE/md/md_ui_shots" "$HERE/md/out" && frames_ok "$HERE/md/out"
+}
+
+# One note through each of the six CP voices: a keygroup table pointing past
+# its data would crash or render silence here before it reaches a board.
+t_cp_render() {
+    "$HERE/cp/build_render.sh" && mkdir -p "$HERE/cp/out" || return 1
+    local i
+    for i in 0 1 2 3 4 5; do
+        "$HERE/cp/render" "$i" 60 100 1.0 1.5 "$HERE/cp/out/ci_voice$i.raw" \
+            && audible "$HERE/cp/out/ci_voice$i.raw" || return 1
+    done
+}
+
+ALL="veeprom d5 dx_sysex ob j6_ui yc ui_kit md_ui cp_render"
+
+# --- runner -----------------------------------------------------------------
+
+failed=0
+for name in ${*:-$ALL}; do
+    if ! declare -F "t_$name" > /dev/null; then
+        echo "unknown test '$name' (have: $ALL)" >&2
+        failed=$((failed + 1))
+        continue
+    fi
+    log="$OUT/$name.log"
+    t0=$(date +%s)
+    if ( set -e; "t_$name" ) > "$log" 2>&1; then
+        status="pass"
+    else
+        status="FAIL"
+        failed=$((failed + 1))
+    fi
+    printf '%-10s %s  %3ds\n' "$name" "$status" "$(( $(date +%s) - t0 ))"
+    if [ "$status" = FAIL ]; then
+        sed 's/^/    | /' "$log" | tail -n 30
+    fi
+done
+
+if [ "$failed" -eq 0 ]; then
+    echo "all host tests passed"
+else
+    echo "$failed host test(s) FAILED - logs in $OUT"
+fi
+exit "$failed"

--- a/tools/host_tests/yc/yc_engine_host_test.cpp
+++ b/tools/host_tests/yc/yc_engine_host_test.cpp
@@ -12,6 +12,7 @@
 #include <cmath>
 #include <cstdint>
 #include <cstring>
+#include <string>
 #include <algorithm>
 
 static void write_wav_mono_16bit(const char* filename,
@@ -64,8 +65,9 @@ static void write_wav_mono_16bit(const char* filename,
                 filename, (uint32_t)samples.size(), sample_rate);
 }
 
-int main()
+int main(int argc, char** argv)
 {
+    (void)argc;
     // 1. Engine initialisieren
     yc_engine_state_t state{};
     yc_rotary_state_t rstate{};
@@ -165,10 +167,17 @@ int main()
     else
         std::printf("[WARNUNG] Sehr niedrige Amplitude\n");
 
-    // 6. WAV-Datei schreiben
-    write_wav_mono_16bit("test/yc_engine_host_test_output.wav",
-                         audio, 44100);
+    // 6. WAV-Datei schreiben - neben das Binary, wie beim OB-Test, egal
+    //    aus welchem Verzeichnis der Aufruf kommt.
+    std::string wavPath = "yc_engine_host_test.wav";
+    if (const char* slash = std::strrchr(argv[0], '/')) {
+        wavPath = std::string(argv[0], (size_t)(slash + 1 - argv[0])) + "yc_engine_host_test.wav";
+    }
+    write_wav_mono_16bit(wavPath.c_str(), audio, 44100);
 
-    std::printf("\nTest abgeschlossen.\n");
-    return 0;
+    // Ein Test, der immer 0 liefert, ist keiner: NaN/Inf oder Stille sind ein
+    // Fehler, und run_all.sh (und damit die CI) liest den Exit-Code.
+    const bool failed = nan_inf_count != 0 || nonzero_after_100 == 0 || peak <= 0.001f;
+    std::printf("\n%s\n", failed ? "FAILED" : "Test abgeschlossen.");
+    return failed ? 1 : 0;
 }


### PR DESCRIPTION
Point 1 of the project review: the CI built seven firmware images and ran none of the host tests, so a regression in the core was caught by nobody until a board played it.

### What this adds

- **`tools/host_tests/run_all.sh`** — the nine tests that need neither a sound card, a MIDI port nor a ROM set, with one exit status (number of failures), logs in `_out/`, and the tail of a failing log on the terminal. ~15 s on a Mac, 18 s on Ubuntu 22.04. Takes test names as arguments for a subset.
- **CI job `Host tests`** (`build.yml`) on every push and PR; **`release` now needs it green** alongside the seven builds. Fetches only the u8g2 submodule, not the SDK tree. Uploads the logs and the rendered panel frames (`ui/out`, `md/out`) as an artifact, so a GUI change can be looked at from the PR without flashing anything.

### What it covers

| test | checks |
|---|---|
| `veeprom` | core virtual EEPROM: wear levelling, CRC, oversize rejection, 1000 saves |
| `d5` | PCM pitch law, TVF base cutoff, pulse width (firmware-derived laws) |
| `dx_sysex` | reface DX SysEx round trip, both directions, byte for byte |
| `ob` | OB-X engine: bend ranges, LFO routing, all presets finite |
| `j6_ui` | J6 controller + patch store through a scripted panel session |
| `yc` | YC engine render — **now a real test**: it used to return 0 whatever it found and wrote to a path from the standalone repo; it fails on NaN/Inf or silence and writes next to its binary, like the OB test |
| `ui_kit` | shared UI kit rendered through the real u8g2; every frame must be written |
| `md_ui` | the real `MD_Controller`, seven pages as frames |
| `cp_render` | one note through each of the six CP voices, each must be audible — a keygroup table pointing past its data fails here, not on a board |

Not in it, on purpose: the four CoreAudio/PortMidi players and the ROM-bound JV/D5 renders.

### Verified

All nine pass on the Mac and in an `ubuntu:22.04` container with g++ 11.4 from a fresh clone (the exact CI recipe: `apt build-essential python3`, u8g2 submodule at depth 1). This PR's own run is the first on the real runner.

No firmware change; nothing to test on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
